### PR TITLE
Update to sync with latest Operator Framework

### DIFF
--- a/lib/charms/mongodb_k8s/v0/mongodb.py
+++ b/lib/charms/mongodb_k8s/v0/mongodb.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from ops.relation import ConsumerBase
+from ops.framework import Object
 
 # The unique Charmhub library identifier, never change it
 LIBID = "1057f353503741a98ed79309b5be7e29"
@@ -13,9 +13,9 @@ LIBAPI = 0
 LIBPATCH = 1
 
 
-class MongoConsumer(ConsumerBase):
-    def __init__(self, charm, name, consumes, multi=False):
-        super().__init__(charm, name, consumes, multi)
+class MongoConsumer(Object):
+    def __init__(self, charm, name):
+        super().__init__(charm, name)
         self.charm = charm
         self.relation_name = name
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-git+https://github.com/balbirthomas/operator/@provider-consumer-lib#egg=ops
+git+git://github.com/canonical/operator#egg=ops
 pymongo
-semantic_version
-git+https://github.com/juju-solutions/resource-oci-image/@c5778285d332edf3d9a538f9d0c06154b7ec1b0b#egg=oci-image

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,13 +87,9 @@ class MongoDBCharm(CharmBase):
         layers = MongoLayers(self.config)
         mongo_layer = layers.build()
         plan = container.get_plan()
-        if plan.services != mongo_layer["services"]:
+        if plan.services != mongo_layer.services:
             container.add_layer("mongodb", mongo_layer, combine=True)
-
-            if container.get_service("mongodb").is_running():
-                container.stop("mongodb")
-
-            container.start("mongodb")
+            container.restart("mongodb")
             logger.info("Restarted mongodb container")
 
         self.unit.status = ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,11 +57,7 @@ class MongoDBCharm(CharmBase):
                                self._on_leader_elected)
 
         if self._stored.mongodb_initialized and self.mongo.version:
-            self.mongo_provider = MongoProvider(self,
-                                                'database',
-                                                'mongodb',
-                                                version=self.mongo.version)
-            self.mongo_provider.ready()
+            self.mongo_provider = MongoProvider(self, 'database')
         else:
             logger.debug("Mongo Provider not yet Available")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -87,8 +87,11 @@ class MongoDBCharm(CharmBase):
         layers = MongoLayers(self.config)
         mongo_layer = layers.build()
         plan = container.get_plan()
-        if plan.services != mongo_layer.services:
+        service_changed = plan.services != mongo_layer.services
+        if service_changed:
             container.add_layer("mongodb", mongo_layer, combine=True)
+
+        if service_changed or self.need_replica_set_reconfiguration:
             container.restart("mongodb")
             logger.info("Restarted mongodb container")
 

--- a/src/mongoprovider.py
+++ b/src/mongoprovider.py
@@ -1,13 +1,13 @@
 import json
 import logging
 
-from ops.relation import ProviderBase
+from ops.framework import Object
 from mongoserver import MongoDB
 
 logger = logging.getLogger(__name__)
 
 
-class MongoProvider(ProviderBase):
+class MongoProvider(Object):
 
     def __init__(self, charm, name, *args, **kwargs):
         """Manager of MongoDB relations.

--- a/src/pebble_layers.py
+++ b/src/pebble_layers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+from ops.pebble import Layer
 
 SECRET_PATH = "/var/lib/mongodb-secrets"
 KEY_FILE = "key.file"
@@ -27,7 +28,7 @@ class MongoLayers:
         Returns:
             A dictionary representing the MongoDB pebble layer.
         """
-        layer = {
+        layer_spec = {
             "summary": "MongoDB layer",
             "description": "Pebble layer configuration for replicated MongoDB",
             "services": {
@@ -44,7 +45,7 @@ class MongoLayers:
                 }
             },
         }
-        return layer
+        return Layer(layer_spec)
 
     def _command(self):
         """Construct the MongoDB startup command line.


### PR DESCRIPTION
This PR essentially **minimally** updates the long neglected MonoDB charm to bring it back into sync with upstream Canonical Operator Framework. These changes are
1. Point `requirements.txt` to upstream `ops` repository
2. Remove dependence on `ops.relation`
3. Remove dependence on out of spec behaviour in `ops` that has now been fixed