### PR TITLE
DPE-64 relation joined

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -22,7 +22,7 @@ from ops.model import (
     WaitingStatus,
 )
 
-from mongod_helpers import MONGODB_PORT, ConfigurationError, ConnectionFailure, MongoDB
+from mongod_helpers import MONGODB_PORT, ConfigurationError, ConnectionFailure, OperationFailure, MongoDB
 
 logger = logging.getLogger(__name__)
 
@@ -38,45 +38,56 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(self.on.mongodb_relation_joined, self._mongodb_relation_joined)
         self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_joined)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
 
-    def _mongodb_relation_joined(self, event) -> None:
+    def _on_mongodb_relation_joined(self, event: ops.charm.RelationJoinedEvent) -> None:
+        """Adds the joined unit as a replica to the MongoDB replica set.
+
+        Args:
+            event: The triggering relation joined event.
+        """
+        # only leader should configure replica set
         if not self.unit.is_leader():
             return
 
-        # do not initialise replica set until all peers have joined
-        if not self._check_unit_count:
-            logger.debug("waiting to initialise replica set until all planned units have joined")
+        #  only add the calling unit to the replica set if it has mongod running
+        calling_unit = event.unit
+        calling_unit_ip = str(self._peers.data[calling_unit].get("private-address"))
+        mongo_peer = self._single_mongo_replica(calling_unit_ip)
+        if not mongo_peer.is_ready(standalone=True):
+            logger.debug(
+                "unit is not ready, cannot initialise replica set unit: %s is ready, deferring on relation-joined",
+                calling_unit.name
+            )
+            event.defer()
             return
 
-        # do not initialise replica set until all peers have started mongod
-        for peer in self._peers.units:
-            mongo_peer = self._single_mongo_replica(
-                str(self._peers.data[peer].get("private-address"))
-            )
-            if not mongo_peer.is_ready(standalone=True):
-                logger.debug(
-                    "unit: %s is not ready, cannot initialise replica set until all units are ready, deferring on relation-joined",
-                    peer,
-                )
-                event.defer()
-                return
+        logger.debug("unit: %s is ready to join the replica set", calling_unit.name)
+        self._reconfigure(event)
 
-        # in future patch we will reconfigure the replicaset instead of re-initialising
-        if not self._mongo.is_replica_set():
+    def _reconfigure(self, event: ops.charm.RelationEvent) -> None:
+        """Adds/removes RelationEvent triggering unit from the replica set.
+
+        Note: Removal funcationality will be implemented in the following PR.
+
+        Args:
+            event: The triggering relation event.
+        """
+        # check if reconfiguration is necessary
+        if self._need_replica_set_reconfiguration:
             try:
-                self._initialise_replica_set()
-            except (ConnectionFailure, ConfigurationError):
-                self.unit.status = BlockedStatus("failed to initialise replica set")
-                return
-
-        # verify replica set is ready
-        if not self._mongo.is_ready():
-            logger.debug("Replica set for units: %s, is not ready", self._unit_ips)
-            self.unit.status = BlockedStatus("failed to initialise replica set")
+                # reconfigure replica set
+                self._mongo.reconfigure_replica_set()
+                # update the set of replica set hosts
+                self._peers.data[self.app]["replica_set_hosts"] = json.dumps(self._unit_ips)
+                logger.debug("Replica set successfully reconfigured")
+            except (ConnectionFailure, ConfigurationError, OperationFailure) as e:
+                logger.error("deferring reconfigure of replica set: %s", str(e))
+                self.unit.status = WaitingStatus("waiting to reconfigure replica set")
+                event.defer()
 
     def _on_install(self, _) -> None:
         """Handle the install event (fired on startup).
@@ -261,7 +272,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         try:
             leader_ip = str(self.model.get_binding(PEER).network.bind_address)
             self._mongo.initialise_replica_set([leader_ip])
-            self._peers.data[self.app]["replica_set_hosts"] = json.dumps(leader_ip)
+            self._peers.data[self.app]["replica_set_hosts"] = json.dumps([leader_ip])
         except (ConnectionFailure, ConfigurationError) as e:
             logger.error("error initialising replica sets in _on_start: error: %s", str(e))
             self.unit.status = WaitingStatus("waiting to initialise replica set")
@@ -278,6 +289,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         unit_config = self._config
         unit_config["calling_unit_ip"] = ip_address
         return MongoDB(unit_config)
+
+    @property
+    def _need_replica_set_reconfiguration(self) -> bool:
+        """Does MongoDB replica set need reconfiguration.
+
+        Returns:
+            bool: that indicates if the replica set hosts should be reconfigured
+        """
+        # are the units for the application all assigned to a host
+        return set(self._unit_ips) != set(self._replica_set_hosts)
 
     @property
     def _check_unit_count(self) -> bool:
@@ -310,6 +331,15 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         return addresses
 
     @property
+    def _replica_set_hosts(self):
+        """Fetch current list of hosts in the replica set.
+
+        Returns:
+            A list of hosts addresses (strings).
+        """
+        return json.loads(self._peers.data[self.app].get("replica_set_hosts", "[]"))
+
+    @property
     def _config(self) -> dict:
         """Retrieve config options for MongoDB.
 
@@ -320,7 +350,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         config = {
             "app_name": self.app.name,
             "replica_set_name": "rs0",
-            "num_peers": 1,
+            "num_hosts": len(self._unit_ips),
             "port": self._port,
             "root_password": "password",
             "security_key": "",

--- a/src/charm.py
+++ b/src/charm.py
@@ -22,7 +22,13 @@ from ops.model import (
     WaitingStatus,
 )
 
-from mongod_helpers import MONGODB_PORT, ConfigurationError, ConnectionFailure, OperationFailure, MongoDB
+from mongod_helpers import (
+    MONGODB_PORT,
+    ConfigurationError,
+    ConnectionFailure,
+    MongoDB,
+    OperationFailure,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,18 +45,23 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
-        self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_joined)
+        self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_handler)
+        self.framework.observe(self.on.mongodb_relation_changed, self._on_mongodb_relation_handler)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
 
-    def _on_mongodb_relation_joined(self, event: ops.charm.RelationJoinedEvent) -> None:
-        """Adds the joined unit as a replica to the MongoDB replica set.
+    def _on_mongodb_relation_handler(self, event: ops.charm.RelationEvent) -> None:
+        """Adds the unit as a replica to the MongoDB replica set.
 
         Args:
-            event: The triggering relation joined event.
+            event: The triggering relation joined/changed event.
         """
         # only leader should configure replica set
         if not self.unit.is_leader():
+            return
+
+        # app-changed-events can trigger the relation changed hook resulting in no JUJU_REMOTE_UNIT
+        if event.unit is None:
             return
 
         #  only add the calling unit to the replica set if it has mongod running
@@ -60,7 +71,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         if not mongo_peer.is_ready(standalone=True):
             logger.debug(
                 "unit is not ready, cannot initialise replica set unit: %s is ready, deferring on relation-joined",
-                calling_unit.name
+                calling_unit.name,
             )
             event.defer()
             return
@@ -273,7 +284,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             leader_ip = str(self.model.get_binding(PEER).network.bind_address)
             self._mongo.initialise_replica_set([leader_ip])
             self._peers.data[self.app]["replica_set_hosts"] = json.dumps([leader_ip])
-        except (ConnectionFailure, ConfigurationError) as e:
+        except (ConnectionFailure, ConfigurationError, OperationFailure) as e:
             logger.error("error initialising replica sets in _on_start: error: %s", str(e))
             self.unit.status = WaitingStatus("waiting to initialise replica set")
 

--- a/src/mongod_helpers.py
+++ b/src/mongod_helpers.py
@@ -142,7 +142,11 @@ class MongoDB:
             client.close()
 
     def reconfigure_replica_set(self) -> None:
-        """Reconfigure the MongoDB replica set."""
+        """Reconfigure the MongoDB replica set.
+
+        Using the current MongoDB configuration from mongod, reconfigure_replica_set reconfigures
+        the replica set based on the current replica set hosts and the desired replica set hosts.
+        """
         replica_set_client = self.client()
         try:
             # get current configuration and update with correct hosts

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -459,10 +459,9 @@ class TestCharm(unittest.TestCase):
 
         # simulate 2nd MongoDB unit
         rel = self.harness.charm.model.get_relation("mongodb")
-        rel_id = rel.id
         key_values = {"private-address": "127.4.5.6"}
-        self.harness.add_relation_unit(rel_id, "mongodb/1")
-        self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
+        self.harness.add_relation_unit(rel.id, "mongodb/1")
+        self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
 
         # verify that we do not reconfigure replica set
         mongo_reconfigure.assert_not_called()
@@ -484,10 +483,9 @@ class TestCharm(unittest.TestCase):
 
             # simulate 2nd MongoDB unit
             rel = self.harness.charm.model.get_relation("mongodb")
-            rel_id = rel.id
             key_values = {"private-address": "127.4.5.6"}
-            self.harness.add_relation_unit(rel_id, "mongodb/1")
-            self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
+            self.harness.add_relation_unit(rel.id, "mongodb/1")
+            self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
 
             # check if mongod reconfigured replica set
             if reconfiguration:
@@ -521,15 +519,13 @@ class TestCharm(unittest.TestCase):
             OperationFailure("error message"),
         ]
         for exception in exceptions:
-            # exception
             mongodb_reconfigure.side_effect = exception
 
             # simulate 2nd MongoDB unit
             rel = self.harness.charm.model.get_relation("mongodb")
-            rel_id = rel.id
             key_values = {"private-address": "127.4.5.6"}
-            self.harness.add_relation_unit(rel_id, "mongodb/1")
-            self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
+            self.harness.add_relation_unit(rel.id, "mongodb/1")
+            self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
 
             # charm waits
             self.assertEqual(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -12,6 +12,7 @@ from charm import (
     ConfigurationError,
     ConnectionFailure,
     MongodbOperatorCharm,
+    OperationFailure,
     URLError,
     apt,
     subprocess,
@@ -439,150 +440,101 @@ class TestCharm(unittest.TestCase):
         expected_ips = ["127.4.5.6", "1.1.1.1"]
         self.assertEqual(resulting_ips, expected_ips)
 
-    @patch("charm.MongodbOperatorCharm.app")
-    def test_mongodb_relation_joined_non_leader_does_nothing(self, app):
+    @patch("charm.MongodbOperatorCharm._reconfigure")
+    def test_mongodb_relation_joined_non_leader_does_nothing(self, reconfigure):
         rel = self.harness.charm.model.get_relation("mongodb")
         self.harness.set_leader(False)
         self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
 
-        app.planned_units.assert_not_called()
-
-    @patch("charm.MongodbOperatorCharm.app")
-    def test_mongodb_relation_joined_planned_units_does_not_match_joined_units(self, app):
-        rel = self.harness.charm.model.get_relation("mongodb")
-        self.harness.set_leader(True)
-        app.planned_units.return_value = 3
-
-        with self.assertLogs("charm", "DEBUG") as logs:
-            self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
-            self.assertIn(
-                "planned units does not match joined units: 3 != 1",
-                "".join(logs.output),
-            )
+        reconfigure.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charm.MongodbOperatorCharm._initialise_replica_set")
-    @patch("mongod_helpers.MongoDB.is_ready")
-    @patch("mongod_helpers.MongoDB.is_replica_set")
-    @patch("charm.MongodbOperatorCharm.app")
-    def test_mongodb_relation_joined_already_replica_set(
-        self, app, is_replica_set, is_ready, initialise_replica_set
-    ):
-        rel = self.harness.charm.model.get_relation("mongodb")
+    @patch("mongod_helpers.MongoDB.reconfigure_replica_set")
+    @patch("charm.MongodbOperatorCharm._single_mongo_replica")
+    @patch("charm.MongodbOperatorCharm._peers")
+    def test_mongodb_relation_joined_peers_not_ready(self, _, single_replica, mongo_reconfigure):
+        # preset values
         self.harness.set_leader(True)
-        app.planned_units.return_value = len(self.harness.charm._unit_ips)
-        is_replica_set.return_value = True
-        ready_statuses = [True, False]
+        single_replica.return_value.is_ready.return_value = False
 
-        with self.assertLogs("charm", "DEBUG") as logs:
-            for ready_status in ready_statuses:
-                is_ready.return_value = ready_status
-                self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
-                # verify that we do not re-initialise replica set
-                initialise_replica_set.assert_not_called()
+        # simulate 2nd MongoDB unit
+        rel = self.harness.charm.model.get_relation("mongodb")
+        rel_id = rel.id
+        key_values = {"private-address": "127.4.5.6"}
+        self.harness.add_relation_unit(rel_id, "mongodb/1")
+        self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
 
-                # check behavior based on ready status
-                is_ready.assert_called()
-                if ready_status:
-                    continue
+        # verify that we do not reconfigure replica set
+        mongo_reconfigure.assert_not_called()
 
-                self.assertIn(
-                    "Replica set for units: ['1.1.1.1'], is not ready", "".join(logs.output)
-                )
-                self.assertEqual(
-                    self.harness.charm.unit.status,
-                    BlockedStatus("failed to initialise replica set"),
-                )
+    @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.MongodbOperatorCharm._single_mongo_replica")
+    @patch("charm.MongodbOperatorCharm._need_replica_set_reconfiguration")
+    @patch("mongod_helpers.MongoDB.reconfigure_replica_set")
+    def test_mongodb_relation_joined_peer_ready(
+        self, mongodb_reconfigure, need_reconfiguration, single_replica
+    ):
+        # preset values
+        self.harness.set_leader(True)
+        single_replica.return_value.is_ready.return_value = True
 
-        @patch_network_get(private_address="1.1.1.1")
-        @patch("charm.MongodbOperatorCharm._initialise_replica_set")
-        @patch("mongod_helpers.MongoDB.is_ready")
-        @patch("mongod_helpers.MongoDB.is_replica_set")
-        @patch("charm.MongodbOperatorCharm.app")
-        def test_mongodb_relation_joined_not_yet_replica_set(
-            self, app, is_replica_set, is_ready, initialise_replica_set
-        ):
+        # test cases where replica set should and shouldn't be reconfigured
+        for reconfiguration in [False, True]:
+            self.harness.charm._need_replica_set_reconfiguration = reconfiguration
+
+            # simulate 2nd MongoDB unit
             rel = self.harness.charm.model.get_relation("mongodb")
-            self.harness.set_leader(True)
-            app.planned_units.return_value = len(self.harness.charm._unit_ips)
-            is_replica_set.return_value = False
-            ready_statuses = [True, False]
+            rel_id = rel.id
+            key_values = {"private-address": "127.4.5.6"}
+            self.harness.add_relation_unit(rel_id, "mongodb/1")
+            self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
 
-            with self.assertLogs("charm", "DEBUG") as logs:
-                for ready_status in ready_statuses:
-                    is_ready.return_value = ready_status
-                    self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
-                    # verify that we do initialise replica set
-                    initialise_replica_set.assert_called()
+            # check if mongod reconfigured replica set
+            if reconfiguration:
+                mongodb_reconfigure.assert_called()
 
-                    # check behavior based on ready status
-                    is_ready.assert_called()
-                    if ready_status:
-                        continue
+                # verify replica set hosts updated accordingly
+                self.assertEqual(
+                    self.harness.charm._replica_set_hosts,
+                    ["127.4.5.6", "1.1.1.1"],
+                )
 
-                    self.assertIn(
-                        "Replica set for units: ['1.1.1.1'], is not ready", "".join(logs.output)
-                    )
-                    self.assertEqual(
-                        self.harness.charm.unit.status,
-                        BlockedStatus("failed to initialise replica set"),
-                    )
+            else:
+                mongodb_reconfigure.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charm.MongodbOperatorCharm._initialise_replica_set")
-    @patch("mongod_helpers.MongoDB.is_ready")
-    @patch("charm.MongodbOperatorCharm.app")
-    def test_mongodb_relation_joined_peers_not_ready(self, app, is_ready, initialise_replica_set):
-        # preset values
-        self.harness.set_leader(True)
-        is_ready.return_value = False
-
-        # simulate 2nd MongoDB unit
-        rel = self.harness.charm.model.get_relation("mongodb")
-        rel_id = rel.id
-        key_values = {"private-address": "127.4.5.6"}
-        self.harness.add_relation_unit(rel_id, "mongodb/1")
-        self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
-        app.planned_units.return_value = len(self.harness.charm._unit_ips)
-
-        with self.assertLogs("charm", "DEBUG") as logs:
-            self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
-
-            self.assertIn(
-                "unit: <ops.model.Unit mongodb/1> is not ready, cannot "
-                + "initialise replica set until all units are ready, deferring "
-                + "on relation-joined",
-                "".join(logs.output),
-            )
-
-            # verify that we do not initialise replica set
-            initialise_replica_set.assert_not_called()
-
-    @patch_network_get(private_address="1.1.1.1")
-    @patch("mongod_helpers.MongoDB.is_replica_set")
-    @patch("charm.MongodbOperatorCharm._initialise_replica_set")
-    @patch("mongod_helpers.MongoDB.is_ready")
-    @patch("charm.MongodbOperatorCharm.app")
-    def test_mongodb_relation_joined_peers_ready(
-        self, app, is_ready, initialise_replica_set, is_replica_set
+    @patch("charm.MongodbOperatorCharm._single_mongo_replica")
+    @patch("charm.MongodbOperatorCharm._need_replica_set_reconfiguration")
+    @patch("mongod_helpers.MongoDB.reconfigure_replica_set")
+    def test_mongodb_relation_joined_failure(
+        self, mongodb_reconfigure, need_reconfiguration, single_replica
     ):
         # preset values
         self.harness.set_leader(True)
-        is_ready.return_value = True
-        is_replica_set.return_value = False
+        single_replica.return_value.is_ready.return_value = True
+        self.harness.charm._need_replica_set_reconfiguration = True
 
-        # simulate 2nd MongoDB unit
-        rel = self.harness.charm.model.get_relation("mongodb")
-        rel_id = rel.id
-        key_values = {"private-address": "127.4.5.6"}
-        self.harness.add_relation_unit(rel_id, "mongodb/1")
-        self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
-        app.planned_units.return_value = len(self.harness.charm._unit_ips)
+        # test cases where replica set should and shouldn't be reconfigured
+        exceptions = [
+            ConnectionFailure("error message"),
+            ConfigurationError("error message"),
+            OperationFailure("error message"),
+        ]
+        for exception in exceptions:
+            # exception
+            mongodb_reconfigure.side_effect = exception
 
-        self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
+            # simulate 2nd MongoDB unit
+            rel = self.harness.charm.model.get_relation("mongodb")
+            rel_id = rel.id
+            key_values = {"private-address": "127.4.5.6"}
+            self.harness.add_relation_unit(rel_id, "mongodb/1")
+            self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
 
-        # verify that we do not initialise replica set
-        initialise_replica_set.assert_called()
+            # charm waits
+            self.assertEqual(
+                self.harness.charm.unit.status, WaitingStatus("waiting to reconfigure replica set")
+            )
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("mongod_helpers.MongoDB.is_ready")
@@ -601,6 +553,7 @@ class TestCharm(unittest.TestCase):
         exceptions = [
             ConnectionFailure("connection error message"),
             ConfigurationError("configuration error message"),
+            OperationFailure("operation error message"),
         ]
         log_messages = [
             "ERROR:charm:error initialising replica sets in _on_start: error: connection error message",
@@ -633,33 +586,14 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm.on.start.emit()
         initialise_replica_set.assert_called()
+
+        # assert added to replica set hosts
         self.assertEqual(
-            self.harness.charm._peers.data[self.harness.charm.app]["replica_set_hosts"],
-            '"1.1.1.1"',
+            self.harness.charm._replica_set_hosts,
+            ["1.1.1.1"],
         )
 
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus(""))
-
-    @patch_network_get(private_address="1.1.1.1")
-    @patch("mongod_helpers.MongoDB.is_ready")
-    @patch("mongod_helpers.MongoDB.initialise_replica_set")
-    @patch("charm.MongodbOperatorCharm._open_port_tcp")
-    @patch("charm.service_running")
-    @patch("mongod_helpers.MongoDB.is_replica_set")
-    def test_initialise_replica_only_once(
-        self, is_replica, service_running, _open_port_tcp, initialise_replica_set, is_ready
-    ):
-        self.harness.set_leader(True)
-        is_ready.return_value = True
-        is_replica.side_effect = [False, True, True]
-
-        # emit both events
-        self.harness.charm.on.start.emit()
-        rel = self.harness.charm.model.get_relation("mongodb")
-        self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
-
-        initialise_replica_set.assert_called_once()
-        is_replica.assert_called()
 
     @patch_network_get(private_address="1.1.1.1")
     def test_single_mongo_replica(self):
@@ -712,3 +646,14 @@ class TestCharm(unittest.TestCase):
 
         self.harness.charm._on_get_primary_action(mock_event)
         mock_event.set_results.assert_called_with({"replica-set-primary": "mongodb/1"})
+
+    @patch("charm.MongodbOperatorCharm._unit_ips")
+    @patch("charm.MongodbOperatorCharm._replica_set_hosts")
+    def test_need_replica_set_reconfiguration(self, units, hosts):
+        self.harness.charm._unit_ips = ["1.1.1.1", "2.2.2.2"]
+        self.harness.charm._replica_set_hosts = ["1.1.1.1"]
+        self.assertEqual(self.harness.charm._need_replica_set_reconfiguration, True)
+
+        self.harness.charm._unit_ips = ["1.1.1.1", "2.2.2.2"]
+        self.harness.charm._replica_set_hosts = ["1.1.1.1", "2.2.2.2"]
+        self.assertEqual(self.harness.charm._need_replica_set_reconfiguration, False)

--- a/tests/unit/test_mongod_helpers.py
+++ b/tests/unit/test_mongod_helpers.py
@@ -133,8 +133,8 @@ class TestMongoServer(unittest.TestCase):
         # verify we make a call to replSetReconfig
         mongo.reconfigure_replica_set()
         mock_client.admin.command.assert_called()
-        command, _ = mock_client.admin.command.call_args
-        self.assertEqual("replSetReconfig", command[0])
+        (command, _), _ = mock_client.admin.command.call_args
+        self.assertEqual("replSetReconfig", command)
 
         # verify we close connection
         (mock_client.close).assert_called()

--- a/tests/unit/test_mongod_helpers.py
+++ b/tests/unit/test_mongod_helpers.py
@@ -7,12 +7,17 @@ from unittest.mock import patch
 from pymongo import MongoClient
 from tenacity import RetryError
 
-from mongod_helpers import MongoDB
+from mongod_helpers import (
+    ConfigurationError,
+    ConnectionFailure,
+    MongoDB,
+    OperationFailure,
+)
 
 MONGO_CONFIG = {
     "app_name": "mongodb",
     "replica_set_name": "rs0",
-    "num_peers": 1,
+    "num_hosts": 2,
     "port": 27017,
     "root_password": "password",
     "unit_ips": ["1.1.1.1", "2.2.2.2"],
@@ -72,7 +77,7 @@ class TestMongoServer(unittest.TestCase):
         client.return_value = mock_client
 
         hosts = {}
-        for i in range(config["num_peers"]):
+        for i in range(config["num_hosts"]):
             hosts[i] = "host{}".format(i)
 
         mongo.initialise_replica_set(hosts)
@@ -116,3 +121,76 @@ class TestMongoServer(unittest.TestCase):
         replica_set_status = mongo.is_replica_set()
         close.assert_called()
         self.assertEqual(replica_set_status, False)
+
+    @patch("mongod_helpers.MongoDB.client")
+    @patch("pymongo.MongoClient")
+    def test_reconfiguring_replica_invokes_admin_command(self, mock_client, client):
+        # presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+        client.return_value = mock_client
+
+        # verify we make a call to replSetReconfig
+        mongo.reconfigure_replica_set()
+        mock_client.admin.command.assert_called()
+        command, _ = mock_client.admin.command.call_args
+        self.assertEqual("replSetReconfig", command[0])
+
+        # verify we close connection
+        (mock_client.close).assert_called()
+
+    @patch("mongod_helpers.MongoDB.client")
+    @patch("pymongo.MongoClient")
+    def test_reconfiguring_replica_handles_failure(self, mock_client, client):
+        # presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+        client.return_value = mock_client
+
+        # verify we make a call to reconfigure
+        exceptions = [
+            ConnectionFailure("error message"),
+            ConfigurationError("error message"),
+            OperationFailure("error message"),
+        ]
+        raises = [ConnectionFailure, ConfigurationError, OperationFailure]
+        for exception, expected_raise in zip(exceptions, raises):
+            with self.assertRaises(expected_raise):
+                mock_client.admin.command.side_effect = exception
+
+                # call function
+                mongo.reconfigure_replica_set()
+
+                # verify we close connection
+                (mock_client.close).assert_called()
+
+    def test_replica_set_config_no_changes(self):
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+
+        current_config = {}
+        current_config["config"] = {}
+        current_config["config"]["members"] = [
+            {"host": "1.1.1.1:27017", "_id": 0},
+            {"host": "2.2.2.2:27017", "_id": 1},
+        ]
+
+        new_config = mongo.replica_set_config(current_config)
+        self.assertEqual(new_config, current_config["config"]["members"])
+
+    def test_replica_set_config_adds_member(self):
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+
+        current_config = {}
+        current_config["config"] = {}
+        current_config["config"]["members"] = [{"host": "1.1.1.1:27017", "_id": 0}]
+
+        expected_new_members = [
+            {"host": "1.1.1.1:27017", "_id": 0},
+            {"host": "2.2.2.2:27017", "_id": 1},
+        ]
+        new_config = mongo.replica_set_config(current_config)
+        self.assertEqual(new_config, expected_new_members)


### PR DESCRIPTION
This PR addresses [this JIRA story](https://warthogs.atlassian.net/browse/DPE-64?atlOrigin=eyJpIjoiOTNhY2IxYTk3ZDExNDM0MWI1M2Q2NzcyYmMzMGJhMzgiLCJwIjoiaiJ9). Previously when deploying multiple units at a time with `juju deploy ./*charm -n <num_units>` the charm would wait for all units to be ready to initialise the replica set. This PR updates the code so that the charm adds replicas to the replica set one at a time on relation-joined/relation-changed hook firing. As promised this PR now resolves the failing integration tests

For the reader:
Tests which are no longer relevant were removed as well.

To reduce keep this PR within scope we will test add-unit in a later PR. (This PR is meant to ensure functionality of `juju deploy ./*charm -n <num_units>`.) 

Similarly, to reduce the size of this PR removal of now un-used functions will be done in the subsequent PR. An additional tests will also be updated accordingly

Accounting for unit restart will be taken into account after unit removal (via relation-departed events) has been adequately handled 