### PR TITLE
Fixing Charmhub Failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,8 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    # flake8 version 5.0.0 & 5.0.1 has issues with `flake8.options.config`
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/tox.ini
+++ b/tox.ini
@@ -93,3 +93,13 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native {[vars]tst_path}integration/relation_tests --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto
+
+[testenv:integration]
+description = Run all integration tests
+deps =
+    pytest
+    juju
+    pytest-operator
+    -r{toxinidir}/requirements.txt
+commands =
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native  {[vars]tst_path}integration/test_charm.py --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto
+    pytest -v --tb native  {[vars]tst_path}integration/test_charm.py --log-cli-level=INFO -s {posargs} --durations=0
 
 [testenv:ha-integration]
 description = Run high availability integration tests
@@ -82,7 +82,7 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native {[vars]tst_path}integration/ha_tests/test_ha.py --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto
+    pytest -v --tb native {[vars]tst_path}integration/ha_tests/test_ha.py --log-cli-level=INFO -s {posargs} --durations=0
 
 [testenv:relation-integration]
 description = Run relation integration tests
@@ -92,7 +92,7 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native {[vars]tst_path}integration/relation_tests --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto
+    pytest -v --tb native {[vars]tst_path}integration/relation_tests --log-cli-level=INFO -s {posargs} --durations=0
 
 [testenv:integration]
 description = Run all integration tests
@@ -102,4 +102,4 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0 --asyncio-mode=auto
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs} --durations=0


### PR DESCRIPTION
See Issue #65  
Charmhub is failing to publish since tox.ini no longer has the integration workflow, see [here](https://github.com/canonical/mongodb-operator/actions/runs/2759294471)
