### PR TITLE
Fix hanging units - "Waiting to Initialise Replica Set"

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -347,6 +347,22 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             self.unit.status = BlockedStatus("cannot have both legacy and new relations")
             return
 
+        # occassionally mongod.service will try to restart too quickly leading to systemd not
+        # being able to start the process at all. If this is the case we need to restart the
+        # process ourselves. We defer to give it time to get started before reporting its
+        # status.
+        with MongoDBConnection(self.mongodb_config, "localhost", direct=True) as direct_mongo:
+            if not direct_mongo.is_ready:
+                logger.debug("mongodb service is not ready yet, restarting.")
+                restart_mongod_service(
+                    auth=auth_enabled(),
+                    machine_ip=self._unit_ip(self.unit),
+                    config=self.mongodb_config,
+                )
+                self.unit.status = WaitingStatus("waiting for MongoDB to start")
+                event.defer()
+                return
+
         # no need to report on replica set status until initialised
         if "db_initialised" not in self.app_peer_data:
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -22,7 +22,9 @@ from charms.mongodb.v0.helpers import (
     get_create_user_cmd,
 )
 from charms.mongodb.v0.machine_helpers import (
+    auth_enabled,
     push_file_to_unit,
+    restart_mongod_service,
     start_mongod_service,
     update_mongod_service,
 )
@@ -347,7 +349,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             self.unit.status = BlockedStatus("cannot have both legacy and new relations")
             return
 
-        # occassionally mongod.service will try to restart too quickly leading to systemd not
+        # Occasionally mongod.service will try to restart too quickly leading to systemd not
         # being able to start the process at all. If this is the case we need to restart the
         # process ourselves. We defer to give it time to get started before reporting its
         # status.
@@ -359,7 +361,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                     machine_ip=self._unit_ip(self.unit),
                     config=self.mongodb_config,
                 )
-                self.unit.status = WaitingStatus("waiting for MongoDB to start")
+                self.unit.status = WaitingStatus("Waiting for MongoDB to start")
                 event.defer()
                 return
 

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -263,7 +263,7 @@ async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes) -> None:
     # deploy new cluster
     my_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(my_charm, num_units=1, application_name=ANOTHER_DATABASE_APP_NAME)
-    await ops_test.model.wait_for_idle()
+    await ops_test.model.wait_for_idle(apps=[ANOTHER_DATABASE_APP_NAME], status="active")
 
     # write data to new cluster
     ip_addresses = [


### PR DESCRIPTION
This PR is a fix for #87 

### Issue
On rare occasions in a deployment of the MongoDB charm one or more units will be failed to be added to the replica set and the leader unit will report "Waiting to Initialise Replica Set" or "Waiting to reconfigure replica set"

### Context
After reproducing this issue it was discovered that this is due to one of the replicas not having `mongod` running. When insepcting with `systemd` it seems that this is due to a failure to restart by retrying to restart too many times and then giving up.

### Solution
This check  does a fail-safe self healing in case the automated self healing from systemd fails 