### PR TITLE
Functional testing of replication pt.1

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -33,29 +33,31 @@ async def run_command_on_unit(unit, command: str) -> Optional[str]:
     return action.results.get("Stdout", None)
 
 
-def replica_set_client(replica_ips: List[str], password: str) -> MongoClient:
+def replica_set_client(replica_ips: List[str], password: str, app=APP_NAME) -> MongoClient:
     """Generates the replica set URI for multiple IP addresses.
 
     Args:
         replica_ips: list of ips hosting the replica set.
         password: password of database.
+        app: name of application which has the cluster.
     """
     hosts = ["{}:{}".format(replica_ip, PORT) for replica_ip in replica_ips]
     hosts = ",".join(hosts)
 
-    replica_set_uri = f"mongodb://operator:" f"{password}@" f"{hosts}/admin?replicaSet=mongodb"
+    replica_set_uri = f"mongodb://operator:" f"{password}@" f"{hosts}/admin?replicaSet={app}"
     return MongoClient(replica_set_uri)
 
 
-async def fetch_replica_set_members(replica_ips: List[str], ops_test: OpsTest):
+async def fetch_replica_set_members(replica_ips: List[str], ops_test: OpsTest, app=APP_NAME):
     """Fetches the IPs listed as replica set members in the MongoDB replica set configuration.
 
     Args:
         replica_ips: list of ips hosting the replica set.
         ops_test: reference to deployment.
+        app: name of application which has the cluster.
     """
     # connect to replica set uri
-    password = await get_password(ops_test)
+    password = await get_password(ops_test, app)
     client = replica_set_client(replica_ips, password)
 
     # get ips from MongoDB replica set configuration
@@ -70,37 +72,36 @@ async def fetch_replica_set_members(replica_ips: List[str], ops_test: OpsTest):
     return member_ips
 
 
-def unit_uri(ip_address: str, password) -> str:
+def unit_uri(ip_address: str, password, app=APP_NAME) -> str:
     """Generates URI that is used by MongoDB to connect to a single replica.
 
     Args:
         ip_address: ip address of replica/unit
         password: password of database.
+        app: name of application which has the cluster.
     """
-    return f"mongodb://operator:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet=mongodb"
+    return f"mongodb://operator:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet={app}"
 
 
-async def get_password(ops_test: OpsTest) -> str:
+async def get_password(ops_test: OpsTest, app=APP_NAME) -> str:
     """Use the charm action to retrieve the password from provided unit.
 
     Returns:
         String with the password stored on the peer relation databag.
     """
     # can retrieve from any unit running unit so we pick the first
-    unit_name = ops_test.model.applications[APP_NAME].units[0].name
+    unit_name = ops_test.model.applications[app].units[0].name
     unit_id = unit_name.split("/")[1]
 
-    action = await ops_test.model.units.get(f"{APP_NAME}/{unit_id}").run_action(
-        "get-admin-password"
-    )
+    action = await ops_test.model.units.get(f"{app}/{unit_id}").run_action("get-admin-password")
     action = await action.wait()
     return action.results["admin-password"]
 
 
-async def fetch_primary(replica_set_hosts: List[str], ops_test: OpsTest) -> str:
+async def fetch_primary(replica_set_hosts: List[str], ops_test: OpsTest, app=APP_NAME) -> str:
     """Returns IP address of current replica set primary."""
     # connect to MongoDB client
-    password = await get_password(ops_test)
+    password = await get_password(ops_test, app)
     client = replica_set_client(replica_set_hosts, password)
 
     # grab the replica set status
@@ -127,7 +128,9 @@ async def fetch_primary(replica_set_hosts: List[str], ops_test: OpsTest) -> str:
     stop=stop_after_attempt(5),
     wait=wait_exponential(multiplier=1, min=2, max=30),
 )
-async def replica_set_primary(replica_set_hosts: List[str], ops_test: OpsTest) -> str:
+async def replica_set_primary(
+    replica_set_hosts: List[str], ops_test: OpsTest, app=APP_NAME
+) -> str:
     """Returns the primary of the replica set.
 
     Retrying 5 times to give the replica set time to elect a new primary, also checks against the
@@ -138,7 +141,7 @@ async def replica_set_primary(replica_set_hosts: List[str], ops_test: OpsTest) -
     valid_ips:
         list of ips that are currently in the replica set.
     """
-    primary = await fetch_primary(replica_set_hosts, ops_test)
+    primary = await fetch_primary(replica_set_hosts, ops_test, app)
     # return None if primary is no longer in the replica set
     if primary is not None and primary not in replica_set_hosts:
         return None
@@ -171,10 +174,10 @@ def count_primaries(ops_test: OpsTest, password: str) -> int:
     return number_of_primaries
 
 
-async def find_unit(ops_test: OpsTest, leader: bool) -> ops.model.Unit:
+async def find_unit(ops_test: OpsTest, leader: bool, app=APP_NAME) -> ops.model.Unit:
     """Helper function identifies the a unit, based on need for leader or non-leader."""
     ret_unit = None
-    for unit in ops_test.model.applications[APP_NAME].units:
+    for unit in ops_test.model.applications[app].units:
         if await unit.is_leader_from_status() == leader:
             ret_unit = unit
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,15 +14,18 @@ from helpers import (
     fetch_replica_set_members,
     find_unit,
     get_password,
+    replica_set_client,
     replica_set_primary,
     unit_uri,
 )
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
+
+ANOTHER_DATABASE_APP_NAME = "another-database-a"
 
 
 @pytest.mark.skipif(
@@ -198,3 +201,123 @@ async def test_scale_down_capablities(ops_test: OpsTest) -> None:
     member_ips = await fetch_replica_set_members(ip_addresses, ops_test)
 
     assert set(member_ips) == set(ip_addresses), "mongod config contains deleted units"
+
+
+async def test_replication_across_members(ops_test: OpsTest) -> None:
+    """Check consistency, ie write to primary, read data from secondaries."""
+    # first find primary, write to primary, then read from each unit
+    ip_addresses = [unit.public_address for unit in ops_test.model.applications[APP_NAME].units]
+    primary = await replica_set_primary(ip_addresses, ops_test)
+    password = await get_password(ops_test)
+    client = MongoClient(unit_uri(primary, password), directConnection=True)
+
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    ubuntu = {"release_name": "Focal Fossa", "version": 20.04, "LTS": True}
+    test_collection.insert(ubuntu)
+
+    client.close()
+
+    secondaries = set(ip_addresses) - set([primary])
+    logger.error(secondaries)
+    for secondary in secondaries:
+        client = MongoClient(unit_uri(secondary, password), directConnection=True)
+
+        db = client["new-db"]
+        test_collection = db["test_collection"]
+        query = test_collection.find({}, {"release_name": 1})
+        logger.error(query[0]["release_name"])
+        assert query[0]["release_name"] == "Focal Fossa"
+
+        client.close()
+
+
+async def test_unique_cluster_dbs(ops_test: OpsTest) -> None:
+    """Verify unique clusters do not share DBs."""
+    # deploy new cluster
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(my_charm, num_units=1, application_name=ANOTHER_DATABASE_APP_NAME)
+    await ops_test.model.wait_for_idle()
+
+    # write data to new cluster
+    ip_addresses = [
+        unit.public_address
+        for unit in ops_test.model.applications[ANOTHER_DATABASE_APP_NAME].units
+    ]
+    password = await get_password(ops_test, app=ANOTHER_DATABASE_APP_NAME)
+    client = replica_set_client(ip_addresses, password, app=ANOTHER_DATABASE_APP_NAME)
+
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    ubuntu = {"release_name": "Jammy Jelly", "version": 22.04, "LTS": False}
+    test_collection.insert(ubuntu)
+
+    # read all entries from new cluster
+    cursor = test_collection.find({})
+    cluster_1_entries = set()
+    for document in cursor:
+        logger.error(document)
+        cluster_1_entries.add(document["release_name"])
+
+    client.close()
+
+    # read all entries from other cluster
+    ip_addresses = [unit.public_address for unit in ops_test.model.applications[APP_NAME].units]
+    password = await get_password(ops_test)
+    client = replica_set_client(ip_addresses, password)
+
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+
+    # read all entries from original cluster
+    cursor = test_collection.find({})
+    cluster_2_entries = set()
+    for document in cursor:
+        cluster_2_entries.add(document["release_name"])
+
+    client.close()
+
+    common_entries = cluster_2_entries.intersection(cluster_1_entries)
+    logger.error(cluster_1_entries)
+    logger.error(cluster_2_entries)
+    assert len(common_entries) == 0, "Writes from one cluster are replicated to another cluster."
+
+
+async def test_replication_member_scaling(ops_test: OpsTest) -> None:
+    """Verify newly added and newly removed members properly replica data.
+
+    Verify newly members have replicated data and newly removed members are gone without data.
+    """
+    original_ip_addresses = [
+        unit.public_address for unit in ops_test.model.applications[APP_NAME].units
+    ]
+    await ops_test.model.applications[APP_NAME].add_unit(count=1)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+    assert len(ops_test.model.applications[APP_NAME].units) == 4
+
+    new_ip_addresses = [
+        unit.public_address for unit in ops_test.model.applications[APP_NAME].units
+    ]
+    new_member_ip = list(set(new_ip_addresses) - set(original_ip_addresses))[0]
+    password = await get_password(ops_test)
+    client = MongoClient(unit_uri(new_member_ip, password), directConnection=True)
+
+    # check for replicated data while retrying to give time for replica to copy over data.
+    try:
+        for attempt in Retrying(stop=stop_after_delay(2 * 60), wait=wait_fixed(3)):
+            with attempt:
+                db = client["new-db"]
+                test_collection = db["test_collection"]
+                query = test_collection.find({}, {"release_name": 1})
+                logger.error(query[0]["release_name"])
+                assert query[0]["release_name"] == "Focal Fossa"
+
+    except RetryError:
+        assert False, "Newly added unit doesn't replicate data."
+
+    client.close()
+
+    # TODO in a future PR implement: newly removed members are gone without data.
+    # TODO in a future PR implement: a test that option "preserves data on delete" works
+    # Note for above tests it will be necessary to test on a different substrate (ie AWS) see:
+    # https://chat.canonical.com/canonical/pl/eirmfogfx3rmufmom9thjx6pwr

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,8 +14,10 @@ from helpers import (
     fetch_replica_set_members,
     find_unit,
     get_password,
+    insert_entry,
     replica_set_client,
     replica_set_primary,
+    retrieve_entries,
     unit_uri,
 )
 from pymongo import MongoClient
@@ -210,23 +212,17 @@ async def test_replication_across_members(ops_test: OpsTest) -> None:
     primary = await replica_set_primary(ip_addresses, ops_test)
     password = await get_password(ops_test)
     client = MongoClient(unit_uri(primary, password), directConnection=True)
-
-    db = client["new-db"]
-    test_collection = db["test_collection"]
-    ubuntu = {"release_name": "Focal Fossa", "version": 20.04, "LTS": True}
-    test_collection.insert(ubuntu)
-
+    entry = {"release_name": "Focal Fossa", "version": 20.04, "LTS": True}
+    insert_entry(client, db_name="new-db", collection_name="test_collection", entry=entry)
     client.close()
 
     secondaries = set(ip_addresses) - set([primary])
-    logger.error(secondaries)
     for secondary in secondaries:
         client = MongoClient(unit_uri(secondary, password), directConnection=True)
 
         db = client["new-db"]
         test_collection = db["test_collection"]
         query = test_collection.find({}, {"release_name": 1})
-        logger.error(query[0]["release_name"])
         assert query[0]["release_name"] == "Focal Fossa"
 
         client.close()
@@ -246,47 +242,33 @@ async def test_unique_cluster_dbs(ops_test: OpsTest) -> None:
     ]
     password = await get_password(ops_test, app=ANOTHER_DATABASE_APP_NAME)
     client = replica_set_client(ip_addresses, password, app=ANOTHER_DATABASE_APP_NAME)
+    entry = {"release_name": "Jammy Jelly", "version": 22.04, "LTS": False}
+    insert_entry(client, db_name="new-db", collection_name="test_collection", entry=entry)
 
-    db = client["new-db"]
-    test_collection = db["test_collection"]
-    ubuntu = {"release_name": "Jammy Jelly", "version": 22.04, "LTS": False}
-    test_collection.insert(ubuntu)
+    cluster_1_entries = await retrieve_entries(
+        ops_test,
+        app=ANOTHER_DATABASE_APP_NAME,
+        db_name="new-db",
+        collection_name="test_collection",
+        query_field="release_name",
+    )
 
-    # read all entries from new cluster
-    cursor = test_collection.find({})
-    cluster_1_entries = set()
-    for document in cursor:
-        logger.error(document)
-        cluster_1_entries.add(document["release_name"])
-
-    client.close()
-
-    # read all entries from other cluster
-    ip_addresses = [unit.public_address for unit in ops_test.model.applications[APP_NAME].units]
-    password = await get_password(ops_test)
-    client = replica_set_client(ip_addresses, password)
-
-    db = client["new-db"]
-    test_collection = db["test_collection"]
-
-    # read all entries from original cluster
-    cursor = test_collection.find({})
-    cluster_2_entries = set()
-    for document in cursor:
-        cluster_2_entries.add(document["release_name"])
-
-    client.close()
+    cluster_2_entries = await retrieve_entries(
+        ops_test,
+        app=APP_NAME,
+        db_name="new-db",
+        collection_name="test_collection",
+        query_field="release_name",
+    )
 
     common_entries = cluster_2_entries.intersection(cluster_1_entries)
-    logger.error(cluster_1_entries)
-    logger.error(cluster_2_entries)
     assert len(common_entries) == 0, "Writes from one cluster are replicated to another cluster."
 
 
 async def test_replication_member_scaling(ops_test: OpsTest) -> None:
     """Verify newly added and newly removed members properly replica data.
 
-    Verify newly members have replicated data and newly removed members are gone without data.
+    Verify newly add members have replicated data and newly removed members are gone without data.
     """
     original_ip_addresses = [
         unit.public_address for unit in ops_test.model.applications[APP_NAME].units
@@ -304,12 +286,11 @@ async def test_replication_member_scaling(ops_test: OpsTest) -> None:
 
     # check for replicated data while retrying to give time for replica to copy over data.
     try:
-        for attempt in Retrying(stop=stop_after_delay(2 * 60), wait=wait_fixed(3)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
             with attempt:
                 db = client["new-db"]
                 test_collection = db["test_collection"]
                 query = test_collection.find({}, {"release_name": 1})
-                logger.error(query[0]["release_name"])
                 assert query[0]["release_name"] == "Focal Fossa"
 
     except RetryError:


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
Need HA tests for Replication

### Solution
<!-- A summary of the solution addressing the above problem -->
Add missing HA tests for Replication

### Release Notes
<!-- A digestable summary of the change in this PR -->
`tests/integration/helpers.py` - updated to be more generalised to add multi-cluster testing
`tests/integration/test_charm.py` - updated to have tests for:
        - write to primary, read data from secondaries (check consistency)
        - create two clusters, check that writes in one cluster NOT replicated to another cluster
        - scale-up, read data from new member, 
        - kill primary, check reelection was already tested [here](https://github.com/canonical/mongodb-operator/blob/ba829d188d9590eb60e0e213964f77d35db61fd6/tests/integration/test_charm.py#L152) via `juju remove-unit`
        
### Future PRs
- test scale down, check that member gone without data  
- test that option "preserves data on delete" works
- test with continous writes to DB via an application relation 