### PR TITLE
Bug fix: _init_user crash when called twice

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -483,7 +483,11 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
     @property
     def app_data(self) -> Dict:
         """Peer relation data object."""
-        return self.model.get_relation(PEER).data[self.app]
+        relation = self.model.get_relation(PEER)
+        if relation is None:
+            return {}
+
+        return relation.data[self.app]
 
     @property
     def _peers(self) -> Optional[Relation]:
@@ -511,13 +515,18 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         It is needed to install mongodb-clients inside charm container to make
         this function work correctly.
         """
+        if "user_created" in self.app_data or not self.unit.is_leader():
+            return
+
         out = subprocess.run(
             get_create_user_cmd(self.mongodb_config),
             input=self.mongodb_config.password.encode(),
         )
         if out.returncode == 0:
             raise AdminUserCreationError
+
         logger.debug("User created")
+        self.app_data["user_created"] = "True"
 
 
 class AdminUserCreationError(Exception):

--- a/src/charm.py
+++ b/src/charm.py
@@ -484,7 +484,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
     def app_data(self) -> Dict:
         """Peer relation data object."""
         relation = self.model.get_relation(PEER)
-        if relation is None:
+        if not relation:
             return {}
 
         return relation.data[self.app]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -547,3 +547,20 @@ class TestCharm(unittest.TestCase):
             )
             self.harness.charm.process_unremoved_units(mock.Mock())
             connection.return_value.__enter__.return_value.remove_replset_member.assert_called()
+
+    @patch_network_get(private_address="1.1.1.1")
+    @patch("charm.MongoDBConfiguration")
+    @patch("charm.subprocess.run")
+    def test_start_init_user_after_second_call(self, run, config):
+        """Tests that the creation of the admin user is only performed once.
+
+        Verifies that if the user is already set up, that no attempts to set it up again are
+        made.
+        """
+        self.harness.set_leader(True)
+
+        self.harness.charm._init_admin_user()
+        self.assertEqual("user_created" in self.harness.charm.app_data, True)
+
+        self.harness.charm._init_admin_user()
+        run.assert_called_once()


### PR DESCRIPTION
This PR contains the following:
- Fix handling the case where `_init_user` is called multiple times due to a failure in the `oversee_users` method
- Unit test for said fix