### PR TITLE
[UPDATED] App relation data refresh feature on mongo cluster scale up and down.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -107,9 +107,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self._update_hosts(event)
 
-        if "db_initialised" not in self.app_data:
-            return
-
         try:
             self.update_app_relation_data()
         except PyMongoError as e:

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,6 +58,8 @@ MONGO_DATA_DIR = "/data/db"
 # We expect the MongoDB container to use the default ports
 MONGODB_PORT = 27017
 
+REL_NAME = "database"
+
 
 class MongodbOperatorCharm(ops.charm.CharmBase):
     """Charm the service."""
@@ -69,7 +71,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
-        self.framework.observe(self.on[PEER].relation_joined, self._on_mongodb_relation_handler)
+        self.framework.observe(self.on[PEER].relation_joined, self._on_mongodb_relation_joined)
         self.framework.observe(self.on[PEER].relation_changed, self._on_mongodb_relation_handler)
 
         self.framework.observe(self.on.update_status, self._on_update_status)
@@ -105,6 +107,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self._update_hosts(event)
 
+        if "db_initialised" not in self.app_data:
+            return
+
+        try:
+            self.update_app_relation_data()
+        except PyMongoError as e:
+            logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
+
     def _update_hosts(self, event) -> None:
         """Update replica set hosts and remove any unremoved replicas from the config."""
         if "db_initialised" not in self.app_data:
@@ -132,15 +144,43 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         except PyMongoError as e:
             logger.error("Failed to remove %s from replica set, error=%r", self.unit.name, e)
 
+    def update_app_relation_data(self) -> None:
+        """Helper function to update application relation data."""
+        if "db_initialised" not in self.app_data:
+            return
+
+        database_users = set()
+
+        with MongoDBConnection(self.mongodb_config) as mongo:
+            database_users = mongo.get_users()
+
+        for relation in self.model.relations[REL_NAME]:
+            username = self.client_relations._get_username_from_relation_id(relation.id)
+            password = relation.data[self.app]["password"]
+            config = self.client_relations._get_config(username, password)
+            if username in database_users:
+                data = relation.data[self.app]
+                data["endpoints"] = ",".join(config.hosts)
+                data["uris"] = config.uri
+                relation.data[self.app].update(data)
+
     def _relation_departed(self, event: ops.charm.RelationDepartedEvent) -> None:
         """Remove peer from replica set if it wasn't able to remove itself.
 
         Args:
             event: The triggering relation departed event.
         """
-        # allow leader to update hosts if it isn't leaving
-        if self.unit.is_leader() and not event.departing_unit == self.unit:
-            self._update_hosts(event)
+        # allow leader to update relation data and hosts if it isn't leaving
+        if not self.unit.is_leader() or event.departing_unit == self.unit:
+            return
+        self._update_hosts(event)
+
+        try:
+            self.update_app_relation_data()
+        except PyMongoError as e:
+            logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
 
     def process_unremoved_units(self, event) -> None:
         """Removes replica set members that are no longer running as a juju hosts."""
@@ -157,6 +197,23 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                 logger.error("Deferring process_unremoved_units: error=%r", e)
                 event.defer()
 
+    def _on_mongodb_relation_joined(self, event: ops.charm.RelationJoinedEvent) -> None:
+        """Add peer to replica set.
+
+        Args:
+            event: The triggering relation joined event.
+        """
+        if not self.unit.is_leader():
+            return
+
+        self._on_mongodb_relation_handler(event)
+        try:
+            self.update_app_relation_data()
+        except PyMongoError as e:
+            logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
+
     def _on_mongodb_relation_handler(self, event: ops.charm.RelationEvent) -> None:
         """Adds the unit as a replica to the MongoDB replica set.
 
@@ -166,6 +223,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         # only leader should configure replica set and app-changed-events can trigger the relation
         # changed hook resulting in no JUJU_REMOTE_UNIT if this is the case we should return
         # further reconfiguration can be successful only if a replica set is initialised.
+
         if not (self.unit.is_leader() and event.unit) or "db_initialised" not in self.app_data:
             return
 

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -185,7 +185,7 @@ async def test_scale_down_capablities(ops_test: OpsTest, continuous_writes) -> N
         deleted_unit_ips.append(unit_to_remove.public_address)
         units_to_remove.append(unit_to_remove.name)
 
-    # destroy units simulatenously
+    # destroy units simultaneously
     expected_units = len(ops_test.model.applications[app].units) - len(units_to_remove)
     await ops_test.model.destroy_units(*units_to_remove)
 
@@ -482,7 +482,7 @@ async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes, reset_re
     for unit in ops_test.model.applications[app].units:
         await update_restart_delay(ops_test, unit, RESTART_DELAY)
 
-    # kill all units "simulatenously"
+    # kill all units "simultaneously"
     await asyncio.gather(
         *[
             kill_unit_process(ops_test, unit.name, kill_code="SIGKILL")
@@ -491,7 +491,7 @@ async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes, reset_re
     )
 
     # This test serves to verify behavior when all replicas are down at the same time that when
-    # they come back online they operate as expected. This check verfies that we meet the criterea
+    # they come back online they operate as expected. This check verifies that we meet the criterea
     # of all replicas being down at the same time.
     assert await all_db_processes_down(ops_test), "Not all units down at the same time."
 
@@ -530,7 +530,7 @@ async def test_full_cluster_restart(ops_test: OpsTest, continuous_writes, reset_
     for unit in ops_test.model.applications[app].units:
         await update_restart_delay(ops_test, unit, RESTART_DELAY)
 
-    # kill all units "simulatenously"
+    # kill all units "simultaneously"
     await asyncio.gather(
         *[
             kill_unit_process(ops_test, unit.name, kill_code="SIGTERM")
@@ -539,7 +539,7 @@ async def test_full_cluster_restart(ops_test: OpsTest, continuous_writes, reset_
     )
 
     # This test serves to verify behavior when all replicas are down at the same time that when
-    # they come back online they operate as expected. This check verfies that we meet the criterea
+    # they come back online they operate as expected. This check verifies that we meet the criterea
     # of all replicas being down at the same time.
     assert await all_db_processes_down(ops_test), "Not all units down at the same time."
 

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -185,7 +185,7 @@ class TestMongoProvider(unittest.TestCase):
     def test_oversee_users_create_user_failure(
         self, connection, relation_users, get_config, set_relation
     ):
-        """Verfies when user creation fails an exception is raised and no relations are set."""
+        """Verifies when user creation fails an exception is raised and no relations are set."""
         # presets, such that the need to create user relations is triggered
         relation_users.return_value = {"relation-user1", "relation-user2"}
         connection.return_value.__enter__.return_value.get_users.return_value = {"relation-user1"}


### PR DESCRIPTION
This pull request contains changes to update the application metadata (specifically endpoints and uris) as the mongodb cluster scales up and down. 

A detailed description of the feature requirements can be found [here](https://github.com/canonical/mongodb-operator/issues/59). 

An integration test covering both the scale up and down scenario has been added as well.

In addition to refactoring input, would request the reviewers to suggest more test case scenarios which make sense to add for this feature.

[UPDATE] 
Hi all, 
Kindly take a look at the feature and share your thoughts on error scenarios handling, especially during leader election cases.