### PR TITLE
Fix init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 .vscode
 build
-mongodb.charm
+*.charm
 bin/
 lib64
 pyvenv.cfg
 share/
+venv/

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ following commands
 
 Install the charmcraft tool
 
-    sudo snap install charmcraft
+    sudo snap install charmcraft --classic
 
 Build the charm in this git repository
 
-    charmcraft build
+    charmcraft pack
 
 ## Usage
 
@@ -38,7 +38,7 @@ Create a Juju model for your operators, say "lma"
 
 Deploy a single unit of MongoDB using its default configuration
 
-    juju deploy ./mongodb.charm --resource mongodb-image=mongo:4.4.1
+    juju deploy ./mongodb-k8s_ubuntu-20.04-amd64.charm --resource mongodb-image=mongo:4.4.1
 
 It is customary to use MongoDB with replication. Hence usually more
 than one unit (preferably and odd number) is deployed. Additionally
@@ -49,7 +49,7 @@ units (say two more) may be deployed using
 Alternatively multiple MongoDB units may be deployed at the
 outset. This is usually faster
 
-    juju deploy -n 3 ./mongodb.charm
+    juju deploy -n 3 ./mongodb-k8s_ubuntu-20.04-amd64.charm --resource mongodb-image=mongo:4.4.1
 
 If required, remove the deployed monitoring model completely
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -158,7 +158,9 @@ class MongoDBCharm(CharmBase):
             self.unit.status = WaitingStatus(status_message)
             # TODO: remove container restarting here when Pebble
             # does this automatically if workload is inactive
-            self.restart()
+            container = self.unit.get_container("mongodb")
+            if container.can_connect() and "mongodb" in container.get_services():
+                self.restart()
             return
 
         if not self._stored.mongodb_initialized:


### PR DESCRIPTION
Fixes a race condition where the `update-status` handler is sometimes called before the `pebble-ready` event fires and therefore the charm errors when `update-status` tries to restart  an undefined pebble service.