### PR TITLE
Rotate password

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -5,4 +5,11 @@ get-primary:
   description: Report primary replica
 
 get-admin-password:
-  description: Get the admin user password for the database.
+  description: Get the admin user password used by charm.
+
+set-admin-password:
+  description: Change the admin user password used by charm.
+  params:
+    password:
+      type: string
+      description: The password will be auto-generated if this option is not specified.

--- a/lib/charms/mongodb_libs/v0/mongodb.py
+++ b/lib/charms/mongodb_libs/v0/mongodb.py
@@ -274,6 +274,14 @@ class MongoDBConnection:
             roles=self._get_roles(config),
         )
 
+    def set_user_password(self, username, password: str):
+        """Update the password."""
+        self.client.admin.command(
+            "updateUser",
+            username,
+            pwd=password,
+        )
+
     @staticmethod
     def _get_roles(config: MongoDBConfiguration) -> List[dict]:
         """Generate roles List."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -344,24 +344,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         """Returns the password for the user as an action response."""
         event.set_results({"admin-password": self.app_data.get("admin_password")})
 
-        new_password = generate_password()
-        if "password" in event.params:
-            new_password = event.params["password"]
-
-        with MongoDBConnection(self.mongodb_config) as mongo:
-            try:
-                mongo.set_user_password("admin", new_password)
-            except NotReadyError:
-                event.fail(
-                    "Failed changing the password: Not all members healthy or finished initial sync."
-                )
-                return
-            except PyMongoError as e:
-                event.fail(f"Failed changing the password: {e}")
-                return
-        self.app_data["admin_password"] = new_password
-        event.set_results({"admin-password": self.app_data.get("admin_password")})
-
     def _on_set_admin_password(self, event: ops.charm.ActionEvent) -> None:
         """Set the password for the admin user."""
         # only leader can write the new password into peer relation.
@@ -384,6 +366,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             except PyMongoError as e:
                 event.fail(f"Failed changing the password: {e}")
                 return
+
         self.app_data["admin_password"] = new_password
         event.set_results({"admin-password": self.app_data.get("admin_password")})
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -51,7 +51,7 @@ def replica_set_client(replica_ips: List[str], password: str, app=APP_NAME) -> M
     hosts = ["{}:{}".format(replica_ip, PORT) for replica_ip in replica_ips]
     hosts = ",".join(hosts)
 
-    replica_set_uri = f"mongodb://operator:" f"{password}@" f"{hosts}/admin?replicaSet={app}"
+    replica_set_uri = f"mongodb://admin:" f"{password}@" f"{hosts}/admin?replicaSet={app}"
     return MongoClient(replica_set_uri)
 
 
@@ -88,7 +88,7 @@ def unit_uri(ip_address: str, password, app=APP_NAME) -> str:
         password: password of database.
         app: name of application which has the cluster.
     """
-    return f"mongodb://operator:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet={app}"
+    return f"mongodb://admin:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet={app}"
 
 
 async def get_password(ops_test: OpsTest, app) -> str:
@@ -242,7 +242,7 @@ async def clear_db_writes(ops_test: OpsTest) -> bool:
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app}"
+    connection_string = f"mongodb://admin:{password}@{hosts}/admin?replicaSet={app}"
 
     client = MongoClient(connection_string)
     db = client["new-db"]
@@ -267,7 +267,7 @@ async def start_continous_writes(ops_test: OpsTest, starting_number: int) -> Non
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app}"
+    connection_string = f"mongodb://admin:{password}@{hosts}/admin?replicaSet={app}"
 
     # run continuous writes in the background.
     subprocess.Popen(
@@ -295,7 +295,7 @@ async def stop_continous_writes(ops_test: OpsTest) -> int:
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app}"
+    connection_string = f"mongodb://admin:{password}@{hosts}/admin?replicaSet={app}"
 
     client = MongoClient(connection_string)
     db = client["new-db"]
@@ -313,7 +313,7 @@ async def count_writes(ops_test: OpsTest) -> int:
     password = await get_password(ops_test, app)
     hosts = [unit.public_address for unit in ops_test.model.applications[app].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app}"
+    connection_string = f"mongodb://admin:{password}@{hosts}/admin?replicaSet={app}"
 
     client = MongoClient(connection_string)
     db = client["new-db"]
@@ -330,7 +330,7 @@ async def secondary_up_to_date(ops_test: OpsTest, unit_ip, expected_writes) -> b
     """
     app = await app_name(ops_test)
     password = await get_password(ops_test, app)
-    connection_string = f"mongodb://operator:{password}@{unit_ip}:{PORT}/admin?"
+    connection_string = f"mongodb://admin:{password}@{unit_ip}:{PORT}/admin?"
     client = MongoClient(connection_string, directConnection=True)
 
     try:

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -551,9 +551,11 @@ async def all_db_processes_down(ops_test: OpsTest) -> bool:
                     # `ps aux | grep {DB_PROCESS}` is a process on it's own and will be shown in
                     # the output of ps aux, hence it it is important that we check if there is
                     # more than one process containing the name `DB_PROCESS`
-                    # splitting processes by "\n" results in an empty line, hence we need to
-                    # remove one to account for the extra entry
-                    if len(processes.split("\n")) - 1 > 1:
+                    # splitting processes by "\n" results in one or more empty lines, hence we
+                    # need to process these lines accordingly.
+                    processes = [proc for proc in processes.split("\n") if len(proc) > 0]
+
+                    if len(processes) > 1:
                         raise ProcessRunningError
     except RetryError:
         return False

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -23,7 +23,7 @@ def unit_uri(ip_address: str, password, app=APP_NAME) -> str:
         password: password of database.
         app: name of application which has the cluster.
     """
-    return f"mongodb://operator:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet={app}"
+    return f"mongodb://admin:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet={app}"
 
 
 async def get_password(ops_test: OpsTest, app=APP_NAME) -> str:

--- a/tests/unit/test_mongodb_lib.py
+++ b/tests/unit/test_mongodb_lib.py
@@ -12,7 +12,7 @@ from lib.charms.mongodb_libs.v0.mongodb import MongoDBConnection, NotReadyError
 MONGO_CONFIG = {
     "replset": "mongo-k8s",
     "database": "admin",
-    "username": "operator",
+    "username": "admin",
     "password": "password",
     "hosts": set(["1.1.1.1", "2.2.2.2"]),
 }


### PR DESCRIPTION
### Problem
<!-- What problem is this PR trying to solve? -->
Password rotation not supported

### Solution
<!-- A summary of the solution addressing the above problem -->
Support password rotation with/without a provided password.

### Release Notes
<!-- A digestable summary of the change in this PR -->
1. Updated admin user from `operator` -> `admin`
2. Added implementation for `set_admin_password` based on k8s charm. Needs **not** reviewed.
3. Added tests (unit + integration for `set_admin_password`) **Needs** review

### Testing
<!-- A digestable summary of the change in this PR -->
Integration Tests Verify:
1. setting a specified admin password updates app data and `mongod`
2. requesting to set admin password without a provided password updates app data and `mongod` with newly generated password
Unit Tests Verify:
1. password gets updated correctly (when provided by the user and when not provided by the user)
2. when reseting the password results in failure the app data does not change.


