### PR TITLE
DPE-113 wait for ready

### DIFF
--- a/src/mongod_helpers.py
+++ b/src/mongod_helpers.py
@@ -59,7 +59,7 @@ class MongoDB:
 
         Args:
             replica_ip: ip of replica to check status of
-            """
+        """
         # connect to mongod and retrieve replica set status
         client = self.client(standalone=True)
         try:
@@ -81,7 +81,7 @@ class MongoDB:
         return None
 
     def all_replicas_ready(self) -> bool:
-        """TODO."""
+        """Returns true if all replica hosts are ready."""
         for unit_ip in self._replica_set_hosts:
             if not self.is_replica_ready(unit_ip):
                 logger.debug("unit: %s is not ready", unit_ip)

--- a/src/mongod_helpers.py
+++ b/src/mongod_helpers.py
@@ -74,8 +74,9 @@ class MongoDB:
         # look for our ip address in set of members
         for member in status["members"]:
             # get member ip without ":PORT"
-            logger.debug(member["name"].split(":")[0])
-            if replica_ip == member["name"].split(":")[0]:
+            member_ip = member["name"].split(":")[0]
+            logger.debug(member_ip)
+            if replica_ip == member_ip:
                 return member["stateStr"]
 
         return None

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -509,7 +509,7 @@ class TestCharm(unittest.TestCase):
     def test_mongodb_relation_joined_all_replicas_not_ready(
         self, all_replicas_ready, mongodb_reconfigure, need_reconfiguration, single_replica
     ):
-        """Tests that when current replcia set hosts are not ready that we go into waiting
+        """Tests that when current replcia set hosts are not ready that we go into waiting.
 
         Tests the scenario that a failure to check the current statuses of replica set hosts
         results in WaitingStatus and no attempt to reconfigure is made.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -27,6 +27,7 @@ REPO_ENTRY = (
     "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse"
 )
 REPO_MAP = {"deb-https://repo.mongodb.org/apt/ubuntu-focal/mongodb-org/5.0"}
+PEER_ADDR = {"private-address": "127.4.5.6"}
 
 PYMONGO_EXCEPTIONS = [
     ConnectionFailure("error message"),
@@ -388,10 +389,9 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     def test_unit_ips(self):
-        key_values = {"private-address": "127.4.5.6"}
         rel_id = self.harness.charm.model.get_relation("mongodb").id
         self.harness.add_relation_unit(rel_id, "mongodb/1")
-        self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
+        self.harness.update_relation_data(rel_id, "mongodb/1", PEER_ADDR)
 
         resulting_ips = self.harness.charm._unit_ips
         expected_ips = ["127.4.5.6", "1.1.1.1"]
@@ -421,9 +421,8 @@ class TestCharm(unittest.TestCase):
 
         # simulate 2nd MongoDB unit
         rel = self.harness.charm.model.get_relation("mongodb")
-        key_values = {"private-address": "127.4.5.6"}
         self.harness.add_relation_unit(rel.id, "mongodb/1")
-        self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+        self.harness.update_relation_data(rel.id, "mongodb/1", PEER_ADDR)
 
         # verify that we do not reconfigure replica set
         mongo_reconfigure.assert_not_called()
@@ -451,9 +450,8 @@ class TestCharm(unittest.TestCase):
 
             # simulate 2nd MongoDB unit
             rel = self.harness.charm.model.get_relation("mongodb")
-            key_values = {"private-address": "127.4.5.6"}
             self.harness.add_relation_unit(rel.id, "mongodb/1")
-            self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+            self.harness.update_relation_data(rel.id, "mongodb/1", PEER_ADDR)
 
             # check if mongod reconfigured replica set
             if reconfiguration:
@@ -491,9 +489,8 @@ class TestCharm(unittest.TestCase):
 
             # simulate 2nd MongoDB unit
             rel = self.harness.charm.model.get_relation("mongodb")
-            key_values = {"private-address": "127.4.5.6"}
             self.harness.add_relation_unit(rel.id, "mongodb/1")
-            self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+            self.harness.update_relation_data(rel.id, "mongodb/1", PEER_ADDR)
 
             # verify we go into waiting and don't reconfigure
             self.assertEqual(
@@ -509,7 +506,7 @@ class TestCharm(unittest.TestCase):
     def test_mongodb_relation_joined_all_replicas_not_ready(
         self, all_replicas_ready, mongodb_reconfigure, need_reconfiguration, single_replica
     ):
-        """Tests that when current replcia set hosts are not ready that we go into waiting.
+        """Tests that we go into waiting when current ReplicaSet hosts are not ready.
 
         Tests the scenario that a failure to check the current statuses of replica set hosts
         results in WaitingStatus and no attempt to reconfigure is made.
@@ -520,9 +517,8 @@ class TestCharm(unittest.TestCase):
 
         # simulate 2nd MongoDB unit
         rel = self.harness.charm.model.get_relation("mongodb")
-        key_values = {"private-address": "127.4.5.6"}
         self.harness.add_relation_unit(rel.id, "mongodb/1")
-        self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+        self.harness.update_relation_data(rel.id, "mongodb/1", PEER_ADDR)
 
         # verify we go into waiting and don't reconfigure
         self.assertEqual(
@@ -549,9 +545,8 @@ class TestCharm(unittest.TestCase):
 
             # simulate 2nd MongoDB unit
             rel = self.harness.charm.model.get_relation("mongodb")
-            key_values = {"private-address": "127.4.5.6"}
             self.harness.add_relation_unit(rel.id, "mongodb/1")
-            self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+            self.harness.update_relation_data(rel.id, "mongodb/1", PEER_ADDR)
 
             # charm waits
             self.assertEqual(
@@ -572,9 +567,8 @@ class TestCharm(unittest.TestCase):
         # add peer unit
         rel = self.harness.charm.model.get_relation("mongodb")
         rel_id = rel.id
-        key_values = {"private-address": "127.4.5.6"}
         self.harness.add_relation_unit(rel_id, "mongodb/1")
-        self.harness.update_relation_data(rel_id, "mongodb/1", key_values)
+        self.harness.update_relation_data(rel_id, "mongodb/1", PEER_ADDR)
 
         # remove unit to trigger event
         self.harness.remove_relation_unit(rel_id, "mongodb/1")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -131,10 +131,8 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
     @patch("charm.service_resume")
     @patch("charm.MongodbOperatorCharm._initialise_replica_set")
-    @patch("charm.MongodbOperatorCharm.app")
     def test_on_start_not_leader_doesnt_initialise_replica_set(
         self,
-        app,
         _initialise_replica_set,
         service_resume,
         _open_port_tcp,
@@ -149,7 +147,6 @@ class TestCharm(unittest.TestCase):
         _open_port_tcp.assert_called()
         is_ready.assert_called()
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
-        app.planned_units.assert_not_called()
         _initialise_replica_set.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
@@ -435,8 +432,9 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._single_mongo_replica")
     @patch("charm.MongodbOperatorCharm._need_replica_set_reconfiguration")
     @patch("mongod_helpers.MongoDB.reconfigure_replica_set")
+    @patch("mongod_helpers.MongoDB.all_replicas_ready", return_value=True)
     def test_mongodb_relation_joined_peer_ready(
-        self, mongodb_reconfigure, need_reconfiguration, single_replica
+        self, all_replicas_ready, mongodb_reconfigure, need_reconfiguration, single_replica
     ):
         """Test leader unit operations when peer unit is ready to join the replica set.
 
@@ -469,6 +467,68 @@ class TestCharm(unittest.TestCase):
 
             else:
                 mongodb_reconfigure.assert_not_called()
+
+    @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.MongodbOperatorCharm._single_mongo_replica")
+    @patch("charm.MongodbOperatorCharm._need_replica_set_reconfiguration", return_value=True)
+    @patch("mongod_helpers.MongoDB.reconfigure_replica_set")
+    @patch("mongod_helpers.MongoDB.check_replica_status")
+    def test_mongodb_relation_joined_check_status_failure(
+        self, check_replica_status, mongodb_reconfigure, need_reconfiguration, single_replica
+    ):
+        """Test failure in checking status results in waiting.
+
+        Tests the scenario that a failure to check the current statuses of replica set hosts
+        results in WaitingStatus and no attempt to reconfigure is made.
+        """
+        # preset values
+        self.harness.set_leader(True)
+        single_replica.return_value.is_ready.return_value = True
+
+        for exception in PYMONGO_EXCEPTIONS:
+            # simulate failure to check replica status
+            check_replica_status.side_effect = exception
+
+            # simulate 2nd MongoDB unit
+            rel = self.harness.charm.model.get_relation("mongodb")
+            key_values = {"private-address": "127.4.5.6"}
+            self.harness.add_relation_unit(rel.id, "mongodb/1")
+            self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+
+            # verify we go into waiting and don't reconfigure
+            self.assertEqual(
+                self.harness.charm.unit.status, WaitingStatus("waiting to reconfigure replica set")
+            )
+            mongodb_reconfigure.assert_not_called()
+
+    @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.MongodbOperatorCharm._single_mongo_replica")
+    @patch("charm.MongodbOperatorCharm._need_replica_set_reconfiguration", return_value=True)
+    @patch("mongod_helpers.MongoDB.reconfigure_replica_set")
+    @patch("mongod_helpers.MongoDB.all_replicas_ready", return_value=False)
+    def test_mongodb_relation_joined_all_replicas_not_ready(
+        self, all_replicas_ready, mongodb_reconfigure, need_reconfiguration, single_replica
+    ):
+        """Tests that when current replcia set hosts are not ready that we go into waiting
+
+        Tests the scenario that a failure to check the current statuses of replica set hosts
+        results in WaitingStatus and no attempt to reconfigure is made.
+        """
+        # preset values
+        self.harness.set_leader(True)
+        single_replica.return_value.is_ready.return_value = True
+
+        # simulate 2nd MongoDB unit
+        rel = self.harness.charm.model.get_relation("mongodb")
+        key_values = {"private-address": "127.4.5.6"}
+        self.harness.add_relation_unit(rel.id, "mongodb/1")
+        self.harness.update_relation_data(rel.id, "mongodb/1", key_values)
+
+        # verify we go into waiting and don't reconfigure
+        self.assertEqual(
+            self.harness.charm.unit.status, WaitingStatus("waiting to reconfigure replica set")
+        )
+        mongodb_reconfigure.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongodbOperatorCharm._single_mongo_replica")

--- a/tests/unit/test_mongod_helpers.py
+++ b/tests/unit/test_mongod_helpers.py
@@ -330,7 +330,7 @@ class TestMongoServer(unittest.TestCase):
     @patch("pymongo.MongoClient")
     @patch("mongod_helpers.MongoDB.client")
     def test_not_all_replicas_ready(self, is_replica_ready, mock_client, client):
-        """Verifies that all_replicas_ready returns False when not all replicas are ready"""
+        """Verifies that all_replicas_ready returns False when not all replicas are ready."""
         # standard presets
         config = MONGO_CONFIG.copy()
         mongo = MongoDB(config)

--- a/tests/unit/test_mongod_helpers.py
+++ b/tests/unit/test_mongod_helpers.py
@@ -22,6 +22,7 @@ MONGO_CONFIG = {
     "root_password": "password",
     "unit_ips": ["1.1.1.1", "2.2.2.2"],
     "calling_unit_ip": ["1.1.1.1"],
+    "replica_set_hosts": ["1.1.1.1", "2.2.2.2"],
 }
 
 PYMONGO_EXCEPTIONS = [
@@ -322,5 +323,32 @@ class TestMongoServer(unittest.TestCase):
         for exception, expected_raise in PYMONGO_EXCEPTIONS:
             with self.assertRaises(expected_raise):
                 mock_client.admin.command.side_effect = exception
-                mongo.check_replica_status()
+                mongo.check_replica_status("1.1.1.1")
             mock_client.close.assert_called()
+
+    @patch("mongod_helpers.MongoDB.is_replica_ready", return_value=False)
+    @patch("pymongo.MongoClient")
+    @patch("mongod_helpers.MongoDB.client")
+    def test_not_all_replicas_ready(self, is_replica_ready, mock_client, client):
+        """Verifies that all_replicas_ready returns False when not all replicas are ready"""
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+
+        # verify result of all replicas ready
+        self.assertEqual(mongo.all_replicas_ready(), False)
+
+    @patch("mongod_helpers.MongoDB.check_replica_status")
+    @patch("pymongo.MongoClient")
+    @patch("mongod_helpers.MongoDB.client")
+    def test_not_all_replicas_check_failure(self, check_replica_status, mock_client, client):
+        """Verifies that all_replicas_ready returns False failure to check status occurs."""
+        # standard presets
+        config = MONGO_CONFIG.copy()
+        mongo = MongoDB(config)
+
+        for exception in PYMONGO_EXCEPTIONS:
+            check_replica_status.side_effect = exception
+
+            # verify result of all replicas ready
+            self.assertEqual(mongo.all_replicas_ready(), False)


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
[JIRA ticket](https://warthogs.atlassian.net/jira/software/c/projects/DPE/boards/390?modal=detail&selectedIssue=DPE-113&quickFilter=844)

As of now a the MongoDB charm adds a new replica to the replica set if that replica has `mongod` running, however an extra check is needed. A check to see if all of the current replica set hosts are ready. Without this check there can be an increased downtime or performance degradation (see more on why in the section Context)


### Solution
<!-- A summary of the solution addressing the above problem -->
To resolve this we add a function `all_replicas_ready` which returns true if all replicas are ready to serve read and write requests. And this is checked before adding a replica to the replica set. 

### Context
<!-- What is some specialised knowledge relevant to this project/technology -->

It is important that all replicas be in the ready state before adding a new replica because during scale-up, each new member takes a backup from an alive member. e.g. during scale up from 3 to 6 all 3 current members will be loaded by the backup procedure. as result, they will not be able to serve (business) application queries. 

### Release Notes
<!-- A digestable summary of the change in this PR -->
Major Changes:
- `src/mongod_helpers.py` - `all_replicas_ready` function returns true if for every replica host each replica is ready to serve read/write requests

Minor Changes:
- `src/mongod_helpers.py` - now has field `_replica_set_hosts` this is different from the unit its, in that the unit ips are hosting MongoDB but not guaranteed to be hosting a replica 