### PR TITLE
Fix typo - accessing standalone uri

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -210,9 +210,9 @@ class MongoDBCharm(CharmBase):
         event.relation.data[self.unit][
             'replica_set_name'] = self.replica_set_name
         event.relation.data[self.unit]['standalone_uri'] = "{}".format(
-            self.standalone_uri)
+            self.mongo.standalone_uri)
         event.relation.data[self.unit]['replica_set_uri'] = "{}".format(
-            self.replica_set_uri)
+            self.mongo.replica_set_uri)
 
     ##############################################
     #               PROPERTIES                   #


### PR DESCRIPTION
This commit fixes an error introduced by a recent refactor
that does not specify the right object on which to access
the standalone_uri property.