### PR TITLE
Add a check for if a replica is ready

### DIFF
--- a/src/mongod_helpers.py
+++ b/src/mongod_helpers.py
@@ -82,7 +82,7 @@ class MongoDB:
         try:
             replica_status = self.check_replica_status()
         except (ConnectionFailure, ConfigurationError, OperationFailure):
-            return None
+            return False
 
         if replica_status == "PRIMARY" or replica_status == "SECONDARY" or replica_status == "ARBITER":
             return True

--- a/src/mongod_helpers.py
+++ b/src/mongod_helpers.py
@@ -61,7 +61,7 @@ class MongoDB:
             status = client.admin.command("replSetGetStatus")
         except (ConnectionFailure, ConfigurationError, OperationFailure) as e:
             logger.error("Failed to check the replica status, error: %s", e)
-            raise e
+            raise
         finally:
             client.close()
 
@@ -84,13 +84,17 @@ class MongoDB:
         except (ConnectionFailure, ConfigurationError, OperationFailure):
             return False
 
-        if replica_status == "PRIMARY" or replica_status == "SECONDARY" or replica_status == "ARBITER":
+        if (
+            replica_status == "PRIMARY"
+            or replica_status == "SECONDARY"
+            or replica_status == "ARBITER"
+        ):
             return True
 
         return False
 
     def is_mongod_ready(self) -> bool:
-        """Are mongod services available on a singe replica.
+        """Are mongod services available on a single replica.
 
         Returns:
             bool: True if services is ready False otherwise.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -80,7 +80,13 @@ class TestCharm(unittest.TestCase):
     @patch("charm.service_resume")
     @patch("mongod_helpers.MongoDB.is_replica_set")
     def test_on_start_full_successful_execution(
-        self, is_replica, service_resume, _open_port_tcp, initialise_replica_set, is_mongod_ready, is_replica_ready
+        self,
+        is_replica,
+        service_resume,
+        _open_port_tcp,
+        initialise_replica_set,
+        is_mongod_ready,
+        is_replica_ready,
     ):
         self.harness.set_leader(True)
         is_replica_ready.return_value = True
@@ -198,7 +204,13 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._initialise_replica_set")
     @patch("charm.service_running")
     def test_on_start_replica_not_ready_waits(
-        self, service_running, initialise_replica_set, _open_port_tcp, is_mongod_ready, is_replica_ready, is_replica_set
+        self,
+        service_running,
+        initialise_replica_set,
+        _open_port_tcp,
+        is_mongod_ready,
+        is_replica_ready,
+        is_replica_set,
     ):
         """Tests that if a replica is not ready that the charm goes into waiting."""
         self.harness.set_leader(True)
@@ -218,7 +230,13 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._initialise_replica_set")
     @patch("charm.service_running")
     def test_on_start_cannot_check_replica_status(
-        self, service_running, initialise_replica_set, _open_port_tcp, is_mongod_ready, check_replica_status, is_replica_set
+        self,
+        service_running,
+        initialise_replica_set,
+        _open_port_tcp,
+        is_mongod_ready,
+        check_replica_status,
+        is_replica_set,
     ):
         """Tests that failure to check replica state results in waiting status."""
         self.harness.set_leader(True)
@@ -568,7 +586,13 @@ class TestCharm(unittest.TestCase):
     @patch("charm.service_running")
     @patch("mongod_helpers.MongoDB.is_replica_set")
     def test_initialise_replica_success(
-        self, is_replica, service_running, _open_port_tcp, initialise_replica_set, is_mongod_ready, is_replica_ready
+        self,
+        is_replica,
+        service_running,
+        _open_port_tcp,
+        initialise_replica_set,
+        is_mongod_ready,
+        is_replica_ready,
     ):
         self.harness.set_leader(True)
         service_running.return_value = True


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
As of now a the MongoDB charm checks `is_ready` by seeing if the mongo daemon is running (`mongod`) while this is important to do, it is also important that we check if replica is in the ready state (ie is the replica is ready to serve read and write requests.)

So essentially the problem is that we have no check to see if the replica is ready to serve read or write requests


### Solution
<!-- A summary of the solution addressing the above problem -->
To resolve this we add a second function `is_replica_ready` which returns true if the replica is ready to serve read and write requests. This is done by checking if that replica is in the `SECONDARY`, `PRIMARY`, or `ARBITER` state.

Note: when in the `ARBITER` state we cannot accept reads or writes, but this replica will still be considered as ready as it is not in an error state or starting up or rolling back. 

### Context
<!-- What is some specialised knowledge relevant to this project/technology -->

There are two definitions of ready:
- `mongod` (the MongoDB daemon) is available to serve requests 
- The replicas in the replica set are ready to function ie are in one of the states `SECONDARY`, `PRIMARY`, or `ARBITER`


### Release Notes
<!-- A digestable summary of the change in this PR -->
Major Changes:
- `src/mongod_helpers.py` - old `is_ready` function has now been changed to `is_mongod_started` to indicate that this function should be used to check whether `mongod` is available
-  `src/mongod_helpers.py` - `is_replica_ready` now checks whether the replica is in one of the ready states (`SECONDARY`, `PRIMARY`, or `ARBITER`)
-  `src/mongod_helpers.py` - `check_replica_status` is added as a helper function to retrieve the replica status

Minor Changes:
- `src/charm.py` usage of `is_ready` updated to check either the replica status or the mongod status where appropriate
- `tests/unit/test_mongod_helpers` added new tests and updating old tests 
- `tests/unit/test_mongod_helpers` updating old tests for this new schema


### Notes to the reader
<!-- A digestable summary of the change in this PR -->
This is the first step in a larger process. I wanted to break up my PRs in a digestible way and this is my attempt to do so.

_What is the larger process you might ask?_ Well, the plan is to:
- Have unit status properly reflect the replica status as per the JIRA task [DPE-112](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-112&quickFilter=844)
- Using the replica status wait to add replicas the replica set until all replicas are ready as per the JIRA task [DPE-113](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-113&quickFilter=844)
- Using the replica status wait to remove replicas from the replica set until all replicas are ready as per the JIRA task [DPE-114](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-114&quickFilter=844)
- I see that this code gets re-used often, I will make a new PR for this to create a const for this:
```        
       exceptions = [
            ConnectionFailure("error message"),
            ConfigurationError("error message"),
            OperationFailure("error message"),
        ]
```
