### PR TITLE
Feat: add network restore self healing

### DIFF
--- a/lib/charms/mongodb_libs/v0/machine_helpers.py
+++ b/lib/charms/mongodb_libs/v0/machine_helpers.py
@@ -143,8 +143,7 @@ def generate_service_args(auth: bool, machine_ip: str, replset: str) -> str:
     mongod_start_args = [
         "ExecStart=/usr/bin/mongod",
         # bind to localhost and external interfaces
-        "--bind_ip",
-        f"localhost,{machine_ip}",
+        "--bind_ip_all",
         # part of replicaset
         "--replSet",
         f"{replset}",

--- a/lib/charms/mongodb_libs/v0/mongodb.py
+++ b/lib/charms/mongodb_libs/v0/mongodb.py
@@ -175,6 +175,23 @@ class MongoDBConnection:
                 logger.error("Cannot initialize replica set. error=%r", e)
                 raise e
 
+    def get_replset_status(self) -> Dict:
+        """Get a replica set status as a dict.
+
+        Returns:
+            A set of the replica set members along with their status.
+
+        Raises:
+            ConfigurationError, ConfigurationError, OperationFailure
+        """
+        rs_status = self.client.admin.command("replSetGetStatus")
+        rs_status_parsed = {}
+        for member in rs_status["members"]:
+            member_name = self._hostname_from_hostport(member["name"])
+            rs_status_parsed[member_name] = member["stateStr"]
+
+        return rs_status_parsed
+
     def get_replset_members(self) -> Set[str]:
         """Get a replica set members.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -348,20 +348,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         # cuts can lead to new IP addresses and therefore will require a reconfigure. Especially
         # in the case that the leader a change in IP address it will not receive a relation event.
         if self.unit.is_leader():
-            # remove any IPs that are no longer juju hosts & update app data.
-            self._update_hosts(event)
-            # Add in any new IPs to the replica set. Relation handlers require a reference to
-            # a unit.
-            event.unit = self.unit
-            self._on_mongodb_relation_handler(event)
-
-            # app relations should be made aware of the new set of hosts
-            try:
-                self.update_app_relation_data()
-            except PyMongoError as e:
-                logger.error("Deferring on updating app relation data since: error: %r", e)
-                event.defer()
-                return
+            self._handle_reconfigure(event)
 
         # update the units status based on it's replica set status.
         with MongoDBConnection(self.mongodb_config) as mongo:
@@ -383,6 +370,30 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                 self.unit.status = WaitingStatus("Member is removing..")
             else:
                 self.unit.status = BlockedStatus(replica_status)
+
+    def _handle_reconfigure(self, event):
+        """Reconfigures the replica set if necessary.
+
+        Removes any mongod hosts that are no longer present in the replica set or adds hosts that
+        should exist in the replica set. This function is meant to be called periodically by the
+        leader in the update status hook to perform any necessary cluster healing.
+        """
+        if not self.unit.is_leader():
+            logger.debug("only the leader can perform reconfigurations to the replica set.")
+        # remove any IPs that are no longer juju hosts & update app data.
+        self._update_hosts(event)
+        # Add in any new IPs to the replica set. Relation handlers require a reference to
+        # a unit.
+        event.unit = self.unit
+        self._on_mongodb_relation_handler(event)
+
+        # app relations should be made aware of the new set of hosts
+        try:
+            self.update_app_relation_data()
+        except PyMongoError as e:
+            logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
 
     def _on_get_primary_action(self, event: ops.charm.ActionEvent):
         event.set_results({"replica-set-primary": self._primary})

--- a/tests/unit/test_machine_helpers.py
+++ b/tests/unit/test_machine_helpers.py
@@ -23,8 +23,7 @@ class TestCharm(unittest.TestCase):
         service_args_auth = " ".join(
             [
                 "ExecStart=/usr/bin/mongod",
-                "--bind_ip",
-                "localhost,1.1.1.1",
+                "--bind_ip_all",
                 "--replSet",
                 "my_repl_set",
                 "--auth",
@@ -42,8 +41,7 @@ class TestCharm(unittest.TestCase):
             [
                 "ExecStart=/usr/bin/mongod",
                 # bind to localhost and external interfaces
-                "--bind_ip",
-                "localhost,1.1.1.1",
+                "--bind_ip_all",
                 # part of replicaset
                 "--replSet",
                 "my_repl_set",


### PR DESCRIPTION
### For the Reader
This is the first PR in a series of PRs, next PRs will cover Integration tests, update in README

### Problem
<!-- What problem is this PR trying to solve? -->
When the network fails on a unit and comes back up as a different IP this address is not in the cluster and thus `mongod` will not consider it a replica.

### Solution
<!-- A summary of the solution addressing the above problem -->
1. First change the start of `mongod` from `--bind_ip <unit address>` to `--bind_ip_all`, this means when a unit comes back up we do not need to reconfigure and restart the `mongod` service with a new IP address
2. Allow the leader to reconfigure the replica set in `update_status` event handler. In the case that a non-leader looses connection the leader unit will receive a `relation changed event` and update the replica set as necessary. But if the leader is the one that receives a network cut it will need to check for this change in `update_status` when it comes back up

### Release notes:
1. Updated to use `--bind_ip_all`
2. Updated `update_status` to do any reconfigure
3. `update_status` now outputs more verbose status messges.

### Testing
<!-- A digestable summary of the change in this PR -->
1. Unit tests here check the status message of the unit, this is typically considered poor practice in unit tests. However I have the opinion that status messages should be checked in the case of testing the update status hook



