### PR TITLE
HA-Tests are performed under a load

### DIFF
--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This file is meant to run in the background continuously writing entries to MongoDB."""
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+import sys
+
+
+def continous_writes(connection_string: str, starting_number: int):
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    write_value = starting_number
+    while True:
+        try:
+            test_collection.insert_one({"number": write_value})
+            # this insures that no numbers are skipped. This can be moved and analysis can be done
+            # on all failed writes.
+            write_value += 1
+        except PyMongoError:
+            # ignore all errors related to pymongo
+            continue
+
+
+def main():
+    connection_string = sys.argv[1]
+    starting_number = int(sys.argv[2])
+    continous_writes(connection_string, starting_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
@@ -36,7 +36,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins


### PR DESCRIPTION
## Description:
This PR adds functionality for the deployed MongoDB charm to be operated under a load. In this case the load is continuous numerical writes.

When members leave/join the replica set, the continuous writes must be updated with `update_continuous_writes` so that the correct Replica Set URI is used. 

If needed this functionality can be put into a test application charm (in a future PR). If you'd like that just let me know :) 