### PR TITLE
Self healing tests pt1

### DIFF
--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -25,6 +25,12 @@ logger = logging.getLogger(__name__)
 MONGOD_SERVICE_UPSTREAM_PATH = "/lib/systemd/system/mongod.service"
 MONGOD_SERVICE_DEFAULT_PATH = "/etc/systemd/system/mongod.service"
 
+# restart options specify that systemd should attempt to restart the service on failure.
+RESTART_OPTIONS = ["Restart=on-failure\n", "RestartSec=5s\n"]
+# limits ensure that the process will not continously retry to restart if it continously fails to
+# restart.
+RESTARTING_LIMITS = ["StartLimitIntervalSec=500\n", "StartLimitBurst=5\n"]
+
 MONGO_USER = "mongodb"
 MONGO_DATA_DIR = "/data/db"
 
@@ -86,15 +92,17 @@ def start_mongod_service() -> None:
 
 def update_mongod_service(auth: bool, machine_ip: str, replset: str) -> None:
     """Updates the mongod service file with the new options for starting."""
-    mongod_start_args = generate_service_args(auth, machine_ip, replset)
-
     with open(MONGOD_SERVICE_UPSTREAM_PATH, "r") as mongodb_service_file:
         mongodb_service = mongodb_service_file.readlines()
 
     # replace start command with our parameterized one
+    mongod_start_args = generate_service_args(auth, machine_ip, replset)
     for index, line in enumerate(mongodb_service):
         if "ExecStart" in line:
             mongodb_service[index] = mongod_start_args
+
+    # self healing is implemented via systemd
+    add_self_healing(mongodb_service)
 
     # systemd gives files in /etc/systemd/system/ precedence over those in /lib/systemd/system/
     # hence our changed file in /etc will be read while maintaining the original one in /lib.
@@ -107,6 +115,22 @@ def update_mongod_service(auth: bool, machine_ip: str, replset: str) -> None:
 
     # changes to service files are only applied after reloading
     systemd.daemon_reload()
+
+
+def add_self_healing(service_lines):
+    """Updates the service file to auto-restart the DB service on service failure.
+
+    Options for restarting allow for auto-restart on crashed services, i.e. DB killed, DB frozen,
+    DB terminated.
+    """
+    for index, line in enumerate(service_lines):
+        if "[Unit]" in line:
+            service_lines.insert(index + 1, RESTARTING_LIMITS[0])
+            service_lines.insert(index + 1, RESTARTING_LIMITS[1])
+
+        if "[Service]" in line:
+            service_lines.insert(index + 1, RESTART_OPTIONS[0])
+            service_lines.insert(index + 1, RESTART_OPTIONS[1])
 
 
 def generate_service_args(auth: bool, machine_ip: str, replset: str) -> str:

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -26,7 +26,7 @@ MONGOD_SERVICE_UPSTREAM_PATH = "/lib/systemd/system/mongod.service"
 MONGOD_SERVICE_DEFAULT_PATH = "/etc/systemd/system/mongod.service"
 
 # restart options specify that systemd should attempt to restart the service on failure.
-RESTART_OPTIONS = ["Restart=on-failure\n", "RestartSec=5s\n"]
+RESTART_OPTIONS = ["Restart=always\n", "RestartSec=5s\n"]
 # limits ensure that the process will not continously retry to restart if it continously fails to
 # restart.
 RESTARTING_LIMITS = ["StartLimitIntervalSec=500\n", "StartLimitBurst=5\n"]

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -27,7 +27,7 @@ MONGOD_SERVICE_DEFAULT_PATH = "/etc/systemd/system/mongod.service"
 
 # restart options specify that systemd should attempt to restart the service on failure.
 RESTART_OPTIONS = ["Restart=always\n", "RestartSec=5s\n"]
-# limits ensure that the process will not continously retry to restart if it continously fails to
+# limits ensure that the process will not continuously retry to restart if it continuously fails to
 # restart.
 RESTARTING_LIMITS = ["StartLimitIntervalSec=500\n", "StartLimitBurst=5\n"]
 

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -5,7 +5,7 @@
 import sys
 
 from pymongo import MongoClient
-from pymongo.errors import PyMongoError, AutoReconnect
+from pymongo.errors import AutoReconnect, PyMongoError
 
 
 def continous_writes(connection_string: str, starting_number: int):

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -1,0 +1,33 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This file is meant to run in the background continuously writing entries to MongoDB."""
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError
+import sys
+
+
+def continous_writes(connection_string: str, starting_number: int):
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    write_value = starting_number
+    while True:
+        try:
+            test_collection.insert_one({"number": write_value})
+            # this insures that no numbers are skipped. This can be moved and analysis can be done
+            # on all failed writes.
+            write_value += 1
+        except PyMongoError:
+            # ignore all errors related to pymongo
+            continue
+
+
+def main():
+    connection_string = sys.argv[1]
+    starting_number = int(sys.argv[2])
+    continous_writes(connection_string, starting_number)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -2,9 +2,10 @@
 # See LICENSE file for licensing details.
 
 """This file is meant to run in the background continuously writing entries to MongoDB."""
-from pymongo import MongoClient
-from pymongo.errors import PyMongoError
 import sys
+
+from pymongo import MongoClient
+from pymongo.errors import PyMongoError, AutoReconnect
 
 
 def continous_writes(connection_string: str, starting_number: int):
@@ -15,17 +16,23 @@ def continous_writes(connection_string: str, starting_number: int):
     while True:
         try:
             test_collection.insert_one({"number": write_value})
-            # this insures that no numbers are skipped. This can be moved and analysis can be done
-            # on all failed writes.
-            write_value += 1
-        except PyMongoError:
-            # ignore all errors related to pymongo
+        except AutoReconnect:
+            # this means that the primary was not able to be found. An application should try to
+            # reconnect and re-write the previous value. Hence, we `continue` here, without
+            # incrementing `write_value` as to try to insert this value again.
             continue
+        except PyMongoError:
+            # we should not raise this exception but instead increment the write value and move
+            # on, indicating that there was a failure writing to the database.
+            pass
+
+        write_value += 1
 
 
 def main():
     connection_string = sys.argv[1]
     starting_number = int(sys.argv[2])
+
     continous_writes(connection_string, starting_number)
 
 

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -5,7 +5,7 @@
 import sys
 
 from pymongo import MongoClient
-from pymongo.errors import AutoReconnect, PyMongoError, NotPrimaryError
+from pymongo.errors import AutoReconnect, NotPrimaryError, PyMongoError
 from pymongo.write_concern import WriteConcern
 
 
@@ -27,12 +27,12 @@ def continous_writes(connection_string: str, starting_number: int):
                     wtimeout=1000,
                 )
             ).insert_one({"number": write_value})
-        except (NotPrimaryError) as e:  # AutoReconnect
+        except (NotPrimaryError, AutoReconnect):
             # this means that the primary was not able to be found. An application should try to
             # reconnect and re-write the previous value. Hence, we `continue` here, without
             # incrementing `write_value` as to try to insert this value again.
             continue
-        except (PyMongoError, AutoReconnect) as e:
+        except (PyMongoError, AutoReconnect):
             # we should not raise this exception but instead increment the write value and move
             # on, indicating that there was a failure writing to the database.
             pass

--- a/tests/integration/ha_tests/continuous_writes.py
+++ b/tests/integration/ha_tests/continuous_writes.py
@@ -5,7 +5,7 @@
 import sys
 
 from pymongo import MongoClient
-from pymongo.errors import AutoReconnect, PyMongoError
+from pymongo.errors import AutoReconnect, PyMongoError, NotPrimaryError
 
 
 def continous_writes(connection_string: str, starting_number: int):
@@ -16,7 +16,7 @@ def continous_writes(connection_string: str, starting_number: int):
     while True:
         try:
             test_collection.insert_one({"number": write_value})
-        except AutoReconnect:
+        except (AutoReconnect, NotPrimaryError):
             # this means that the primary was not able to be found. An application should try to
             # reconnect and re-write the previous value. Hence, we `continue` here, without
             # incrementing `write_value` as to try to insert this value again.
@@ -32,7 +32,6 @@ def continous_writes(connection_string: str, starting_number: int):
 def main():
     connection_string = sys.argv[1]
     starting_number = int(sys.argv[2])
-
     continous_writes(connection_string, starting_number)
 
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -18,8 +18,8 @@ from tenacity import (
     retry_if_result,
     stop_after_attempt,
     stop_after_delay,
-    wait_fixed,
     wait_exponential,
+    wait_fixed,
 )
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
@@ -507,7 +507,7 @@ async def db_step_down(ops_test: OpsTest, unit_ip: str):
         if "msg" not in item:
             continue
 
-        # this message indicates that the previous primary preformed a repl step down operation.
+        # this message indicates that the previous primary performed a repl step down operation.
         if item["msg"] == "Starting an election due to step up request":
             return True
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -5,11 +5,6 @@ import subprocess
 from pathlib import Path
 from typing import List
 
-import logging
-
-logger = logging.getLogger(__name__)
-
-
 import ops
 import yaml
 from pymongo import MongoClient
@@ -246,8 +241,6 @@ async def stop_continous_writes(ops_test: OpsTest) -> int:
     app = await app_name(ops_test)
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]
-    logger.error(ops_test.model.applications[app].units)
-    logger.error(hosts)
     hosts = ",".join(hosts)
     connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app}"
 
@@ -262,7 +255,7 @@ async def stop_continous_writes(ops_test: OpsTest) -> int:
 
 
 async def count_writes(ops_test: OpsTest) -> int:
-    """New versions of pymongo no longer support the count operation, instead find should be used."""
+    """New versions of pymongo no longer support the count operation, instead find is used."""
     app = await app_name(ops_test)
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -124,8 +124,8 @@ async def fetch_primary(replica_set_hosts: List[str], ops_test: OpsTest) -> str:
     return primary
 
 
-async def count_primaries(ops_test: OpsTest) -> str:
-    """Returns IP address of current replica set primary."""
+async def count_primaries(ops_test: OpsTest) -> int:
+    """Returns the number of primaries in a replica set."""
     # connect to MongoDB client
     app = await app_name(ops_test)
     password = await get_password(ops_test, app)
@@ -310,7 +310,7 @@ async def count_writes(ops_test: OpsTest) -> int:
     client = MongoClient(connection_string)
     db = client["new-db"]
     test_collection = db["test_collection"]
-    count = sum(1 for _ in test_collection.find())
+    count = test_collection.count_documents({})
     client.close()
     return count
 
@@ -330,7 +330,7 @@ async def secondary_up_to_date(ops_test: OpsTest, unit_ip, expected_writes) -> b
             with attempt:
                 db = client["new-db"]
                 test_collection = db["test_collection"]
-                secondary_writes = sum(1 for _ in test_collection.find())
+                secondary_writes = test_collection.count_documents({})
                 assert secondary_writes == expected_writes
     except RetryError:
         return False
@@ -463,16 +463,12 @@ async def kill_unit_process(ops_test: OpsTest, unit_name: str, kill_code: str):
         await ops_test.model.applications[app].add_unit(count=1)
         await ops_test.model.wait_for_idle(apps=[app], status="active", timeout=1000)
 
-    # find the DB process on the unit and kill it
-    find_pid = f" run --unit {unit_name} ps aux | grep {DB_PROCESS}"
-    output = await ops_test.juju(*find_pid.split())
-    pid = output[1].split()[1]
-    kill_cmd = f"run --unit {unit_name} -- kill -s {kill_code} {pid}"
-    output = await ops_test.juju(*kill_cmd.split())
+    kill_cmd = f"run --unit {unit_name} -- pkill --signal {kill_code} -f {DB_PROCESS}"
+    return_code, _, _ = await ops_test.juju(*kill_cmd.split())
 
-    if not output[0] == 0:
+    if return_code != 0:
         raise ProcessError(
-            "Expected kill command %s to succeed instead it failed: %s", kill_cmd, output
+            "Expected kill command %s to succeed instead it failed: %s", kill_cmd, return_code
         )
 
 

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -3,12 +3,12 @@
 # See LICENSE file for licensing details.
 
 
-import pytest
 import time
+
+import pytest
 from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
-
 
 from tests.integration.ha_tests.helpers import (
     APP_NAME,
@@ -17,22 +17,22 @@ from tests.integration.ha_tests.helpers import (
     clear_db_writes,
     count_primaries,
     count_writes,
-    secondary_up_to_date,
-    mongod_ready,
     db_step_down,
     fetch_replica_set_members,
     find_unit,
     get_password,
     insert_focal_to_cluster,
+    kill_unit_process,
+    mongod_ready,
     replica_set_client,
     replica_set_primary,
     retrieve_entries,
     reused_storage,
+    secondary_up_to_date,
     start_continous_writes,
     stop_continous_writes,
     storage_id,
     storage_type,
-    kill_unit_process,
     unit_uri,
 )
 
@@ -406,7 +406,7 @@ async def test_freeze_db_process(ops_test, continuous_writes):
     new_primary_name = await replica_set_primary(ip_addresses, ops_test, return_name=True)
     assert new_primary_name != primary_name, "un-frozen primary should be secondary."
 
-    # verify that no writes were missed. Pausing and unpausing the primary can occassionally lead
+    # verify that no writes were missed. Pausing and unpausing the primary can occasionally lead
     # to a single duplicate write, hence the `<= actual_writes + 1`.
     total_expected_writes = await stop_continous_writes(ops_test)
     actual_writes = await count_writes(ops_test)

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -2,12 +2,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from itertools import count
-import logging
-from xml.etree.ElementPath import ops
-
-logger = logging.getLogger(__name__)
-
 
 import pytest
 from pymongo import MongoClient
@@ -18,6 +12,7 @@ from tests.integration.ha_tests.helpers import (
     APP_NAME,
     app_name,
     clear_db_writes,
+    count_writes,
     fetch_replica_set_members,
     find_unit,
     get_password,
@@ -25,13 +20,10 @@ from tests.integration.ha_tests.helpers import (
     replica_set_primary,
     retrieve_entries,
     start_continous_writes,
+    stop_continous_writes,
     unit_ids,
     unit_uri,
-    stop_continous_writes,
-    count_writes,
 )
-
-logger = logging.getLogger(__name__)
 
 ANOTHER_DATABASE_APP_NAME = "another-database-a"
 
@@ -83,7 +75,6 @@ async def test_add_units(ops_test: OpsTest, continuous_writes) -> None:
     # verify that the no writes were skipped
     total_expected_writes = await stop_continous_writes(ops_test)
 
-    logger.error(" total expected writes %s", total_expected_writes)
     actual_expected_writes = await count_writes(ops_test)
     assert total_expected_writes["number"] == actual_expected_writes
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
@@ -36,7 +36,7 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8==4.0.1
     flake8-docstrings
     flake8-copyright
     flake8-builtins

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,7 @@ deps =
     pytest-operator
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native {[vars]tst_path}integration/ha_tests/test_ha.py --log-cli-level=INFO -s {posargs} --durations=0
+    pytest -vvv --tb native {[vars]tst_path}integration/ha_tests/test_ha.py --log-cli-level=INFO -s {posargs} --durations=0
 
 [testenv:relation-integration]
 description = Run relation integration tests


### PR DESCRIPTION
### Release Notes
<!-- A summary of the solution addressing the above problem -->
This PR adds and tests self-healing.
1. Self healing was added via adding restart options to the service file, this is seen in `lib/charms/mongodb_libs/v0/machine_helpers.py`
2. This performs three self healing tests "kill DB process", "freeze DB process", and "graceful restart of one instance."

### Specialised Knowledge
<!-- What is some specialised knowledge relevant to this project/technology -->
1. `MongoDBClient` will hang on insert unless `socketTimeoutMS=5000` is specified.
2. `systemd` restarts the service via options in the Service File. We specify `Restart=always`, as to restart the DB process anytime it gets shutdown (ie SIGTERM), not only on failure (ie SIGKILL)
3. Pausing and unpausing the primary can lead to duplicate writes, hence in this test we ensure we don't miss any writes, but we do not check if there are no duplicates.

### Release Notes
<!-- A digestable summary of the change in this PR -->
1. Added self healing functionality in `tests/integration/ha_tests/helpers.py`
2. Tests added in `tests/integration/ha_tests/test_ha.py`

### Testing
<!-- A digestable summary of the change in this PR -->
Tests 
1. kill DB process
2. freeze DB process
3. graceful restart of one instance


