### PR TITLE
TLS implementation 

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -13,3 +13,13 @@ set-admin-password:
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.
+
+set-tls-private-key:
+  description: Set the privates key, which will be used for certificate signing requests (CSR). Run for each unit separately.
+  params:
+    external-key:
+      type: string
+      description: The content of private key for external communications with clients. Content will be auto-generated if this option is not specified.
+    internal-key:
+      type: string
+      description: The content of private key for internal communications with clients. Content will be auto-generated if this option is not specified.

--- a/lib/charms/mongodb_libs/v0/helpers.py
+++ b/lib/charms/mongodb_libs/v0/helpers.py
@@ -21,6 +21,10 @@ LIBPATCH = 1
 
 # path to store mongodb ketFile
 KEY_FILE = "/etc/mongodb/keyFile"
+TLS_EXT_PEM_FILE = "/etc/mongodb/external-cert.pem"
+TLS_EXT_CA_FILE = "/etc/mongodb/external-ca.crt"
+TLS_INT_PEM_FILE = "/etc/mongodb/internal-cert.pem"
+TLS_INT_CA_FILE = "/etc/mongodb/internal-ca.crt"
 
 
 logger = logging.getLogger(__name__)
@@ -59,7 +63,6 @@ def get_create_user_cmd(config: MongoDBConfiguration) -> List[str]:
 
 def get_mongod_cmd(config: MongoDBConfiguration) -> str:
     """Construct the MongoDB startup command line.
-
     Returns:
         A string representing the command used to start MongoDB.
     """
@@ -71,14 +74,35 @@ def get_mongod_cmd(config: MongoDBConfiguration) -> str:
         "--auth",
         # part of replicaset
         f"--replSet={config.replset}",
-        # keyFile used for authentication replica set peers
-        # TODO: replace with x509
-        "--clusterAuthMode=keyFile",
-        f"--keyFile={KEY_FILE}",
-        # TODO: add TLS certificates paths
-        # allow self signed certificates
-        # cmd.append("--tlsAllowInvalidCertificates")
     ]
+    if config.tls_external:
+        cmd.extend(
+            [
+                f"--tlsCAFile={TLS_EXT_CA_FILE}",
+                f"--tlsCertificateKeyFile={TLS_EXT_PEM_FILE}",
+                # allow non-TLS connections
+                "--tlsMode=preferTLS",
+            ]
+        )
+
+    # internal TLS can be enabled only in external is enabled
+    if config.tls_internal and config.tls_external:
+        cmd.extend(
+            [
+                "--clusterAuthMode=x509",
+                "--tlsAllowInvalidCertificates",
+                f"--tlsClusterCAFile={TLS_INT_CA_FILE}",
+                f"--tlsClusterFile={TLS_INT_PEM_FILE}",
+            ]
+        )
+    else:
+        # keyFile used for authentication replica set peers if no internal tls configured.
+        cmd.extend(
+            [
+                "--clusterAuthMode=keyFile",
+                f"--keyFile={KEY_FILE}",
+            ]
+        )
     return " ".join(cmd)
 
 

--- a/lib/charms/mongodb_libs/v0/helpers.py
+++ b/lib/charms/mongodb_libs/v0/helpers.py
@@ -63,6 +63,7 @@ def get_create_user_cmd(config: MongoDBConfiguration) -> List[str]:
 
 def get_mongod_cmd(config: MongoDBConfiguration) -> str:
     """Construct the MongoDB startup command line.
+
     Returns:
         A string representing the command used to start MongoDB.
     """

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -170,7 +170,7 @@ def generate_service_args(auth: bool, machine_ip: str, config: MongoDBConfigurat
                 ]
             )
 
-        # internal TLS can be enabled only in external is enabled
+        # internal TLS can be enabled only if external is enabled
         if config.tls_internal and config.tls_external:
             mongod_start_args.extend(
                 [
@@ -207,7 +207,7 @@ def push_file_to_unit(parent_dir, file_name, file_contents) -> None:
 
 
 def restart_mongod_service(auth: bool, machine_ip: str, config: MongoDBConfiguration):
-    """Restarts the mongod service with its associated configuratiion."""
+    """Restarts the mongod service with its associated configuration."""
     stop_mongod_service()
     update_mongod_service(auth, machine_ip, config)
     start_mongod_service()

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -196,15 +196,15 @@ def generate_service_args(auth: bool, machine_ip: str, config: MongoDBConfigurat
     return mongod_start_args
 
 
-def push_file_to_unit(file_name, file_contents) -> None:
+def push_file_to_unit(parent_dir, file_name, file_contents) -> None:
     """K8s charms can push files to their containers easily, this is the machine charm workaround."""
-    Path(file_name).mkdir(parents=True, exist_ok=True)
-    with open(KEY_FILE, "w") as key_file:
-        key_file.write(file_contents)
+    Path(parent_dir).mkdir(parents=True, exist_ok=True)
+    with open(file_name, "w") as write_file:
+        write_file.write(file_contents)
 
-    os.chmod(KEY_FILE, 0o400)
+    os.chmod(file_name, 0o400)
     mongodb_user = pwd.getpwnam(MONGO_USER)
-    os.chown(KEY_FILE, mongodb_user.pw_uid, mongodb_user.pw_gid)
+    os.chown(file_name, mongodb_user.pw_uid, mongodb_user.pw_gid)
 
 
 def restart_mongod_service(auth: bool, machine_ip: str, config: MongoDBConfiguration):

--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -4,18 +4,17 @@
 import logging
 import os
 import pwd
-
 from pathlib import Path
-from charms.mongodb_libs.v0.mongodb import MongoDBConfiguration
+
 from charms.mongodb_libs.v0.helpers import (
     KEY_FILE,
-    TLS_EXT_PEM_FILE,
     TLS_EXT_CA_FILE,
-    TLS_INT_PEM_FILE,
+    TLS_EXT_PEM_FILE,
     TLS_INT_CA_FILE,
+    TLS_INT_PEM_FILE,
 )
+from charms.mongodb_libs.v0.mongodb import MongoDBConfiguration
 from charms.operator_libs_linux.v1 import systemd
-
 
 # The unique Charmhub library identifier, never change it
 LIBID = "6q947ainc54837t38yhuidshahfgw8f"
@@ -197,7 +196,7 @@ def generate_service_args(auth: bool, machine_ip: str, config: MongoDBConfigurat
 
 
 def push_file_to_unit(parent_dir, file_name, file_contents) -> None:
-    """K8s charms can push files to their containers easily, this is the machine charm workaround."""
+    """K8s charms can push files to their containers easily, this is the vm charm workaround."""
     Path(parent_dir).mkdir(parents=True, exist_ok=True)
     with open(file_name, "w") as write_file:
         write_file.write(file_contents)
@@ -208,6 +207,7 @@ def push_file_to_unit(parent_dir, file_name, file_contents) -> None:
 
 
 def restart_mongod_service(auth: bool, machine_ip: str, config: MongoDBConfiguration):
+    """Restarts the mongod service with its associated configuratiion."""
     stop_mongod_service()
     update_mongod_service(auth, machine_ip, config)
     start_mongod_service()

--- a/lib/charms/mongodb_libs/v0/mongodb.py
+++ b/lib/charms/mongodb_libs/v0/mongodb.py
@@ -52,6 +52,8 @@ class MongoDBConfiguration:
     password: str
     hosts: Set[str]
     roles: Set[str]
+    tls_external: bool
+    tls_internal: bool
 
     @property
     def uri(self):

--- a/lib/charms/mongodb_libs/v0/mongodb.py
+++ b/lib/charms/mongodb_libs/v0/mongodb.py
@@ -44,6 +44,8 @@ class MongoDBConfiguration:
     — username: username.
     — password: password.
     — hosts: full list of hosts to connect to, needed for the URI.
+    - tls_external: indicator for use of internal TLS connection.
+    - tls_internal: indicator for use of external TLS connection.
     """
 
     replset: str

--- a/lib/charms/mongodb_libs/v0/mongodb_tls.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_tls.py
@@ -1,0 +1,247 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In this class we manage client database relations.
+
+This class creates user and database for each application relation
+and expose needed information for client connection via fields in
+external relation.
+"""
+
+import re
+import logging
+import base64
+import socket
+from cryptography import x509
+from cryptography.x509.extensions import ExtensionType
+from ops.framework import Object
+from ops.charm import ActionEvent, RelationJoinedEvent, RelationBrokenEvent
+from ops.model import ActiveStatus, MaintenanceStatus
+from charms.mongodb_libs.v0.machine_helpers import restart_mongod_service
+from charms.tls_certificates_interface.v1.tls_certificates import (
+    CertificateAvailableEvent,
+    CertificateExpiringEvent,
+    TLSCertificatesRequiresV1,
+    generate_csr,
+    generate_private_key,
+)
+from typing import List, Optional, Tuple
+
+# The unique Charmhub library identifier, never change it
+LIBID = "1057f353503741a98ed79309b5be7e33"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version.
+LIBPATCH = 0
+
+logger = logging.getLogger(__name__)
+TLS_RELATION = "certificates"
+
+
+class MongoDBTLS(Object):
+    """In this class we manage client database relations."""
+
+    def __init__(self, charm, peer_relation, substrate="k8s"):
+        """Manager of MongoDB client relations."""
+        super().__init__(charm, "client-relations")
+        self.charm = charm
+        self.substrate = substrate
+        self.peer_relation = peer_relation
+        self.certs = TLSCertificatesRequiresV1(self.charm, TLS_RELATION)
+        self.framework.observe(
+            self.charm.on.set_tls_private_key_action, self._on_set_tls_private_key
+        )
+        self.framework.observe(
+            self.charm.on[TLS_RELATION].relation_joined, self._on_tls_relation_joined
+        )
+        self.framework.observe(
+            self.charm.on[TLS_RELATION].relation_broken, self._on_tls_relation_broken
+        )
+        self.framework.observe(self.certs.on.certificate_available, self._on_certificate_available)
+        self.framework.observe(self.certs.on.certificate_expiring, self._on_certificate_expiring)
+
+    def _on_set_tls_private_key(self, event: ActionEvent) -> None:
+        """Set the TLS private key, which will be used for requesting the certificate."""
+        try:
+            self._request_certificate("unit", event.params.get("external-key", None))
+            if not self.charm.unit.is_leader():
+                event.log(
+                    "Only juju leader unit can set private key for the internal certificate. Skipping."
+                )
+                return
+            self._request_certificate("app", event.params.get("internal-key", None))
+        except ValueError as e:
+            event.fail(str(e))
+
+    def _request_certificate(self, scope: str, param: Optional[str]):
+        if param is None:
+            key = generate_private_key()
+        else:
+            key = self._parse_tls_file(param)
+
+        csr = generate_csr(
+            private_key=key,
+            subject=self.charm.get_hostname_by_unit(self.charm.unit.name),
+            organization=self.charm.app.name,
+            sans=self._get_sans(),
+        )
+
+        self.charm.set_secret(scope, "key", key.decode("utf-8"))
+        self.charm.set_secret(scope, "csr", csr.decode("utf-8"))
+
+        if self.charm.model.get_relation(TLS_RELATION):
+            self.certs.request_certificate_creation(certificate_signing_request=csr)
+
+    @staticmethod
+    def _parse_tls_file(raw_content: str) -> bytes:
+        """Parse TLS files from both plain text or base64 format."""
+        if re.match(r"(-+(BEGIN|END) [A-Z ]+-+)", raw_content):
+            return re.sub(
+                r"(-+(BEGIN|END) [A-Z ]+-+)",
+                "\n\\1\n",
+                raw_content,
+            ).encode("utf-8")
+        return base64.b64decode(raw_content)
+
+    def _on_tls_relation_joined(self, _: RelationJoinedEvent) -> None:
+        """Request certificate when TLS relation joined."""
+        if self.charm.unit.is_leader():
+            self._request_certificate("app", None)
+
+        self._request_certificate("unit", None)
+
+    def _on_tls_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Disable TLS when TLS relation broken."""
+        self.charm.set_secret("unit", "ca", None)
+        self.charm.set_secret("unit", "cert", None)
+        self.charm.set_secret("unit", "chain", None)
+        if self.charm.unit.is_leader():
+            self.charm.set_secret("app", "ca", None)
+            self.charm.set_secret("app", "cert", None)
+            self.charm.set_secret("app", "chain", None)
+        if self.charm.get_secret("app", "cert"):
+            logger.debug(
+                "Defer till the leader delete the internal TLS certificate to avoid second restart."
+            )
+            event.defer()
+            return
+
+        if self.substrate == "vm":
+            logger.debug("disabling TLS on mongod.service")
+            self.charm.unit.status = MaintenanceStatus("disabling TLS")
+            restart_mongod_service(
+                auth=True,
+                machine_ip=self.charm._unit_ip(self.charm.unit),
+                config=self.charm.mongodb_config,
+            )
+            self.charm.unit.status = ActiveStatus()
+        else:
+            self.charm.on_mongod_pebble_ready(event)
+
+    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
+        """Enable TLS when TLS certificate available."""
+        if (
+            event.certificate_signing_request.rstrip()
+            == self.charm.get_secret("unit", "csr").rstrip()
+        ):
+            logger.debug("The external TLS certificate available.")
+            scope = "unit"  # external crs
+        elif (
+            event.certificate_signing_request.rstrip()
+            == self.charm.get_secret("app", "csr").rstrip()
+        ):
+            logger.debug("The internal TLS certificate available.")
+            if not self.charm.unit.is_leader():
+                return
+            scope = "app"  # internal crs
+        else:
+            logger.error("An unknown certificate available.")
+            return
+
+        old_cert = self.charm.get_secret(scope, "cert")
+        renewal = old_cert and old_cert != event.certificate
+        self.charm.set_secret(scope, "chain", event.chain)
+        self.charm.set_secret(scope, "cert", event.certificate)
+        self.charm.set_secret(scope, "ca", event.ca)
+
+        if renewal:
+            self.charm.unit.get_container("mongod").stop("mongod")
+        elif not self.charm.get_secret("app", "cert") or not self.charm.get_secret("unit", "cert"):
+            logger.debug(
+                "Defer till both internal and external TLS certificates available to avoid second restart."
+            )
+            event.defer()
+            return
+
+        if self.substrate == "vm":
+            logger.debug("enalbing TLS on mongod.service")
+            self.charm.unit.status = MaintenanceStatus("disabling TLS")
+            restart_mongod_service(
+                auth=True,
+                machine_ip=self.charm._unit_ip(self.charm.unit),
+                config=self.charm.mongodb_config,
+            )
+            self.charm.unit.status = ActiveStatus()
+        else:
+            self.charm.on_mongod_pebble_ready(event)
+
+    def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
+        """Request the new certificate when old certificate is expiring."""
+        if event.certificate.rstrip() == self.charm.get_secret("unit", "cert").rstrip():
+            logger.debug("The external TLS certificate expiring.")
+            scope = "unit"  # external cert
+        elif event.certificate.rstrip() == self.charm.get_secret("app", "cert").rstrip():
+            logger.debug("The internal TLS certificate expiring.")
+            scope = "app"  # internal cert
+        else:
+            logger.error("An unknown certificate expiring.")
+            return
+
+        key = self.charm.get_secret(scope, "key").encode("utf-8")
+        old_csr = self.charm.get_secret(scope, "csr").encode("utf-8")
+        new_csr = generate_csr(
+            private_key=key,
+            subject=self.charm.get_hostname_by_unit(self.charm.unit.name),
+            organization=self.charm.app.name,
+            sans=self._get_sans(),
+        )
+        self.certs.request_certificate_renewal(
+            old_certificate_signing_request=old_csr,
+            new_certificate_signing_request=new_csr,
+        )
+        self.charm.set_secret(scope, "csr", new_csr.decode("utf-8"))
+
+    def _get_sans(self) -> List[str]:
+        """Create a list of DNS names for a MongoDB unit.
+
+        Returns:
+            A list representing the hostnames of the MongoDB unit.
+        """
+        unit_id = self.charm.unit.name.split("/")[1]
+        return [
+            f"{self.charm.app.name}-{unit_id}",
+            socket.getfqdn(),
+            str(self.charm.model.get_binding(self.peer_relation).network.bind_address),
+        ]
+
+    def get_tls_files(self, scope: str) -> Tuple[Optional[str], Optional[str]]:
+        """Prepare TLS files in special MongoDB way.
+
+        MongoDB needs two files:
+        — CA file should have a full chain.
+        — PEM file should have private key and certificate without certificate chain.
+        """
+        ca = self.charm.get_secret(scope, "ca")
+        chain = self.charm.get_secret(scope, "chain")
+        ca_file = chain if chain else ca
+
+        key = self.charm.get_secret(scope, "key")
+        cert = self.charm.get_secret(scope, "cert")
+        pem_file = key
+        if cert:
+            pem_file = key + "\n" + cert if key else cert
+
+        return ca_file, pem_file

--- a/lib/charms/mongodb_libs/v0/mongodb_tls.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_tls.py
@@ -13,7 +13,7 @@ import re
 import socket
 from typing import List, Optional, Tuple
 
-from charms.mongodb_libs.v0.machine_helpers import restart_mongod_service
+from charms.mongodb_libs.v0.machine_helpers import auth_enabled, restart_mongod_service
 from charms.tls_certificates_interface.v1.tls_certificates import (
     CertificateAvailableEvent,
     CertificateExpiringEvent,
@@ -135,7 +135,7 @@ class MongoDBTLS(Object):
         if self.substrate == "vm":
             self.charm.unit.status = MaintenanceStatus("disabling TLS")
             restart_mongod_service(
-                auth=True,
+                auth=auth_enabled(),
                 machine_ip=self.charm._unit_ip(self.charm.unit),
                 config=self.charm.mongodb_config,
             )
@@ -184,9 +184,9 @@ class MongoDBTLS(Object):
         logger.debug("Restarting mongod with TLS enabled.")
         if self.substrate == "vm":
             self.charm._push_tls_certificate_to_workload()
-            self.charm.unit.status = MaintenanceStatus("disabling TLS")
+            self.charm.unit.status = MaintenanceStatus("enabling TLS")
             restart_mongod_service(
-                auth=True,
+                auth=auth_enabled(),
                 machine_ip=self.charm._unit_ip(self.charm.unit),
                 config=self.charm.mongodb_config,
             )

--- a/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb_libs/v0/mongodb_vm_legacy_provider.py
@@ -9,12 +9,7 @@ the expected relation data for legacy relations.
 import logging
 from typing import Optional
 
-from charms.mongodb_libs.v0.machine_helpers import (
-    auth_enabled,
-    start_mongod_service,
-    stop_mongod_service,
-    update_mongod_service,
-)
+from charms.mongodb_libs.v0.machine_helpers import auth_enabled, restart_mongod_service
 from charms.operator_libs_linux.v1 import systemd
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
@@ -79,13 +74,11 @@ class MongoDBLegacyProvider(Object):
             try:
                 logger.debug("Disabling authentication.")
                 self.charm.unit.status = MaintenanceStatus("disabling authentication")
-                stop_mongod_service()
-                update_mongod_service(
+                restart_mongod_service(
                     auth=False,
                     machine_ip=self.charm._unit_ip(self.charm.unit),
-                    replset=self.charm.app.name,
+                    config=self.charm.mongodb_config,
                 )
-                start_mongod_service()
                 self.charm.unit.status = ActiveStatus()
             except systemd.SystemdError:
                 self.charm.unit.status = BlockedStatus("couldn't restart MongoDB")

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,3 +24,8 @@ storage:
 peers:
   database-peers:
     interface: mongodb-peers
+
+requires:
+  certificates:
+    interface: tls-certificates
+    limit: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tenacity==8.0.1
-pymongo==3.12.1
+pymongo==4.2.0
 ops >= 1.2.0
 jsonschema==4.15.0
-cryptography==2.8
+cryptography==38.0.1
+pyOpenSSL==22.0.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -457,23 +457,35 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             return
 
         # put keyfile on the machine with appropriate permissions
-        push_file_to_unit(file_name=KEY_FILE, file_contents=self.get_secret("app", "keyfile"))
+        push_file_to_unit(
+            parent_dir="/etc/mongodb/",
+            file_name=KEY_FILE,
+            file_contents=self.get_secret("app", "keyfile"),
+        )
 
     def _push_tls_certificate_to_workload(self) -> None:
         """Uploads certificate to the workload container."""
         external_ca, external_pem = self.tls.get_tls_files("unit")
         if external_ca is not None:
-            push_file_to_unit(file_name=TLS_EXT_CA_FILE, file_contents=external_ca)
+            push_file_to_unit(
+                parent_dir="/etc/mongodb/", file_name=TLS_EXT_CA_FILE, file_contents=external_ca
+            )
 
         if external_pem is not None:
-            push_file_to_unit(file_name=TLS_EXT_PEM_FILE, file_contents=external_pem)
+            push_file_to_unit(
+                parent_dir="/etc/mongodb/", file_name=TLS_EXT_PEM_FILE, file_contents=external_pem
+            )
 
         internal_ca, internal_pem = self.tls.get_tls_files("app")
         if internal_ca is not None:
-            push_file_to_unit(file_name=TLS_INT_CA_FILE, file_contents=internal_ca)
+            push_file_to_unit(
+                parent_dir="/etc/mongodb/", file_name=TLS_INT_CA_FILE, file_contents=internal_ca
+            )
 
         if internal_pem is not None:
-            push_file_to_unit(file_name=TLS_INT_PEM_FILE, file_contents=internal_pem)
+            push_file_to_unit(
+                parent_dir="/etc/mongodb/", file_name=TLS_INT_PEM_FILE, file_contents=internal_pem
+            )
 
     def _initialise_replica_set(self, event: ops.charm.StartEvent) -> None:
         if "db_initialised" in self.app_peer_data:

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,9 +21,9 @@ from charms.mongodb_libs.v0.helpers import (
     get_create_user_cmd,
 )
 from charms.mongodb_libs.v0.machine_helpers import (
+    push_file_to_unit,
     start_mongod_service,
     update_mongod_service,
-    push_file_to_unit,
 )
 from charms.mongodb_libs.v0.mongodb import (
     MongoDBConfiguration,
@@ -32,8 +32,8 @@ from charms.mongodb_libs.v0.mongodb import (
     PyMongoError,
 )
 from charms.mongodb_libs.v0.mongodb_provider import MongoDBProvider
-from charms.mongodb_libs.v0.mongodb_vm_legacy_provider import MongoDBLegacyProvider
 from charms.mongodb_libs.v0.mongodb_tls import MongoDBTLS
+from charms.mongodb_libs.v0.mongodb_vm_legacy_provider import MongoDBLegacyProvider
 from charms.operator_libs_linux.v0 import apt
 from charms.operator_libs_linux.v1 import systemd
 from ops.main import main
@@ -550,12 +550,12 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             if not value:
                 del self.unit_peer_data[key]
                 return
-            self.unit_peer_data.update({key: value})
+            self.unit_peer_data.update({key: str(value)})
         elif scope == "app":
             if not value:
                 del self.app_peer_data[key]
                 return
-            self.app_peer_data.update({key: value})
+            self.app_peer_data.update({key: str(value)})
         else:
             raise RuntimeError("Unknown secret scope.")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -587,7 +587,9 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         Returns:
             a list of IP address associated with MongoDB application.
         """
-        peer_addresses = [self._unit_ip(unit) for unit in self._peers.units]
+        peer_addresses = []
+        if self._peers:
+            peer_addresses = [self._unit_ip(unit) for unit in self._peers.units]
 
         logger.debug("peer addresses: %s", peer_addresses)
         self_address = self._unit_ip(self.unit)

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -465,7 +465,7 @@ async def insert_focal_to_cluster(ops_test: OpsTest) -> None:
     client = MongoClient(unit_uri(primary, password, app), directConnection=True)
     db = client["new-db"]
     test_collection = db["test_ubuntu_collection"]
-    test_collection.insert({"release_name": "Focal Fossa", "version": 20.04, "LTS": True})
+    test_collection.insert_one({"release_name": "Focal Fossa", "version": 20.04, "LTS": True})
     client.close()
 
 

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -265,7 +265,7 @@ async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes) -> None:
     client = replica_set_client(ip_addresses, password, app=ANOTHER_DATABASE_APP_NAME)
     db = client["new-db"]
     test_collection = db["test_ubuntu_collection"]
-    test_collection.insert({"release_name": "Jammy Jelly", "version": 22.04, "LTS": False})
+    test_collection.insert_one({"release_name": "Jammy Jelly", "version": 22.04, "LTS": False})
     client.close()
 
     cluster_1_entries = await retrieve_entries(

--- a/tests/integration/relation_tests/new_relations/test_charm_relations.py
+++ b/tests/integration/relation_tests/new_relations/test_charm_relations.py
@@ -90,8 +90,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
     assert query[0]["release_name"] == "Fancy Fossa"
 
     test_collection.delete_one({"release_name": "Fancy Fossa"})
-    query = test_collection.find({}, {"release_name": 1})
-    assert query.count() == 0
+    assert test_collection.count_documents({"release_name": 1}) == 0
 
     client.close()
 

--- a/tests/integration/relation_tests/new_relations/test_charm_relations.py
+++ b/tests/integration/relation_tests/new_relations/test_charm_relations.py
@@ -190,8 +190,7 @@ async def test_app_relation_metadata_change(ops_test: OpsTest) -> None:
     assert query[0]["release_name"] == "Fancy Fossa"
 
     test_collection.delete_one({"release_name": "Fancy Fossa"})
-    query = test_collection.find({}, {"release_name": 1})
-    assert query.count() == 0
+    assert test_collection.count_documents({"release_name": 1}) == 0
 
     client.close()
 

--- a/tests/integration/relation_tests/new_relations/test_charm_relations.py
+++ b/tests/integration/relation_tests/new_relations/test_charm_relations.py
@@ -77,7 +77,7 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
     db = client[database]
     test_collection = db["test_collection"]
     ubuntu = {"release_name": "Focal Fossa", "version": 20.04, "LTS": True}
-    test_collection.insert(ubuntu)
+    test_collection.insert_one(ubuntu)
 
     query = test_collection.find({}, {"release_name": 1})
     assert query[0]["release_name"] == "Focal Fossa"
@@ -178,7 +178,7 @@ async def test_app_relation_metadata_change(ops_test: OpsTest) -> None:
     test_collection.drop()
     test_collection = db["test_app_collection"]
     ubuntu = {"release_name": "Focal Fossa", "version": 20.04, "LTS": True}
-    test_collection.insert(ubuntu)
+    test_collection.insert_one(ubuntu)
 
     query = test_collection.find({}, {"release_name": 1})
     assert query[0]["release_name"] == "Focal Fossa"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -142,7 +142,7 @@ async def test_set_password_action(ops_test: OpsTest) -> None:
     # verify that the password is updated in mongod by inserting into the collection.
     try:
         client = MongoClient(unit_uri(unit.public_address, new_password), directConnection=True)
-        client["new-db"].collection_names()
+        client["new-db"].list_collection_names()
     except PyMongoError as e:
         assert False, f"Failed to access collection with new password, error: {e}"
     finally:
@@ -160,7 +160,7 @@ async def test_set_password_action(ops_test: OpsTest) -> None:
     # verify that the password is updated in mongod by inserting into the collection.
     try:
         client = MongoClient(unit_uri(unit.public_address, "safe_pass"), directConnection=True)
-        client["new-db"].collection_names()
+        client["new-db"].list_collection_names()
     except PyMongoError as e:
         assert False, f"Failed to access collection with new password, error: {e}"
     finally:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -41,12 +41,10 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._init_admin_user")
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
     @patch("charm.systemd.service_start")
-    @patch("charm.Path")
+    @patch("charm.push_file_to_unit")
     @patch("builtins.open")
-    @patch("charm.os")
-    @patch("charm.pwd")
     def test_on_start_not_leader_doesnt_initialise_replica_set(
-        self, pwd, os, open, path, service_start, _open_port_tcp, init_admin, connection
+        self, open, path, service_start, _open_port_tcp, init_admin, connection
     ):
         """Tests that a non leader unit does not initialise the replica set."""
         # Only leader can set RelationData
@@ -68,14 +66,10 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
     @patch("charm.systemd.service_start", side_effect=systemd.SystemdError)
     @patch("charm.systemd.service_running", return_value=False)
-    @patch("charm.Path")
+    @patch("charm.push_file_to_unit")
     @patch("builtins.open")
-    @patch("charm.os")
-    @patch("charm.pwd")
     def test_on_start_systemd_failure_leads_to_blocked_status(
         self,
-        pwd,
-        os,
         open,
         path,
         service_running,
@@ -100,18 +94,14 @@ class TestCharm(unittest.TestCase):
     @patch("charm.systemd.service_start")
     @patch("charm.systemd.service_running", return_value=True)
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
-    @patch("charm.Path")
+    @patch("charm.push_file_to_unit")
     @patch("builtins.open")
-    @patch("charm.os")
-    @patch("charm.pwd")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongodbOperatorCharm._init_admin_user")
     def test_on_start_mongo_service_ready_doesnt_reenable(
         self,
         init_admin,
         connection,
-        pwd,
-        os,
         open,
         path,
         _open_port_tcp,
@@ -129,18 +119,14 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
     @patch("charm.MongodbOperatorCharm._initialise_replica_set")
     @patch("charm.systemd.service_running", return_value=True)
-    @patch("charm.Path")
+    @patch("charm.push_file_to_unit")
     @patch("builtins.open")
-    @patch("charm.os")
-    @patch("charm.pwd")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongodbOperatorCharm._init_admin_user")
     def test_on_start_mongod_not_ready_defer(
         self,
         init_admin,
         connection,
-        pwd,
-        os,
         open,
         path,
         service_running,
@@ -159,12 +145,10 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
     @patch("charm.systemd.service_running", return_value=True)
-    @patch("charm.Path")
+    @patch("charm.push_file_to_unit")
     @patch("builtins.open")
-    @patch("charm.os")
-    @patch("charm.pwd")
     def test_start_unable_to_open_tcp_moves_to_blocked(
-        self, pwd, os, open, path, service_running, _open_port_tcp
+        self, open, path, service_running, _open_port_tcp
     ):
         """Test verifies that if TCP port cannot be opened we go to the blocked state."""
         self.harness.set_leader(True)
@@ -411,18 +395,14 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongodbOperatorCharm._open_port_tcp")
     @patch("charm.systemd.service_start")
-    @patch("charm.Path")
+    @patch("charm.push_file_to_unit")
     @patch("builtins.open")
-    @patch("charm.os")
-    @patch("charm.pwd")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongodbOperatorCharm._init_admin_user")
     def test_initialise_replica_failure_leads_to_waiting_state(
         self,
         init_admin,
         connection,
-        pwd,
-        os,
         open,
         path,
         service_start,

--- a/tests/unit/test_machine_helpers.py
+++ b/tests/unit/test_machine_helpers.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
@@ -25,16 +26,20 @@ class TestCharm(unittest.TestCase):
                 "ExecStart=/usr/bin/mongod",
                 "--bind_ip",
                 "localhost,1.1.1.1",
-                "--replSet",
-                "my_repl_set",
+                "--replSet=my_repl_set",
                 "--auth",
                 "--clusterAuthMode=keyFile",
                 f"--keyFile={machine_helpers.KEY_FILE}",
                 "\n",
             ]
         )
+
+        config = mock.Mock()
+        config.replset = "my_repl_set"
+        config.tls_external = False
+        config.tls_internal = False
         self.assertEqual(
-            machine_helpers.generate_service_args(True, "1.1.1.1", "my_repl_set"),
+            machine_helpers.generate_service_args(True, "1.1.1.1", config),
             service_args_auth,
         )
 
@@ -45,12 +50,11 @@ class TestCharm(unittest.TestCase):
                 "--bind_ip",
                 "localhost,1.1.1.1",
                 # part of replicaset
-                "--replSet",
-                "my_repl_set",
+                "--replSet=my_repl_set",
                 "\n",
             ]
         )
         self.assertEqual(
-            machine_helpers.generate_service_args(False, "1.1.1.1", "my_repl_set"),
+            machine_helpers.generate_service_args(False, "1.1.1.1", config),
             service_args,
         )

--- a/tests/unit/test_mongodb_lib.py
+++ b/tests/unit/test_mongodb_lib.py
@@ -9,14 +9,6 @@ from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailu
 
 from lib.charms.mongodb_libs.v0.mongodb import MongoDBConnection, NotReadyError
 
-MONGO_CONFIG = {
-    "replset": "mongo-k8s",
-    "database": "admin",
-    "username": "admin",
-    "password": "password",
-    "hosts": set(["1.1.1.1", "2.2.2.2"]),
-}
-
 PYMONGO_EXCEPTIONS = [
     (ConnectionFailure("error message"), ConnectionFailure),
     (ConfigurationError("error message"), ConfigurationError),


### PR DESCRIPTION
### For the reader 
Requesting to merge into `TLS-feature-branch` rather than into `main`, so that all of TLS (libs, implementation, unit-test, int-tests) can be merged at once and pushed to charmhub. TLS integration tests coming in next PR

### Problem
<!-- What problem is this PR trying to solve? -->
TLS not supported

### Solution
<!-- A summary of the solution addressing the above problem -->
TLS now supported.

### Release Notes
<!-- A digestable summary of the change in this PR -->
1. Updated `.yaml` files & `requirements.txt`
2. `lib/charms/mongodb_libs/v0/helpers.py` updated to add/remove tls arguments for starting mongod -- does NOT need reviewed, this is part of the k8s lib requirments
3. `lib/charms/mongodb_libs/v0/machine_helpers.py` updated to add/remove tls arguments for starting mongod via systemd, and added additional machine charm helpers
4. `lib/charms/mongodb_libs/v0/mongodb_tls.py` updated to work with both k8s and VM
5. `src/charm.py` now adds TLS files if necessary

### Testing
<!-- A digestable summary of the change in this PR -->
Integration and Unit tests coming in following PR. 
This work was checked by hand by issuing this command on the associated mongodb unit/(s):
`mongo '<connection uri>' --eval 'rs.status()' --tls --tlsCAFile /etc/mongodb/external-ca.crt --tlsCertificateKeyFile /etc/mongodb/external-cert.pem`

