### PR TITLE
fix flakey relation test 

### DIFF
--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -108,10 +108,10 @@ async def get_password(ops_test: OpsTest, app) -> str:
     return action.results["admin-password"]
 
 
-async def fetch_primary(replica_set_hosts: List[str], ops_test: OpsTest) -> str:
+async def fetch_primary(replica_set_hosts: List[str], ops_test: OpsTest, app=None) -> str:
     """Returns IP address of current replica set primary."""
     # connect to MongoDB client
-    app = await app_name(ops_test)
+    app = app or await app_name(ops_test)
     password = await get_password(ops_test, app)
     client = replica_set_client(replica_set_hosts, password, app)
 
@@ -166,14 +166,15 @@ async def count_primaries(ops_test: OpsTest) -> int:
     wait=wait_exponential(multiplier=1, min=2, max=30),
 )
 async def replica_set_primary(
-    replica_set_hosts: List[str], ops_test: OpsTest, return_name=False
+    replica_set_hosts: List[str], ops_test: OpsTest, return_name=False, app=None
 ) -> str:
     """Returns the primary of the replica set.
 
     Retrying 5 times to give the replica set time to elect a new primary, also checks against the
     valid_ips to verify that the primary is not outdated.
     """
-    primary_ip = await fetch_primary(replica_set_hosts, ops_test)
+    app = app or await app_name(ops_test)
+    primary_ip = await fetch_primary(replica_set_hosts, ops_test, app)
     # return None if primary is no longer in the replica set
     if primary_ip is not None and primary_ip not in replica_set_hosts:
         return None

--- a/tests/integration/relation_tests/new_relations/application-charm/metadata.yaml
+++ b/tests/integration/relation_tests/new_relations/application-charm/metadata.yaml
@@ -6,6 +6,8 @@ description: |
 summary: |
   Data platform libs application meant to be used
   only for testing of the libs in this repository.
+series:
+  - focal
 
 requires:
   first-database:

--- a/tests/integration/relation_tests/new_relations/helpers.py
+++ b/tests/integration/relation_tests/new_relations/helpers.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import yaml
 from pytest_operator.plugin import OpsTest
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 
 async def get_application_relation_data(
@@ -62,3 +63,37 @@ async def get_application_relation_data(
         )
 
     return relation_data[0]["application-data"].get(key)
+
+
+async def verify_application_data(
+    ops_test: OpsTest,
+    application_name: str,
+    database_app: str,
+    relation_name: str,
+) -> bool:
+    """Verifies the application relation metadata matches with the MongoDB deployment.
+
+    Specifically, it verifies that all units are present in the URI and that there are no
+    additional units
+    """
+    try:
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3)):
+            with attempt:
+                endpoints_str = await get_application_relation_data(
+                    ops_test, application_name, relation_name, "endpoints"
+                )
+                for unit in ops_test.model.applications[database_app].units:
+                    if unit.public_address not in endpoints_str:
+                        raise Exception(f"unit {unit.name} not present in connection URI")
+
+                if len(endpoints_str.split(",")) != len(
+                    ops_test.model.applications[database_app].units
+                ):
+                    raise Exception(
+                        "number of endpoints in replicaset URI do not match number of units"
+                    )
+
+    except RetryError:
+        return False
+
+    return True

--- a/tests/integration/relation_tests/new_relations/test_charm_relations.py
+++ b/tests/integration/relation_tests/new_relations/test_charm_relations.py
@@ -14,6 +14,7 @@ from tenacity import RetryError
 from tests.integration.ha_tests.helpers import replica_set_primary
 from tests.integration.relation_tests.new_relations.helpers import (
     get_application_relation_data,
+    verify_application_data,
 )
 
 APPLICATION_APP_NAME = "application"
@@ -98,63 +99,57 @@ async def test_database_relation_with_charm_libraries(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_app_relation_metadata_change(ops_test: OpsTest) -> None:
     """Verifies that the app metadata changes with db relation joined and departed events."""
-    endpoints_str = await get_application_relation_data(
-        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "endpoints"
-    )
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
-        assert (
-            unit.public_address in endpoints_str
-        ), f"unit {unit.name} not present in connection URI"
+    # verify application metadata is correct before adding/removing units.
+    try:
+        await verify_application_data(
+            ops_test, APPLICATION_APP_NAME, DATABASE_APP_NAME, FIRST_DATABASE_RELATION_NAME
+        )
+    except RetryError:
+        assert False, "Hosts are not correct in application data."
 
-    assert len(endpoints_str.split(",")) == len(
-        ops_test.model.applications[DATABASE_APP_NAME].units
-    ), "number of endpoints in replicaset URI do not match number of units"
-
+    # verify application metadata is correct after adding units.
     await ops_test.model.applications[DATABASE_APP_NAME].add_units(count=2)
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME], status="active", timeout=1000, wait_for_exact_units=4
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=APP_NAMES,
+            status="active",
+            timeout=1000,
+        )
+    try:
+        await verify_application_data(
+            ops_test, APPLICATION_APP_NAME, DATABASE_APP_NAME, FIRST_DATABASE_RELATION_NAME
+        )
+    except RetryError:
+        assert False, "Hosts not updated in application data after adding units."
 
-    endpoints_str = await get_application_relation_data(
-        ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "endpoints"
-    )
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
-        assert (
-            unit.public_address in endpoints_str
-        ), f"unit {unit.name} not present in connection URI after adding units"
-
-    assert len(endpoints_str.split(",")) == len(
-        ops_test.model.applications[DATABASE_APP_NAME].units
-    ), "number of endpoints in replicaset URI do not match number of units after adding units"
-
+    # verify application metadata is correct after removing units.
     await ops_test.model.applications[DATABASE_APP_NAME].destroy_units(
         f"{DATABASE_APP_NAME}/0", f"{DATABASE_APP_NAME}/1"
     )
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME], status="active", timeout=1000, wait_for_exact_units=2
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=APP_NAMES,
+            status="active",
+            timeout=1000,
+        )
+    try:
+        await verify_application_data(
+            ops_test, APPLICATION_APP_NAME, DATABASE_APP_NAME, FIRST_DATABASE_RELATION_NAME
+        )
+    except RetryError:
+        assert False, "Hosts not updated in application data after removing units."
 
+    # verify primary is present in hosts provided to application
     endpoints_str = await get_application_relation_data(
         ops_test, APPLICATION_APP_NAME, FIRST_DATABASE_RELATION_NAME, "endpoints"
     )
-    for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
-        assert (
-            unit.public_address in endpoints_str
-        ), f"unit {unit.name} not present in connection URI after destroying units"
-
-    assert len(endpoints_str.split(",")) == len(
-        ops_test.model.applications[DATABASE_APP_NAME].units
-    ), "number of endpoints in replicaset URI do not match number of units after destroying units"
-
-    # check that the replica set with the remaining units has a primary
     ip_addresses = endpoints_str.split(",")
     try:
-        primary = await replica_set_primary(ip_addresses, ops_test)
+        primary = await replica_set_primary(ip_addresses, ops_test, app=DATABASE_APP_NAME)
     except RetryError:
-        primary = None
+        assert False, "replica set has no primary"
 
-    # verify that the primary is not None
-    assert primary is not None, "replica set has no primary"
+    assert primary in endpoints_str.split(","), "Primary is not present in DB endpoints."
 
     # test crud operations
     connection_string = await get_application_relation_data(


### PR DESCRIPTION
### Problem
Relation test regarding metadata between application and mongoDB is flakey

### Solution
1. `replica_set_primary` is a helper for the HA tests which looks for the first MongoDB application deployed and finds the primary of that application. Since these relation tests have multiple MongoDB applications, it is not guaranteed that `replica_set_primary` will look for the primary of our desired applications. Thus we pass in an option that allows `replica_set_primary` to be run on a specific application
2. Further, some conditions need some time to be met. So we add a retry to wait for condition to be met. 

### Other
Code was also reformatted to reduce redundancy.

