### PR TITLE
DPE-781 Run integration tests for passed lint/unit tests only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         run: python3 -m pip install tox
       - name: Run linters
         run: tox -e lint
+
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -26,8 +27,12 @@ jobs:
         run: python -m pip install tox
       - name: Run tests
         run: tox -e unit
+
   charm-integration-test-lxd:
     name: Charm integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,8 +43,12 @@ jobs:
           provider: lxd
       - name: Run charm integration tests
         run: tox -e charm-integration
+
   ha-integration-test-lxd:
     name: HA integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -50,8 +59,12 @@ jobs:
           provider: lxd
       - name: Run ha integration tests
         run: tox -e ha-integration
+
   relation-integration-test-lxd:
     name: Relation integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,8 +75,12 @@ jobs:
           provider: lxd
       - name: Run relation integration tests
         run: tox -e relation-integration
+
   tls-integration-test-lxd:
     name: TLS integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,10 @@ jobs:
 
   integration-test-lxd:
     name: Integration tests (lxd)
+    needs:
+      - lib-check
+      - lint
+      - unit-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Avoid a long-running integration test in case of failing gatekeeping tests. It will slightly increase the complete tests scope runtime but will save (a lot?) of electricity/money for Canonical as often new pull requests have some initial typos/issues to be polished.