### PR TITLE
Changing charmhub channel to to dpe/edge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,4 +76,4 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "5.0/edge"
+          channel: "dpe/edge"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,4 +76,4 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: "${{ steps.channel.outputs.name }}"
+          channel: "5.0/edge"


### PR DESCRIPTION
As per the conversation with bootstack, the channel for the new mongodb charm should be `5.0/latest`.

UPDATE: DPE team wants `dpe/edge` so updated accordingly


The channel is updated accordingly in the release workflow

