### PR TITLE
DPE-65 basic relation departed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -59,14 +59,11 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         Args:
             event: The triggering relation departed event.
         """
-        # only leader should configure replica set and app-changed-events can trigger the relation
-        # changed hook resulting in no JUJU_REMOTE_UNIT if this is the case we should return
-        print("Before reconfig", self._replica_set_hosts)
-        if not (self.unit.is_leader() and event.unit):
+        # only leader should configure replica set
+        if not self.unit.is_leader():
             return
 
         self._reconfigure(event)
-        print("After reconfig", self._replica_set_hosts)
 
     def _on_mongodb_relation_handler(self, event: ops.charm.RelationEvent) -> None:
         """Adds the unit as a replica to the MongoDB replica set.

--- a/src/charm.py
+++ b/src/charm.py
@@ -22,7 +22,7 @@ from ops.model import (
     WaitingStatus,
 )
 
-from mongod_helpers import MONGODB_PORT, ConfigurationError, ConnectionFailure, MongoDB
+from mongod_helpers import MONGODB_PORT, ConfigurationError, ConnectionFailure, OperationFailure, MongoDB
 
 logger = logging.getLogger(__name__)
 
@@ -38,45 +38,56 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
-        self.framework.observe(self.on.mongodb_relation_joined, self._mongodb_relation_joined)
         self.framework.observe(self.on.start, self._on_start)
+        self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_joined)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
 
-    def _mongodb_relation_joined(self, event) -> None:
+    def _on_mongodb_relation_joined(self, event: ops.charm.RelationJoinedEvent) -> None:
+        """Adds the joined unit as a replica to the MongoDB replica set.
+
+        Args:
+            event: The triggering relation joined event.
+        """
+        # only leader should configure replica set
         if not self.unit.is_leader():
             return
 
-        # do not initialise replica set until all peers have joined
-        if not self._check_unit_count:
-            logger.debug("waiting to initialise replica set until all planned units have joined")
+        #  only add the calling unit to the replica set if it has mongod running
+        calling_unit = event.unit
+        calling_unit_ip = str(self._peers.data[calling_unit].get("private-address"))
+        mongo_peer = self._single_mongo_replica(calling_unit_ip)
+        if not mongo_peer.is_ready(standalone=True):
+            logger.debug(
+                "unit is not ready, cannot initialise replica set unit: %s is ready, deferring on relation-joined",
+                calling_unit.name
+            )
+            event.defer()
             return
 
-        # do not initialise replica set until all peers have started mongod
-        for peer in self._peers.units:
-            mongo_peer = self._single_mongo_replica(
-                str(self._peers.data[peer].get("private-address"))
-            )
-            if not mongo_peer.is_ready(standalone=True):
-                logger.debug(
-                    "unit: %s is not ready, cannot initialise replica set until all units are ready, deferring on relation-joined",
-                    peer,
-                )
-                event.defer()
-                return
+        logger.debug("unit: %s is ready to join the replica set", calling_unit.name)
+        self._reconfigure(event)
 
-        # in future patch we will reconfigure the replicaset instead of re-initialising
-        if not self._mongo.is_replica_set():
+    def _reconfigure(self, event: ops.charm.RelationEvent) -> None:
+        """Adds/removes RelationEvent triggering unit from the replica set.
+
+        Note: Removal funcationality will be implemented in the following PR.
+
+        Args:
+            event: The triggering relation event.
+        """
+        # check if reconfiguration is necessary
+        if self._need_replica_set_reconfiguration:
             try:
-                self._initialise_replica_set()
-            except (ConnectionFailure, ConfigurationError):
-                self.unit.status = BlockedStatus("failed to initialise replica set")
-                return
-
-        # verify replica set is ready
-        if not self._mongo.is_ready():
-            logger.debug("Replica set for units: %s, is not ready", self._unit_ips)
-            self.unit.status = BlockedStatus("failed to initialise replica set")
+                # reconfigure replica set
+                self._mongo.reconfigure_replica_set()
+                # update the set of replica set hosts
+                self._peers.data[self.app]["replica_set_hosts"] = json.dumps(self._unit_ips)
+                logger.debug("Replica set successfully reconfigured")
+            except (ConnectionFailure, ConfigurationError, OperationFailure) as e:
+                logger.error("deferring reconfigure of replica set: %s", str(e))
+                self.unit.status = WaitingStatus("waiting to reconfigure replica set")
+                event.defer()
 
     def _on_install(self, _) -> None:
         """Handle the install event (fired on startup).
@@ -261,7 +272,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         try:
             leader_ip = str(self.model.get_binding(PEER).network.bind_address)
             self._mongo.initialise_replica_set([leader_ip])
-            self._peers.data[self.app]["replica_set_hosts"] = json.dumps(leader_ip)
+            self._peers.data[self.app]["replica_set_hosts"] = json.dumps([leader_ip])
         except (ConnectionFailure, ConfigurationError) as e:
             logger.error("error initialising replica sets in _on_start: error: %s", str(e))
             self.unit.status = WaitingStatus("waiting to initialise replica set")
@@ -278,6 +289,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         unit_config = self._config
         unit_config["calling_unit_ip"] = ip_address
         return MongoDB(unit_config)
+
+    @property
+    def _need_replica_set_reconfiguration(self) -> bool:
+        """Does MongoDB replica set need reconfiguration.
+
+        Returns:
+            bool: that indicates if the replica set hosts should be reconfigured
+        """
+        # are the units for the application all assigned to a host
+        return set(self._unit_ips) != set(self._replica_set_hosts)
 
     @property
     def _check_unit_count(self) -> bool:
@@ -310,6 +331,15 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         return addresses
 
     @property
+    def _replica_set_hosts(self):
+        """Fetch current list of hosts in the replica set.
+
+        Returns:
+            A list of hosts addresses (strings).
+        """
+        return json.loads(self._peers.data[self.app].get("replica_set_hosts", "[]"))
+
+    @property
     def _config(self) -> dict:
         """Retrieve config options for MongoDB.
 
@@ -320,7 +350,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         config = {
             "app_name": self.app.name,
             "replica_set_name": "rs0",
-            "num_peers": 1,
+            "num_hosts": len(self._unit_ips),
             "port": self._port,
             "root_password": "password",
             "security_key": "",

--- a/src/charm.py
+++ b/src/charm.py
@@ -52,7 +52,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
 
-    def _on_mongodb_relation_departed(self, event: ops.charm.RelationEvent) -> None:
+    def _on_mongodb_relation_departed(self, event: ops.charm.RelationDepartedEvent) -> None:
         """Removes the unit from the MongoDB replica set.
 
         Args:

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,14 +47,27 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_handler)
         self.framework.observe(self.on.mongodb_relation_changed, self._on_mongodb_relation_handler)
+        self.framework.observe(self.on.mongodb_relation_departed,
+                               self._on_mongodb_relation_departed)
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
 
-    def _on_mongodb_relation_handler(self, event: ops.charm.RelationEvent) -> None:
-        """Adds the unit as a replica to the MongoDB replica set.
+    def _on_mongodb_relation_departed(self, event: ops.charm.RelationEvent) -> None:
+        """Removes the unit from the MongoDB replica set.
 
         Args:
-            event: The triggering relation joined/chnged event.
+            event: The triggering relation departed event.
+        """
+        # only leader should configure replica set
+        if not self.unit.is_leader():
+            return
+
+        self._reconfigure(event)
+
+    def _on_mongodb_relation_handler(self, event: ops.charm.RelationEvent) -> None:
+        """Adds the unit as a replica to the MongoDB replica set.
+        Args:
+            event: The triggering relation joined/changed event.
         """
         # only leader should configure replica set
         if not self.unit.is_leader():
@@ -312,6 +325,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         return set(self._unit_ips) != set(self._replica_set_hosts)
 
     @property
+    def _check_unit_count(self) -> bool:
+        all_units_joined = self.app.planned_units() == len(self._peers.units) + 1
+        logger.debug(
+            "planned units does not match joined units: %s != %s",
+            str(self.app.planned_units()),
+            str(len(self._peers.units) + 1),
+        )
+        return all_units_joined
+
+    @property
     def _unit_ips(self) -> List[str]:
         """Retrieve IP addresses associated with MongoDB application.
 
@@ -377,6 +400,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
              An `ops.model.Relation` object representing the peer relation.
         """
         return self.model.get_relation(PEER)
+
+    @property
+    def _number_of_expected_units(self) -> int:
+        """Returns the number of units expect for MongoDB application."""
+        return self.app.planned_units()
+
+    @property
+    def _number_of_current_units(self) -> int:
+        """Returns the number of units in the MongoDB application."""
+        return len(self._peers.units) + 1
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,8 +47,9 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_handler)
         self.framework.observe(self.on.mongodb_relation_changed, self._on_mongodb_relation_handler)
-        self.framework.observe(self.on.mongodb_relation_departed,
-                               self._on_mongodb_relation_departed)
+        self.framework.observe(
+            self.on.mongodb_relation_departed, self._on_mongodb_relation_departed
+        )
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -312,16 +312,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         return set(self._unit_ips) != set(self._replica_set_hosts)
 
     @property
-    def _check_unit_count(self) -> bool:
-        all_units_joined = self.app.planned_units() == len(self._peers.units) + 1
-        logger.debug(
-            "planned units does not match joined units: %s != %s",
-            str(self.app.planned_units()),
-            str(len(self._peers.units) + 1),
-        )
-        return all_units_joined
-
-    @property
     def _unit_ips(self) -> List[str]:
         """Retrieve IP addresses associated with MongoDB application.
 
@@ -387,16 +377,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
              An `ops.model.Relation` object representing the peer relation.
         """
         return self.model.get_relation(PEER)
-
-    @property
-    def _number_of_expected_units(self) -> int:
-        """Returns the number of units expect for MongoDB application."""
-        return self.app.planned_units()
-
-    @property
-    def _number_of_current_units(self) -> int:
-        """Returns the number of units in the MongoDB application."""
-        return len(self._peers.units) + 1
 
 
 if __name__ == "__main__":

--- a/src/mongod_helpers.py
+++ b/src/mongod_helpers.py
@@ -147,7 +147,6 @@ class MongoDB:
         Using the current MongoDB configuration from mongod, reconfigure_replica_set reconfigures
         the replica set based on the current replica set hosts and the desired replica set hosts.
         """
-
         replica_set_client = self.client()
         try:
             # get current configuration and update with correct hosts

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -144,25 +144,25 @@ async def test_get_primary_action(ops_test: OpsTest) -> None:
 
 async def test_cluster_is_stable_after_deletion(ops_test: OpsTest) -> None:
     """Tests that the cluster maintains a primary after the primary is delelted."""
-    # find & destroy leader unit
-    leader_ip = None
+    # find & destroy non-leader unit
+    non_leader_ip = None
     for unit in ops_test.model.applications[APP_NAME].units:
-        if await unit.is_leader_from_status():
-            leader_ip = unit.public_address
+        if not await unit.is_leader_from_status():
+            non_leader_ip = unit.public_address
             await unit.destroy()
             break
 
     # wait for app to be active after removal of unit
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
 
-    # verify that there are two units running after deletion of leader
+    # verify that there are two units running after deletion of non leader
     assert len(ops_test.model.applications[APP_NAME].units) == 2
 
-    # grab remaining IPS, must compare against leader_ip since it is not
-    # guaranteed that the leader unit will be fully shutdown
+    # grab remaining IPS, must compare against non_leader_ip since it is not
+    # guaranteed that the non_leader unit will be fully shutdown
     ip_addresses = []
     for unit in ops_test.model.applications[APP_NAME].units:
-        if not unit.public_address == leader_ip:
+        if not unit.public_address == non_leader_ip:
             ip_addresses.append(unit.public_address)
 
     # check that the replica set with the remaining units has a primary
@@ -175,13 +175,23 @@ async def test_cluster_is_stable_after_deletion(ops_test: OpsTest) -> None:
     except RetryError:
         primary = None
 
-    client.close()
-
     # verify that the primary is not None
     assert primary is not None, "replica set with uri {} has no primary".format(replica_set_uri)
 
     # check that the primary is not one of the deleted units
     assert primary[0] in ip_addresses, "replica set primary is not one of the available units"
+
+    # verify that the configuration of mongodb no longer has the deleted ip
+    removed_from_config = True
+    rs_config = client.admin.command("replSetGetConfig")
+    for member in rs_config["config"]["members"]:
+        # get member ip without ":PORT"
+        member_ip = member["host"].split(":")[0]
+        if member_ip == non_leader_ip:
+            removed_from_config = False
+
+    assert removed_from_config, "removed unit is still present in replica set config"
+    client.close()
 
 
 def update_bind_ip(conf: str, ip_address: str) -> str:

--- a/tests/unit/test_mongod_helpers.py
+++ b/tests/unit/test_mongod_helpers.py
@@ -194,3 +194,23 @@ class TestMongoServer(unittest.TestCase):
         ]
         new_config = mongo.replica_set_config(current_config)
         self.assertEqual(new_config, expected_new_members)
+
+    def test_replica_set_config_removes_member(self):
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        # remove a member
+        config["unit_ips"] = ["2.2.2.2"]
+        mongo = MongoDB(config)
+
+        current_config = {}
+        current_config["config"] = {}
+        current_config["config"]["members"] = [
+            {"host": "1.1.1.1:27017", "_id": 0},
+            {"host": "2.2.2.2:27017", "_id": 1},
+        ]
+
+        expected_new_members = [
+            {"host": "2.2.2.2:27017", "_id": 1},
+        ]
+        new_config = mongo.replica_set_config(current_config)
+        self.assertEqual(new_config, expected_new_members)

--- a/tests/unit/test_mongod_helpers.py
+++ b/tests/unit/test_mongod_helpers.py
@@ -7,12 +7,17 @@ from unittest.mock import patch
 from pymongo import MongoClient
 from tenacity import RetryError
 
-from mongod_helpers import MongoDB
+from mongod_helpers import (
+    ConfigurationError,
+    ConnectionFailure,
+    MongoDB,
+    OperationFailure,
+)
 
 MONGO_CONFIG = {
     "app_name": "mongodb",
     "replica_set_name": "rs0",
-    "num_peers": 1,
+    "num_hosts": 2,
     "port": 27017,
     "root_password": "password",
     "unit_ips": ["1.1.1.1", "2.2.2.2"],
@@ -72,7 +77,7 @@ class TestMongoServer(unittest.TestCase):
         client.return_value = mock_client
 
         hosts = {}
-        for i in range(config["num_peers"]):
+        for i in range(config["num_hosts"]):
             hosts[i] = "host{}".format(i)
 
         mongo.initialise_replica_set(hosts)
@@ -116,3 +121,76 @@ class TestMongoServer(unittest.TestCase):
         replica_set_status = mongo.is_replica_set()
         close.assert_called()
         self.assertEqual(replica_set_status, False)
+
+    @patch("mongod_helpers.MongoDB.client")
+    @patch("pymongo.MongoClient")
+    def test_reconfiguring_replica_invokes_admin_command(self, mock_client, client):
+        # presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+        client.return_value = mock_client
+
+        # verify we make a call to replSetReconfig
+        mongo.reconfigure_replica_set()
+        mock_client.admin.command.assert_called()
+        command, _ = mock_client.admin.command.call_args
+        self.assertEqual("replSetReconfig", command[0])
+
+        # verify we close connection
+        (mock_client.close).assert_called()
+
+    @patch("mongod_helpers.MongoDB.client")
+    @patch("pymongo.MongoClient")
+    def test_reconfiguring_replica_handles_failure(self, mock_client, client):
+        # presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+        client.return_value = mock_client
+
+        # verify we make a call to reconfigure
+        exceptions = [
+            ConnectionFailure("error message"),
+            ConfigurationError("error message"),
+            OperationFailure("error message"),
+        ]
+        raises = [ConnectionFailure, ConfigurationError, OperationFailure]
+        for exception, expected_raise in zip(exceptions, raises):
+            with self.assertRaises(expected_raise):
+                mock_client.admin.command.side_effect = exception
+
+                # call function
+                mongo.reconfigure_replica_set()
+
+                # verify we close connection
+                (mock_client.close).assert_called()
+
+    def test_replica_set_config_no_changes(self):
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+
+        current_config = {}
+        current_config["config"] = {}
+        current_config["config"]["members"] = [
+            {"host": "1.1.1.1:27017", "_id": 0},
+            {"host": "2.2.2.2:27017", "_id": 1},
+        ]
+
+        new_config = mongo.replica_set_config(current_config)
+        self.assertEqual(new_config, current_config["config"]["members"])
+
+    def test_replica_set_config_adds_member(self):
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+
+        current_config = {}
+        current_config["config"] = {}
+        current_config["config"]["members"] = [{"host": "1.1.1.1:27017", "_id": 0}]
+
+        expected_new_members = [
+            {"host": "1.1.1.1:27017", "_id": 0},
+            {"host": "2.2.2.2:27017", "_id": 1},
+        ]
+        new_config = mongo.replica_set_config(current_config)
+        self.assertEqual(new_config, expected_new_members)


### PR DESCRIPTION
This PR addresses a basic relation departed. In which the administrator plans for a unit to leave with `juju remove-unit <unit name>`.

_Note this PR does not address the following_:
1. The departing unit is the leader
2. The departing unit is the primary
3. The departing unit departs unexpectedly with the possibility of becoming live again

The aforementioned list will be addressed in subsequent PRs. 