### PR TITLE
DPE-82 test add unit operations

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -279,9 +279,7 @@ async def test_add_unit(ops_test: OpsTest) -> None:
     assert len(ops_test.model.applications[APP_NAME].units) == 2
 
     # grab unit ips
-    ip_addresses = []
-    for unit in ops_test.model.applications[APP_NAME].units:
-        ip_addresses.append(unit.public_address)
+    ip_addresses = [unit.public_address for unit in ops_test.model.applications[APP_NAME].units]
 
     # connect to replica set uri
     replica_set_uri = "mongodb://{}:{},{}:{}/replicaSet=rs0".format(


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
In short this PR address this JIRA ticket [DPE-82](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&quickFilter=844&selectedIssue=DPE-82)

In long: 
- Currently the functionality of `juju add-unit` isn’t integration tested
 
### Solution
<!-- A summary of the solution addressing the above problem -->
Solution in short: add a test for `juju add-unit` :wink:

This tests `juju add-unit`, by confirming that the `relation-joined` hook operates as expected, specifically this verifies that when a unit is added to MongoDB that unit’s IP address is in the replica set config of MongoDB. You can see this in the test `test_add_unit`. 

### Context
<!-- What is some specialised knowledge relevant to this project/technology -->
- Replicas that get added to a replica set in MongoDB **must** be added to the configuration otherwise they will not function as a replica.

### Release Notes
<!-- A digestable summary of the change in this PR -->
- `test/integration/test_charm.py` - `test_add_unit` adds unit and verifies it gets added to the configuration
