### PR TITLE
create secret implementation

### DIFF
--- a/lib/charms/mongodb_libs/v0/mongodb_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_provider.py
@@ -79,7 +79,7 @@ class MongoDBProvider(Object):
             return
         # We shouldn't try to create or update users if the database is not
         # initialised. We will create users as part of initialisation.
-        if "db_initialised" not in self.charm.app_data:
+        if "db_initialised" not in self.charm.app_peer_data:
             return
 
         # legacy relations have auth disabled, which new relations require

--- a/src/charm.py
+++ b/src/charm.py
@@ -96,15 +96,15 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         The same keyFile and admin password on all members needed, hence it is generated once and
         share between members via the app data.
         """
-        if "admin_password" not in self.app_data:
-            self.app_data["admin_password"] = generate_password()
+        if not self.get_secret("app", "admin_password"):
+            self.set_secret("app", "admin_password", generate_password())
 
-        if "keyfile" not in self.app_data:
-            self.app_data["keyfile"] = generate_keyfile()
+        if not self.get_secret("app", "keyfile"):
+            self.set_secret("app", "keyfile", generate_keyfile())
 
     def _on_leader_elected(self, event) -> None:
         """Generates necessary keyfile and updates replica hosts."""
-        if "keyfile" not in self.app_data:
+        if not self.get_secret("app", "keyfile"):
             self._generate_passwords()
 
         self._update_hosts(event)
@@ -118,11 +118,11 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
     def _update_hosts(self, event) -> None:
         """Update replica set hosts and remove any unremoved replicas from the config."""
-        if "db_initialised" not in self.app_data:
+        if "db_initialised" not in self.app_peer_data:
             return
 
         self.process_unremoved_units(event)
-        self.app_data["replica_set_hosts"] = json.dumps(self._unit_ips)
+        self.app_peer_data["replica_set_hosts"] = json.dumps(self._unit_ips)
 
     def _on_mongodb_storage_detaching(self, event: ops.charm.StorageDetachingEvent) -> None:
         """Before storage detaches, allow removing unit to remove itself from the set.
@@ -145,7 +145,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
     def update_app_relation_data(self) -> None:
         """Helper function to update application relation data."""
-        if "db_initialised" not in self.app_data:
+        if "db_initialised" not in self.app_peer_data:
             return
 
         database_users = set()
@@ -223,7 +223,10 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         # changed hook resulting in no JUJU_REMOTE_UNIT if this is the case we should return
         # further reconfiguration can be successful only if a replica set is initialised.
 
-        if not (self.unit.is_leader() and event.unit) or "db_initialised" not in self.app_data:
+        if (
+            not (self.unit.is_leader() and event.unit)
+            or "db_initialised" not in self.app_peer_data
+        ):
             return
 
         with MongoDBConnection(self.mongodb_config) as mongo:
@@ -342,7 +345,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
     def _on_get_admin_password(self, event: ops.charm.ActionEvent) -> None:
         """Returns the password for the user as an action response."""
-        event.set_results({"admin-password": self.app_data.get("admin_password")})
+        event.set_results({"admin-password": self.get_secret("app", "admin_password")})
 
     def _on_set_admin_password(self, event: ops.charm.ActionEvent) -> None:
         """Set the password for the admin user."""
@@ -367,8 +370,8 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                 event.fail(f"Failed changing the password: {e}")
                 return
 
-        self.app_data["admin_password"] = new_password
-        event.set_results({"admin-password": self.app_data.get("admin_password")})
+        self.set_secret("app", "admin_password", new_password)
+        event.set_results({"admin-password": self.get_secret("app", "admin_password")})
 
     def _open_port_tcp(self, port: int) -> None:
         """Open the given port.
@@ -443,7 +446,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
     def _instatiate_keyfile(self, event: ops.charm.StartEvent) -> None:
         # wait for keyFile to be created by leader unit
-        if "keyfile" not in self.app_data:
+        if not self.get_secret("app", "keyfile"):
             logger.debug("waiting for leader unit to generate keyfile contents")
             event.defer()
             return
@@ -451,14 +454,14 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         # put keyfile on the machine with appropriate permissions
         Path("/etc/mongodb/").mkdir(parents=True, exist_ok=True)
         with open(KEY_FILE, "w") as key_file:
-            key_file.write(self.app_data.get("keyfile"))
+            key_file.write(self.get_secret("app", "keyfile"))
 
         os.chmod(KEY_FILE, 0o400)
         mongodb_user = pwd.getpwnam(MONGO_USER)
         os.chown(KEY_FILE, mongodb_user.pw_uid, mongodb_user.pw_gid)
 
     def _initialise_replica_set(self, event: ops.charm.StartEvent) -> None:
-        if "db_initialised" in self.app_data:
+        if "db_initialised" in self.app_peer_data:
             # The replica set should be initialised only once. Check should be
             # external (e.g., check initialisation inside peer relation). We
             # shouldn't rely on MongoDB response because the data directory
@@ -490,7 +493,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                 return
 
             # replica set initialised properly and ready to go
-            self.app_data["db_initialised"] = "True"
+            self.app_peer_data["db_initialised"] = "True"
             self.unit.status = ActiveStatus()
 
     def _unit_ip(self, unit: ops.model.Unit) -> str:
@@ -504,6 +507,30 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         # raise exception if host not found
         else:
             raise ApplicationHostNotFoundError
+
+    def get_secret(self, scope: str, key: str) -> Optional[str]:
+        """Get secret from the secret storage."""
+        if scope == "unit":
+            return self.unit_peer_data.get(key, None)
+        elif scope == "app":
+            return self.app_peer_data.get(key, None)
+        else:
+            raise RuntimeError("Unknown secret scope.")
+
+    def set_secret(self, scope: str, key: str, value: Optional[str]) -> None:
+        """Set secret in the secret storage."""
+        if scope == "unit":
+            if not value:
+                del self.unit_peer_data[key]
+                return
+            self.unit_peer_data.update({key: value})
+        elif scope == "app":
+            if not value:
+                del self.app_peer_data[key]
+                return
+            self.app_peer_data.update({key: value})
+        else:
+            raise RuntimeError("Unknown secret scope.")
 
     @property
     def _primary(self) -> str:
@@ -551,7 +578,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         Returns:
             A list of hosts addresses (strings).
         """
-        return json.loads(self.app_data.get("replica_set_hosts", "[]"))
+        return json.loads(self.app_peer_data.get("replica_set_hosts", "[]"))
 
     @property
     def mongodb_config(self) -> MongoDBConfiguration:
@@ -560,13 +587,22 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             replset=self.app.name,
             database="admin",
             username="admin",
-            password=self.app_data.get("admin_password"),
+            password=self.get_secret("app", "admin_password"),
             hosts=set(self._unit_ips),
             roles={"default"},
         )
 
     @property
-    def app_data(self) -> Dict:
+    def unit_peer_data(self) -> Dict:
+        """Peer relation data object."""
+        relation = self.model.get_relation(PEER)
+        if relation is None:
+            return {}
+
+        return relation.data[self.unit]
+
+    @property
+    def app_peer_data(self) -> Dict:
         """Peer relation data object."""
         relation = self.model.get_relation(PEER)
         if not relation:
@@ -600,7 +636,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         It is needed to install mongodb-clients inside charm container to make
         this function work correctly.
         """
-        if "user_created" in self.app_data or not self.unit.is_leader():
+        if "user_created" in self.app_peer_data or not self.unit.is_leader():
             return
 
         out = subprocess.run(
@@ -611,7 +647,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             raise AdminUserCreationError
 
         logger.debug("User created")
-        self.app_data["user_created"] = "True"
+        self.app_peer_data["user_created"] = "True"
 
 
 class AdminUserCreationError(Exception):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -51,7 +51,7 @@ class TestCharm(unittest.TestCase):
         """Tests that a non leader unit does not initialise the replica set."""
         # Only leader can set RelationData
         self.harness.set_leader(True)
-        self.harness.charm.app_data["keyfile"] = "/etc/mongodb/keyFile"
+        self.harness.charm.app_peer_data["keyfile"] = "/etc/mongodb/keyFile"
 
         self.harness.set_leader(False)
         self.harness.charm.on.start.emit()
@@ -327,7 +327,7 @@ class TestCharm(unittest.TestCase):
         """
         # preset values
         self.harness.set_leader(True)
-        self.harness.charm.app_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = "True"
         connection.return_value.__enter__.return_value.is_ready = False
         connection.return_value.__enter__.return_value.get_replset_members.return_value = {
             "1.1.1.1"
@@ -355,7 +355,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = "True"
         rel = self.harness.charm.model.get_relation("database-peers")
 
         for exception in PYMONGO_EXCEPTIONS:
@@ -388,7 +388,7 @@ class TestCharm(unittest.TestCase):
         """
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = "True"
         connection.return_value.__enter__.return_value.get_replset_members.return_value = {
             "1.1.1.1"
         }
@@ -432,7 +432,7 @@ class TestCharm(unittest.TestCase):
         # set peer data so that leader doesn't reconfigure set on set_leader
 
         self.harness.set_leader(True)
-        self.harness.charm.app_data["_new_leader_must_reconfigure"] = "False"
+        self.harness.charm.app_peer_data["_new_leader_must_reconfigure"] = "False"
         connection.return_value.__enter__.return_value.is_ready = True
 
         for exception in PYMONGO_EXCEPTIONS:
@@ -560,7 +560,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         self.harness.charm._init_admin_user()
-        self.assertEqual("user_created" in self.harness.charm.app_data, True)
+        self.assertEqual("user_created" in self.harness.charm.app_peer_data, True)
 
         self.harness.charm._init_admin_user()
         run.assert_called_once()
@@ -570,11 +570,11 @@ class TestCharm(unittest.TestCase):
     def test_set_admin_password(self, connection):
         """Tests that a new admin password is generated and is returned to the user."""
         self.harness.set_leader(True)
-        original_password = self.harness.charm.app_data["admin_password"]
+        original_password = self.harness.charm.app_peer_data["admin_password"]
         action_event = mock.Mock()
         action_event.params = {}
         self.harness.charm._on_set_admin_password(action_event)
-        new_password = self.harness.charm.app_data["admin_password"]
+        new_password = self.harness.charm.app_peer_data["admin_password"]
 
         # verify app data is updated and results are reported to user
         self.assertNotEqual(original_password, new_password)
@@ -588,7 +588,7 @@ class TestCharm(unittest.TestCase):
         action_event = mock.Mock()
         action_event.params = {"password": "canonical123"}
         self.harness.charm._on_set_admin_password(action_event)
-        new_password = self.harness.charm.app_data["admin_password"]
+        new_password = self.harness.charm.app_peer_data["admin_password"]
 
         # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
@@ -599,7 +599,7 @@ class TestCharm(unittest.TestCase):
     def test_set_admin_password_failure(self, connection):
         """Tests failure to reset password does not update app data and failure is reported."""
         self.harness.set_leader(True)
-        original_password = self.harness.charm.app_data["admin_password"]
+        original_password = self.harness.charm.app_peer_data["admin_password"]
         action_event = mock.Mock()
         action_event.params = {}
 
@@ -608,7 +608,7 @@ class TestCharm(unittest.TestCase):
                 exception
             )
             self.harness.charm._on_set_admin_password(action_event)
-            current_password = self.harness.charm.app_data["admin_password"]
+            current_password = self.harness.charm.app_peer_data["admin_password"]
 
             # verify passwords are not updated.
             self.assertEqual(current_password, original_password)

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -63,7 +63,7 @@ class TestMongoProvider(unittest.TestCase):
         """Tests the errors related to pymongo when overseeing users result in a defer."""
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = "True"
         relation_id = self.harness.add_relation("database", "consumer")
 
         for exception, expected_raise in PYMONGO_EXCEPTIONS:
@@ -90,7 +90,7 @@ class TestMongoProvider(unittest.TestCase):
         """Verifies that when users are formatted incorrectly an assertion error is raised."""
         # presets
         self.harness.set_leader(True)
-        self.harness.charm.app_data["db_initialised"] = "True"
+        self.harness.charm.app_peer_data["db_initialised"] = "True"
         relation_id = self.harness.add_relation("database", "consumer")
 
         # AssertionError is raised when unable to attain users from relation (due to name


### PR DESCRIPTION
This PR aims to move secret implementation logic inside the separate functions. This way when juju secrets becomes available it will be much easier to update the charm to use juju secrets. (Ie without the logic of charm itself.)

Note: we have two types of secrets. Some secrets are shared between units, and some should be accessible and unique only for a particular unit.

This PR will be useful for TLS secrets as well

This addresses issue #84 