### PR TITLE
Migration to new peer naming schema

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,5 +15,5 @@ storage:
     location: /data/db
 
 peers:
-  mongodb:
-    interface: mongodb-replicas
+  database-peers:
+    interface: mongodb-peers

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,7 +39,7 @@ from tenacity import before_log, retry, stop_after_attempt, wait_fixed
 
 logger = logging.getLogger(__name__)
 
-PEER = "mongodb"
+PEER = "database-peers"
 REPO_URL = "deb-https://repo.mongodb.org/apt/ubuntu-focal/mongodb-org/5.0"
 REPO_ENTRY = (
     "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse"
@@ -63,8 +63,8 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
-        self.framework.observe(self.on.mongodb_relation_joined, self._on_mongodb_relation_handler)
-        self.framework.observe(self.on.mongodb_relation_changed, self._on_mongodb_relation_handler)
+        self.framework.observe(self.on[PEER].relation_joined, self._on_mongodb_relation_handler)
+        self.framework.observe(self.on[PEER].relation_changed, self._on_mongodb_relation_handler)
 
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.get_primary_action, self._on_get_primary_action)
@@ -73,7 +73,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         )
         # if a new leader has been elected update hosts of MongoDB
         self.framework.observe(self.on.leader_elected, self._on_leader_elected)
-        self.framework.observe(self.on.mongodb_relation_departed, self._relation_departed)
+        self.framework.observe(self.on[PEER].relation_departed, self._relation_departed)
         self.framework.observe(self.on.get_admin_password_action, self._on_get_admin_password)
 
     def _generate_passwords(self) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -34,7 +34,7 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(MongodbOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-        self.peer_rel_id = self.harness.add_relation("mongodb", "mongodb")
+        self.peer_rel_id = self.harness.add_relation("database-peers", "database-peers")
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
@@ -299,7 +299,7 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     def test_unit_ips(self):
-        rel_id = self.harness.charm.model.get_relation("mongodb").id
+        rel_id = self.harness.charm.model.get_relation("database-peers").id
         self.harness.add_relation_unit(rel_id, "mongodb/1")
         self.harness.update_relation_data(rel_id, "mongodb/1", PEER_ADDR)
 
@@ -310,9 +310,9 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongoDBConnection")
     def test_mongodb_relation_joined_non_leader_does_nothing(self, connection):
         """Test verifies that non-leader units don't reconfigure the replica set on joined."""
-        rel = self.harness.charm.model.get_relation("mongodb")
+        rel = self.harness.charm.model.get_relation("database-peers")
         self.harness.set_leader(False)
-        self.harness.charm.on.mongodb_relation_joined.emit(relation=rel)
+        self.harness.charm.on.database_peers_relation_joined.emit(relation=rel)
         connection.return_value.__enter__.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
@@ -331,7 +331,7 @@ class TestCharm(unittest.TestCase):
         }
 
         # simulate 2nd MongoDB unit
-        rel = self.harness.charm.model.get_relation("mongodb")
+        rel = self.harness.charm.model.get_relation("database-peers")
         self.harness.add_relation_unit(rel.id, "mongodb/1")
         self.harness.update_relation_data(rel.id, "mongodb/1", PEER_ADDR)
 
@@ -352,7 +352,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        rel = self.harness.charm.model.get_relation("mongodb")
+        rel = self.harness.charm.model.get_relation("database-peers")
 
         for exception in PYMONGO_EXCEPTIONS:
             connection.return_value.__enter__.return_value.get_replset_members.side_effect = (
@@ -387,7 +387,7 @@ class TestCharm(unittest.TestCase):
         connection.return_value.__enter__.return_value.get_replset_members.return_value = {
             "1.1.1.1"
         }
-        rel = self.harness.charm.model.get_relation("mongodb")
+        rel = self.harness.charm.model.get_relation("database-peers")
 
         exceptions = PYMONGO_EXCEPTIONS
         exceptions.append(NotReadyError)
@@ -468,7 +468,7 @@ class TestCharm(unittest.TestCase):
     def test_get_primary_peer_unit_primary(self, connection):
         """Tests get primary outputs correct primary when called on a secondary replica."""
         # add peer unit
-        rel_id = self.harness.charm.model.get_relation("mongodb").id
+        rel_id = self.harness.charm.model.get_relation("database-peers").id
         self.harness.add_relation_unit(rel_id, "mongodb/1")
         self.harness.update_relation_data(rel_id, "mongodb/1", {"private-address": "2.2.2.2"})
 
@@ -488,7 +488,7 @@ class TestCharm(unittest.TestCase):
         Verifies that when there is no primary, the property _primary returns None.
         """
         # add peer unit
-        rel_id = self.harness.charm.model.get_relation("mongodb").id
+        rel_id = self.harness.charm.model.get_relation("database-peers").id
         self.harness.add_relation_unit(rel_id, "mongodb/1")
         self.harness.update_relation_data(rel_id, "mongodb/1", {"private-address": "2.2.2.2"})
 


### PR DESCRIPTION
Small PR to migrate to new peer naming schema, as peer [this conversation](https://github.com/canonical/mongodb-operator/pull/new/update-peer-namin)

No big PR description since this is a _tiny change_