### PR TITLE
File re-organisation

### DIFF
--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -7,6 +7,7 @@ import pwd
 
 from charms.operator_libs_linux.v1 import systemd
 from charms.mongodb_libs.v0.helpers import KEY_FILE
+from charms.mongodb_libs.v0.helpers import KEY_FILE
 
 # The unique Charmhub library identifier, never change it
 LIBID = "6q947ainc54837t38yhuidshahfgw8f"
@@ -20,10 +21,6 @@ LIBPATCH = 0
 
 logger = logging.getLogger(__name__)
 
-# We expect the MongoDB container to use the default ports
-MONGODB_PORT = 27017
-MONGODB_VERSION = "5.0"
-PEER = "database-peers"
 MONGO_USER = "mongodb"
 MONGO_DATA_DIR = "/data/db"
 
@@ -69,6 +66,12 @@ def start_mongod_service():
 
 
 def update_mongod_service(auth: bool, machine_ip: str, replset: str):
+    """Construct the mongod startup commandline args for systemd.
+
+    Note that commandline arguments take priority over any user set config file options. User
+    options will be configured in the config file. MongoDB handles this merge of these two
+    options.
+    """
     mongod_start_args = generate_service_args(auth, machine_ip, replset)
 
     with open("/lib/systemd/system/mongod.service", "r") as mongodb_service_file:

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -49,7 +49,7 @@ def stop_mongod_service():
     try:
         systemd.service_stop("mongod.service")
     except systemd.SystemdError as e:
-        logger.error("failed to stop mongod.service, error:", e)
+        logger.error("failed to stop mongod.service, error: %s", str(e))
         raise
 
 
@@ -61,7 +61,7 @@ def start_mongod_service():
     try:
         systemd.service_start("mongod.service")
     except systemd.SystemdError as e:
-        logger.error("failed to enable mongod.service, error:", e)
+        logger.error("failed to enable mongod.service, error: %s", str(e))
         raise
 
 

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -1,0 +1,128 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+import os
+import logging
+import pwd
+
+
+from charms.operator_libs_linux.v1 import systemd
+from charms.mongodb_libs.v0.helpers import KEY_FILE
+
+# The unique Charmhub library identifier, never change it
+LIBID = "6q947ainc54837t38yhuidshahfgw8f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version.
+LIBPATCH = 0
+
+logger = logging.getLogger(__name__)
+
+# We expect the MongoDB container to use the default ports
+MONGODB_PORT = 27017
+MONGODB_VERSION = "5.0"
+PEER = "database-peers"
+MONGO_USER = "mongodb"
+MONGO_DATA_DIR = "/data/db"
+
+
+def auth_enabled():
+    """Checks if mongod service is running with auth enabled."""
+    if not os.path.exists("/lib/systemd/system/mongod.service"):
+        return False
+
+    with open("/etc/systemd/system/mongod.service", "r") as mongodb_service_file:
+        mongodb_service = mongodb_service_file.readlines()
+
+    for _, line in enumerate(mongodb_service):
+        # ExecStart contains the line with the arguments to start mongod service.
+        if "ExecStart" in line and "--auth" in line:
+            return True
+
+    return False
+
+
+def stop_mongod_service():
+    if not systemd.service_running("mongod.service"):
+        return
+
+    logger.debug("stopping mongod.service")
+    try:
+        systemd.service_stop("mongod.service")
+    except systemd.SystemdError as e:
+        logger.error("failed to stop mongod.service, error:", e)
+        raise
+
+
+def start_mongod_service():
+    if systemd.service_running("mongod.service"):
+        return
+
+    logger.debug("starting mongod.service")
+    try:
+        systemd.service_start("mongod.service")
+    except systemd.SystemdError as e:
+        logger.error("failed to enable mongod.service, error:", e)
+        raise
+
+
+def update_mongod_service(auth: bool, machine_ip: str, replset: str):
+    mongod_start_args = generate_service_args(auth, machine_ip, replset)
+
+    with open("/lib/systemd/system/mongod.service", "r") as mongodb_service_file:
+        mongodb_service = mongodb_service_file.readlines()
+
+    # replace start command with our parameterized one
+    for index, line in enumerate(mongodb_service):
+        if "ExecStart" in line:
+            mongodb_service[index] = mongod_start_args
+
+    # systemd gives files in /etc/systemd/system/ precedence over those in /lib/systemd/system/
+    # hence our changed file in /etc will be read while maintaining the original one in /lib.
+    with open("/etc/systemd/system/mongod.service", "w") as service_file:
+        service_file.writelines(mongodb_service)
+
+    # mongod requires permissions to /data/db
+    mongodb_user = pwd.getpwnam(MONGO_USER)
+    os.chown(MONGO_DATA_DIR, mongodb_user.pw_uid, mongodb_user.pw_gid)
+
+    # changes to service files are only applied after reloading
+    systemd.daemon_reload()
+
+
+# TODO replace calls of this with machine_ip=self._unit_ip(self.charm.unit)
+def generate_service_args(auth: bool, machine_ip: str, replset: str) -> str:
+    # Construct the mongod startup commandline args for systemd, note that commandline
+    # arguments take priority over any user set config file options. User options will be
+    # configured in the config file. MongoDB handles this merge of these two options.
+    mongod_start_args = [
+        "ExecStart=/usr/bin/mongod",
+        # bind to localhost and external interfaces
+        "--bind_ip",
+        f"localhost,{machine_ip}",
+        # part of replicaset
+        "--replSet",
+        f"{replset}",
+    ]
+
+    if auth:
+        mongod_start_args.extend(
+            [
+                "--auth",
+                # keyFile used for authenti cation replica set peers, cluster auth, implies user authentication hence we cannot have cluster authentication without user authentication. see: https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+                # TODO: replace with x509
+                "--clusterAuthMode=keyFile",
+                f"--keyFile={KEY_FILE}",
+            ]
+        )
+
+    mongod_start_args.append("\n")
+    mongod_start_args = " ".join(mongod_start_args)
+
+    return mongod_start_args
+
+
+class ApplicationHostNotFoundError(Exception):
+    """Raised when a queried host is not in the application peers or the current host."""

--- a/lib/charms/mongodb_libs/v0/mongodb_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_provider.py
@@ -371,13 +371,3 @@ class MongoDBProvider(Object):
         if roles is not None:
             return set(roles.split(","))
         return {"default"}
-
-
-# TODO move this somewhere appropriate
-
-# # TODO replace functions to not start with "_"
-
-auth_enabled,
-stop_mongod_service,
-start_mongod_service,
-update_mongod_service,

--- a/lib/charms/mongodb_libs/v0/mongodb_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_provider.py
@@ -15,8 +15,13 @@ import re
 from collections import namedtuple
 from typing import Optional, Set
 
-import ops.model
-from charms.mongodb_libs.v0.helpers import KEY_FILE, generate_password
+from charms.mongodb_libs.v0.machine_helpers import (
+    auth_enabled,
+    stop_mongod_service,
+    start_mongod_service,
+    update_mongod_service,
+)
+from charms.mongodb_libs.v0.helpers import generate_password
 from charms.mongodb_libs.v0.mongodb import MongoDBConfiguration, MongoDBConnection
 from charms.operator_libs_linux.v1 import systemd
 from ops.charm import RelationBrokenEvent, RelationChangedEvent
@@ -25,7 +30,6 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation
 from pymongo.errors import PyMongoError
 
 from charms.operator_libs_linux.v1 import systemd
-from charms.mongodb_libs.v0.helpers import KEY_FILE
 
 
 # The unique Charmhub library identifier, never change it
@@ -47,8 +51,6 @@ LEGACY_REL_NAME = "obsolete"
 MONGODB_PORT = 27017
 MONGODB_VERSION = "5.0"
 PEER = "database-peers"
-MONGO_USER = "mongodb"
-MONGO_DATA_DIR = "/data/db"
 
 Diff = namedtuple("Diff", "added changed deleted")
 Diff.__doc__ = """
@@ -247,106 +249,6 @@ class MongoDBProvider(Object):
         relations = self.model.relations[LEGACY_REL_NAME]
         return {self._get_username_from_relation_id(relation.id) for relation in relations}
 
-    # # TODO move to machine charm helpers
-    # def auth_enabled(self):
-    #     """Checks if mongod service is running with auth enabled."""
-    #     if not os.path.exists("/lib/systemd/system/mongod.service"):
-    #         return False
-
-    #     with open("/lib/systemd/system/mongod.service", "r") as mongodb_service_file:
-    #         mongodb_service = mongodb_service_file.readlines()
-
-    #     for _, line in enumerate(mongodb_service):
-    #         # ExecStart contains the line with the arguments to start mongod service.
-    #         if "ExecStart" in line and "--auth" in line:
-    #             return True
-
-    #     return False
-
-    # # TODO move to machine charm helpers
-    # def stop_mongod_service(self):
-    #     if not systemd.service_running("mongod.service"):
-    #         return
-
-    #     self.charm.unit.status = MaintenanceStatus("stopping MongoDB")
-    #     logger.debug("stopping mongod.service")
-    #     try:
-    #         systemd.service_stop("mongod.service")
-    #     except systemd.SystemdError as e:
-    #         logger.error("failed to stop mongod.service, error:", e)
-    #         raise
-
-    # # TODO move to machine charm helpers
-    # def update_mongod_service(self, auth: bool):
-    #     mongod_start_args = generate_service_args(auth)
-
-    #     with open("/lib/systemd/system/mongod.service", "r") as mongodb_service_file:
-    #         mongodb_service = mongodb_service_file.readlines()
-
-    #     # replace start command with our parameterized one
-    #     for index, line in enumerate(mongodb_service):
-    #         if "ExecStart" in line:
-    #             mongodb_service[index] = mongod_start_args
-
-    #     # systemd gives files in /etc/systemd/system/ precedence over those in /lib/systemd/system/
-    #     # hence our changed file in /etc will be read while maintaining the original one in /lib.
-    #     with open("/etc/systemd/system/mongod.service", "w") as service_file:
-    #         service_file.writelines(mongodb_service)
-
-    #     # mongod requires permissions to /data/db
-    #     mongodb_user = pwd.getpwnam(MONGO_USER)
-    #     os.chown(MONGO_DATA_DIR, mongodb_user.pw_uid, mongodb_user.pw_gid)
-
-    #     # changes to service files are only applied after reloading
-    #     systemd.daemon_reload()
-
-    # # TODO move to machine charm helpers
-    # def generate_service_args(self, auth: bool) -> str:
-    #     # Construct the mongod startup commandline args for systemd, note that commandline
-    #     # arguments take priority over any user set config file options. User options will be
-    #     # configured in the config file. MongoDB handles this merge of these two options.
-    #     machine_ip = self.charm._unit_ip(self.charm.unit)
-    #     mongod_start_args = [
-    #         "ExecStart=/usr/bin/mongod",
-    #         # bind to localhost and external interfaces
-    #         "--bind_ip",
-    #         f"localhost,{machine_ip}",
-    #         # part of replicaset
-    #         "--replSet",
-    #         f"{self.charm.app.name}",
-    #     ]
-
-    #     if auth:
-    #         mongod_start_args.extend(
-    #             [
-    #                 "--auth",
-    #                 # keyFile used for authenti cation replica set peers, cluster auth, implies user authentication hence we cannot have cluster authentication without user authentication. see: https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-security.keyFile
-    #                 # TODO: replace with x509
-    #                 "--clusterAuthMode=keyFile",
-    #                 f"--keyFile={KEY_FILE}",
-    #             ]
-    #         )
-
-    #     mongod_start_args.append("\n")
-    #     mongod_start_args = " ".join(mongod_start_args)
-
-    #     return mongod_start_args
-
-    # # TODO move to machine charm helpers
-    # def start_mongod_service(self):
-    #     if systemd.service_running("mongod.service"):
-    #         return
-
-    #     self.charm.unit.status = MaintenanceStatus("starting MongoDB")
-    #     logger.debug("starting mongod.service")
-    #     try:
-    #         systemd.service_start("mongod.service")
-    #     except systemd.SystemdError as e:
-    #         logger.error("failed to enable mongod.service, error:", e)
-    #         raise
-
-    #     self.charm.unit.status = ActiveStatus()
-
     ################################################################################
     # HELPERS
     ################################################################################
@@ -474,106 +376,8 @@ class MongoDBProvider(Object):
 # TODO move this somewhere appropriate
 
 # # TODO replace functions to not start with "_"
-# update uses of self.charm
-def auth_enabled():
-    """Checks if mongod service is running with auth enabled."""
-    if not os.path.exists("/lib/systemd/system/mongod.service"):
-        return False
 
-    with open("/etc/systemd/system/mongod.service", "r") as mongodb_service_file:
-        mongodb_service = mongodb_service_file.readlines()
-
-    for _, line in enumerate(mongodb_service):
-        # ExecStart contains the line with the arguments to start mongod service.
-        if "ExecStart" in line and "--auth" in line:
-            return True
-
-    return False
-
-
-def stop_mongod_service():
-    if not systemd.service_running("mongod.service"):
-        return
-
-    logger.debug("stopping mongod.service")
-    try:
-        systemd.service_stop("mongod.service")
-    except systemd.SystemdError as e:
-        logger.error("failed to stop mongod.service, error:", e)
-        raise
-
-
-def start_mongod_service():
-    if systemd.service_running("mongod.service"):
-        return
-
-    logger.debug("starting mongod.service")
-    try:
-        systemd.service_start("mongod.service")
-    except systemd.SystemdError as e:
-        logger.error("failed to enable mongod.service, error:", e)
-        raise
-
-
-def update_mongod_service(auth: bool, machine_ip: str, replset: str):
-    mongod_start_args = generate_service_args(auth, machine_ip, replset)
-
-    with open("/lib/systemd/system/mongod.service", "r") as mongodb_service_file:
-        mongodb_service = mongodb_service_file.readlines()
-
-    # replace start command with our parameterized one
-    for index, line in enumerate(mongodb_service):
-        if "ExecStart" in line:
-            mongodb_service[index] = mongod_start_args
-
-    # systemd gives files in /etc/systemd/system/ precedence over those in /lib/systemd/system/
-    # hence our changed file in /etc will be read while maintaining the original one in /lib.
-    with open("/etc/systemd/system/mongod.service", "w") as service_file:
-        service_file.writelines(mongodb_service)
-
-    # mongod requires permissions to /data/db
-    mongodb_user = pwd.getpwnam(MONGO_USER)
-    os.chown(MONGO_DATA_DIR, mongodb_user.pw_uid, mongodb_user.pw_gid)
-
-    # changes to service files are only applied after reloading
-    systemd.daemon_reload()
-
-
-# TODO replace calls of this with machine_ip=self._unit_ip(self.charm.unit)
-def generate_service_args(auth: bool, machine_ip: str, replset: str) -> str:
-    # Construct the mongod startup commandline args for systemd, note that commandline
-    # arguments take priority over any user set config file options. User options will be
-    # configured in the config file. MongoDB handles this merge of these two options.
-    mongod_start_args = [
-        "ExecStart=/usr/bin/mongod",
-        # bind to localhost and external interfaces
-        "--bind_ip",
-        f"localhost,{machine_ip}",
-        # part of replicaset
-        "--replSet",
-        f"{replset}",
-    ]
-
-    if auth:
-        mongod_start_args.extend(
-            [
-                "--auth",
-                # keyFile used for authenti cation replica set peers, cluster auth, implies user authentication hence we cannot have cluster authentication without user authentication. see: https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-security.keyFile
-                # TODO: replace with x509
-                "--clusterAuthMode=keyFile",
-                f"--keyFile={KEY_FILE}",
-            ]
-        )
-
-    mongod_start_args.append("\n")
-    mongod_start_args = " ".join(mongod_start_args)
-
-    return mongod_start_args
-
-
-class ApplicationHostNotFoundError(Exception):
-    """Raised when a queried host is not in the application peers or the current host."""
-
-
-class ApplicationHostNotFoundError(Exception):
-    """Raised when a queried host is not in the application peers or the current host."""
+auth_enabled,
+stop_mongod_service,
+start_mongod_service,
+update_mongod_service,

--- a/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
@@ -30,7 +30,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version.
-LIBPATCH = 0
+LIBPATCH = 1
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"

--- a/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
@@ -130,3 +130,8 @@ class MongoDBLegacyProvider(Object):
                 if relation.id != departed_relation_id
             ]
         )
+
+    @staticmethod
+    def _get_username_from_relation_id(relation_id: str) -> str:
+        """Construct username."""
+        return f"relation-{relation_id}"

--- a/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
@@ -1,0 +1,132 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In this class we manage legacy client database relations.
+
+This class is modeled after the legacy machine charm relations, hence it disables auth and exposes
+the expected relation data for legacy relations.
+"""
+import logging
+from typing import Optional
+
+from charms.mongodb_libs.v0.machine_helpers import (
+    auth_enabled,
+    stop_mongod_service,
+    start_mongod_service,
+    update_mongod_service,
+)
+from charms.operator_libs_linux.v1 import systemd
+from ops.framework import Object
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
+
+from charms.operator_libs_linux.v1 import systemd
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "9t384yt02t8fj9iecin83r20359ruij"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version.
+LIBPATCH = 0
+
+logger = logging.getLogger(__name__)
+REL_NAME = "database"
+
+REL_NAME = "database"
+LEGACY_REL_NAME = "obsolete"
+
+# We expect the MongoDB container to use the default ports
+MONGODB_PORT = 27017
+MONGODB_VERSION = "5.0"
+PEER = "database-peers"
+
+
+class MongoDBLegacyProvider(Object):
+    """In this class we manage legacy client database relations."""
+
+    def __init__(self, charm):
+        """Manager of MongoDB client relations."""
+        super().__init__(charm, "client-relations")
+        self.charm = charm
+        self.framework.observe(
+            self.charm.on[LEGACY_REL_NAME].relation_created, self._on_legacy_relation_created
+        )
+        self.framework.observe(
+            self.charm.on[LEGACY_REL_NAME].relation_joined, self._on_legacy_relation_joined
+        )
+
+    ################################################################################
+    # LEGACY RELATIONS VM
+    ################################################################################
+    def _on_legacy_relation_created(self, event):
+        """Legacy relations for MongoDB operate without a password and so we update the server accordingly and
+        set a flag.
+        """
+        logger.warning("DEPRECATION WARNING - `mongodb` interface is a legacy interface.")
+
+        # legacy relations turn off authentication, therefore disabling authentication for current
+        # users (which connect over the new relation interface). If current users exist that use
+        # auth it is necessary to not proceed and go into blocked state.
+        relation_users = self._get_users_from_relations(departed_relation_id=None)
+        if len(relation_users) > 0:
+            self.charm.unit.status = BlockedStatus("cannot have both legacy and new relations")
+            logger.error(
+                "Creating legacy relation would turn off auth effecting the new relations: %s",
+                relation_users,
+            )
+            return
+
+        # If auth is already disabled its likely it has a connection with another legacy relation
+        # user. Shutting down and restarting mongod would lead to downtime for the other legacy
+        # relation user and hence shouldn't be done. Not to mention there is no need to disable
+        # auth if it is already disabled.
+        if auth_enabled():
+            try:
+                logger.debug("Disabling authentication.")
+                self.charm.unit.status = MaintenanceStatus("disabling authentication")
+                stop_mongod_service()
+                update_mongod_service(
+                    auth=False,
+                    machine_ip=self.charm._unit_ip(self.charm.unit),
+                    replset=self.charm.app.name,
+                )
+                start_mongod_service()
+                self.charm.unit.status = ActiveStatus()
+            except systemd.SystemdError:
+                self.charm.unit.status = BlockedStatus("couldn't restart MongoDB")
+                return
+
+    def _on_legacy_relation_joined(self, event):
+        """
+        NOTE: this is retro-fitted from the legacy mongodb charm:
+        https://git.launchpad.net/charm-mongodb/tree/hooks/hooks.py#n1423
+        """
+        logger.warning("DEPRECATION WARNING - `mongodb` interface is a legacy interface.")
+
+        updates = {
+            "hostname": str(self.model.get_binding(PEER).network.bind_address),
+            "port": str(MONGODB_PORT),
+            "type": "database",
+            "version": MONGODB_VERSION,
+            "replset": self.charm.app.name,
+        }
+
+        # reactive charms set relation data on "the current unit" the reactive mongodb charm sets
+        # the relation data for all units, hence all units setting the relation data and not just
+        # the leader
+        relation = self.model.get_relation(REL_NAME, event.relation.id)
+        relation.data[self.charm.unit].update(updates)
+
+    def _get_users_from_relations(self, departed_relation_id: Optional[int], rel=REL_NAME):
+        """Return usernames for all relations except departed relation."""
+        relations = self.model.relations[rel]
+        return set(
+            [
+                self._get_username_from_relation_id(relation.id)
+                for relation in relations
+                if relation.id != departed_relation_id
+            ]
+        )

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,6 +19,10 @@ from charms.mongodb_libs.v0.helpers import (
     generate_password,
     get_create_user_cmd,
 )
+from charms.mongodb_libs.v0.machine_helpers import (
+    start_mongod_service,
+    update_mongod_service,
+)
 from charms.mongodb_libs.v0.mongodb import (
     MongoDBConfiguration,
     MongoDBConnection,
@@ -204,61 +208,13 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         except (apt.InvalidSourceError, ValueError, apt.GPGKeyError, URLError):
             self.unit.status = BlockedStatus("couldn't install MongoDB")
 
-        # TODO future PR, this mongod start args is duplicated code and should be put somewhere
-        # else
-
-        # Construct the mongod startup commandline args for systemd, note that commandline
-        # arguments take priority over any user set config file options. User options will be
-        # configured in the config file. MongoDB handles this merge of these two options.
-        machine_ip = self._unit_ip(self.unit)
-        mongod_start_args = [
-            "ExecStart=/usr/bin/mongod",
-            # bind to localhost and external interfaces
-            "--bind_ip",
-            f"localhost,{machine_ip}",
-            # part of replicaset
-            "--replSet",
-            f"{self.app.name}",
-        ]
-
         # if a new unit is joining a cluster with a legacy relation it should start without auth
-        if not self.client_relations.get_users_from_legacy_relations():
-            # keyFile used for authentication replica set peers, cluster auth, implies user
-            # authentication hence we cannot have cluster authentication without user
-            # authentication. see:
-            # https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-security.keyFile
+        auth = not self.client_relations.get_users_from_legacy_relations()
 
-            mongod_start_args.extend(
-                [
-                    "--auth",
-                    # TODO: replace with x509
-                    "--clusterAuthMode=keyFile",
-                    f"--keyFile={KEY_FILE}",
-                ]
-            )
-
-        mongod_start_args.append("\n")
-        mongod_start_args = " ".join(mongod_start_args)
-
-        with open("/lib/systemd/system/mongod.service", "r") as mongodb_service_file:
-            mongodb_service = mongodb_service_file.readlines()
-
-        # replace start command with our parameterized one
-        for index, line in enumerate(mongodb_service):
-            if "ExecStart" in line:
-                mongodb_service[index] = mongod_start_args
-
-        # systemd gives files in /etc/systemd/system/ precedence over those in /lib/systemd/system/
-        # hence our changed file in /etc will be read while maintaining the original one in /lib.
-        with open("/etc/systemd/system/mongod.service", "w") as service_file:
-            service_file.writelines(mongodb_service)
-
-        # mongod requires permissions to /data/db
-        mongodb_user = pwd.getpwnam(MONGO_USER)
-        os.chown(MONGO_DATA_DIR, mongodb_user.pw_uid, mongodb_user.pw_gid)
-
-        # changes to service files are only applied after reloading
-        systemd.daemon_reload()
+        # Construct the mongod startup commandline args for systemd and reload the daemon.
+        update_mongod_service(
+            auth=auth, machine_ip=self._unit_ip(self.unit), replset=self.app.name
+        )
 
     def _on_config_changed(self, _) -> None:
         """Event handler for configuration changed events."""
@@ -276,16 +232,14 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         # MongoDB with authentication requires a keyfile
         self._instatiate_keyfile(event)
 
-        # start mongo service
-        self.unit.status = MaintenanceStatus("starting MongoDB")
-        if not systemd.service_running("mongod.service"):
-            logger.debug("starting mongod.service")
-            try:
-                systemd.service_start("mongod.service")
-            except systemd.SystemdError:
-                logger.error("failed to enable mongod.service")
-                self.unit.status = BlockedStatus("couldn't start MongoDB")
-                return
+        try:
+            logger.debug("starting MongoDB.")
+            self.unit.status = MaintenanceStatus("starting MongoDB")
+            start_mongod_service()
+            self.unit.status = ActiveStatus()
+        except systemd.SystemdError:
+            self.unit.status = BlockedStatus("couldn't start MongoDB")
+            return
 
         try:
             self._open_port_tcp(self._port)

--- a/src/charm.py
+++ b/src/charm.py
@@ -83,7 +83,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.get_admin_password_action, self._on_get_admin_password)
 
         # handle provider side of relations
-        self.client_relations = MongoDBProvider(self)
+        self.client_relations = MongoDBProvider(self, substrate="vm")
         self.legacy_client_relations = MongoDBLegacyProvider(self)
 
     def _generate_passwords(self) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -96,6 +96,7 @@ class TestCharm(unittest.TestCase):
         init_admin.assert_not_called()
 
     @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.systemd._systemctl", side_effect=systemd.SystemdError)
     @patch("charm.systemd.service_start")
     @patch("charm.systemd.service_running", return_value=True)
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
@@ -116,6 +117,7 @@ class TestCharm(unittest.TestCase):
         _open_port_tcp,
         service_running,
         service_start,
+        _systemctl,
     ):
         """Test verifies that is MongoDB service is available that we don't re-enable it."""
         self.harness.set_leader(True)


### PR DESCRIPTION
Not the typical full description since this is a re-organising PR.

What got re-organised:
1. created a VM code file in the libs called `machine_helpers.py` - this file contains the VM specific code that was in `mongodb_provider.py` 
- it is in the `libs` directory since it is used by both other libs and the charm code
- functions here got modified to be more general
2. created a new lib file called `mongodb_vm_legacy_provider.py`
- it is separate from `mongodb_provider.py` since it is `legacy` code, separating it will make removal of legacy code in the future much easier.
- it is labled as `vm` since it could be the case that the `k8s` charm handles legacy relations differently
3. `src/charm.py` is updated to use functions from  `lib/charms/mongodb_libs/v0/machine_helpers.py`
4. `mongodb_provider.py` is updated to:
- remove functions that were placed in  `machine_helpers.py` &  `mongodb_vm_legacy_provider.py`
- take in an argument for the substrate it is running on
