### PR TITLE
HA-Tests are performed under a load

### DIFF
--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -5,7 +5,7 @@
 import sys
 
 from pymongo import MongoClient
-from pymongo.errors import PyMongoError, AutoReconnect
+from pymongo.errors import AutoReconnect, PyMongoError
 
 
 def continous_writes(connection_string: str, starting_number: int):

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This file is meant to run in the background continuously writing entries to MongoDB."""
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+import sys
+
+
+def continous_writes(connection_string: str, starting_number: int):
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    write_value = starting_number
+    while True:
+        try:
+            test_collection.insert_one({"number": write_value})
+            # this insures that no numbers are skipped. This can be moved and analysis can be done
+            # on all failed writes.
+            write_value += 1
+        except PyMongoError:
+            # ignore all errors related to pymongo
+            continue
+
+
+def main():
+    connection_string = sys.argv[1]
+    starting_number = int(sys.argv[2])
+    continous_writes(connection_string, starting_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -2,9 +2,10 @@
 # See LICENSE file for licensing details.
 
 """This file is meant to run in the background continuously writing entries to MongoDB."""
-from pymongo import MongoClient
-from pymongo.errors import PyMongoError
 import sys
+
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError, AutoReconnect
 
 
 def continous_writes(connection_string: str, starting_number: int):
@@ -15,17 +16,23 @@ def continous_writes(connection_string: str, starting_number: int):
     while True:
         try:
             test_collection.insert_one({"number": write_value})
-            # this insures that no numbers are skipped. This can be moved and analysis can be done
-            # on all failed writes.
-            write_value += 1
-        except PyMongoError:
-            # ignore all errors related to pymongo
+        except AutoReconnect:
+            # this means that the primary was not able to be found. An application should try to
+            # reconnect and re-write the previous value. Hence, we `continue` here, without
+            # incrementing `write_value` as to try to insert this value again.
             continue
+        except PyMongoError:
+            # we should not raise this exception but instead increment the write value and move
+            # on, indicating that there was a failure writing to the database.
+            pass
+
+        write_value += 1
 
 
 def main():
     connection_string = sys.argv[1]
     starting_number = int(sys.argv[2])
+
     continous_writes(connection_string, starting_number)
 
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -5,11 +5,6 @@ import subprocess
 from pathlib import Path
 from typing import List
 
-import logging
-
-logger = logging.getLogger(__name__)
-
-
 import ops
 import yaml
 from pymongo import MongoClient
@@ -246,8 +241,6 @@ async def stop_continous_writes(ops_test: OpsTest) -> int:
     app = await app_name(ops_test)
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]
-    logger.error(ops_test.model.applications[app].units)
-    logger.error(hosts)
     hosts = ",".join(hosts)
     connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app}"
 
@@ -262,7 +255,7 @@ async def stop_continous_writes(ops_test: OpsTest) -> int:
 
 
 async def count_writes(ops_test: OpsTest) -> int:
-    """New versions of pymongo no longer support the count operation, instead find should be used."""
+    """New versions of pymongo no longer support the count operation, instead find is used."""
     app = await app_name(ops_test)
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -2,12 +2,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from itertools import count
-import logging
-from xml.etree.ElementPath import ops
-
-logger = logging.getLogger(__name__)
-
 
 import pytest
 from pymongo import MongoClient
@@ -18,6 +12,7 @@ from tests.integration.ha_tests.helpers import (
     APP_NAME,
     app_name,
     clear_db_writes,
+    count_writes,
     fetch_replica_set_members,
     find_unit,
     get_password,
@@ -25,13 +20,10 @@ from tests.integration.ha_tests.helpers import (
     replica_set_primary,
     retrieve_entries,
     start_continous_writes,
+    stop_continous_writes,
     unit_ids,
     unit_uri,
-    stop_continous_writes,
-    count_writes,
 )
-
-logger = logging.getLogger(__name__)
 
 ANOTHER_DATABASE_APP_NAME = "another-database-a"
 
@@ -83,7 +75,6 @@ async def test_add_units(ops_test: OpsTest, continuous_writes) -> None:
     # verify that the no writes were skipped
     total_expected_writes = await stop_continous_writes(ops_test)
 
-    logger.error(" total expected writes %s", total_expected_writes)
     actual_expected_writes = await count_writes(ops_test)
     assert total_expected_writes["number"] == actual_expected_writes
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
@@ -36,7 +36,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native {[vars]tst_path}integration/ha_tests/test_ha.py --log-cli-level=INFO -s {posargs} --durations=0
+    pytest -vvv --tb native {[vars]tst_path}integration/ha_tests/test_ha.py --log-cli-level=INFO -s {posargs} --durations=0
 
 [testenv:relation-integration]
 description = Run relation integration tests


### PR DESCRIPTION
## Description:
This PR adds functionality for the deployed MongoDB charm to be operated under a load. In this case the load is continuous numerical writes.

At the beginning of **each HA-test** writes to the cluster are started, and at the end those writes are removed, regardless of whether or not the test was successful. This is important since if a production level cluster is provided to the HA-Tests we don't want to keep the writes on that cluster after a successful/unsuccessful test run.

If needed this functionality can be put into a test application charm (in a future PR). If you'd like that just let me know :) 