### PR TITLE
Chore: update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: Tests
 on:
   pull_request:
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,10 +42,9 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
-  integration-test-lxd:
-    name: Integration tests (lxd)
+  charm-integration-test-lxd:
+    name: Charm integration tests (lxd)
     needs:
-      - lib-check
       - lint
       - unit-test
     runs-on: ubuntu-latest
@@ -56,8 +55,72 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-      - name: Run integration tests
-        run: tox -e integration
+      - name: Run charm integration tests
+        run: tox -e charm-integration
+
+  ha-integration-test-lxd:
+    name: HA integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run ha integration tests
+        run: tox -e ha-integration
+
+  relation-integration-test-lxd:
+    name: Relation integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run relation integration tests
+        run: tox -e relation-integration
+
+  legacy-relation-integration-test-lxd:
+    name: Legacay relation integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run legacy relation integration tests
+        run: tox -e legacy-integration
+
+  tls-integration-test-lxd:
+    name: TLS integration tests (lxd)
+    needs:
+      - lint
+      - unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+      - name: Run tls integration tests
+        run: tox -e tls-integration
 
   release-to-charmhub:
     name: Release to CharmHub

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,115 +20,14 @@ jobs:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      - name: Run linters
-        run: tox -e lint
-
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Run tests
-        run: tox -e unit
-
-  charm-integration-test-lxd:
-    name: Charm integration tests (lxd)
-    needs:
-      - lint
-      - unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run charm integration tests
-        run: tox -e charm-integration
-
-  ha-integration-test-lxd:
-    name: HA integration tests (lxd)
-    needs:
-      - lint
-      - unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run ha integration tests
-        run: tox -e ha-integration
-
-  relation-integration-test-lxd:
-    name: Relation integration tests (lxd)
-    needs:
-      - lint
-      - unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run relation integration tests
-        run: tox -e relation-integration
-
-  legacy-relation-integration-test-lxd:
-    name: Legacay relation integration tests (lxd)
-    needs:
-      - lint
-      - unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run legacy relation integration tests
-        run: tox -e legacy-integration
-
-  tls-integration-test-lxd:
-    name: TLS integration tests (lxd)
-    needs:
-      - lint
-      - unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: lxd
-      - name: Run tls integration tests
-        run: tox -e tls-integration
+  ci-tests:
+    uses: ./.github/workflows/ci.yaml
 
   release-to-charmhub:
     name: Release to CharmHub
     needs:
       - lib-check
-      - lint
-      - unit-test
-      - integration-test-lxd
+      - ci-tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -19,7 +19,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 # path to store mongodb ketFile

--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -29,7 +29,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # path to store mongodb ketFile
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v0/mongodb_provider.py
+++ b/lib/charms/mongodb/v0/mongodb_provider.py
@@ -29,7 +29,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
 

--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb/v0/mongodb_vm_legacy_provider.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
 


### PR DESCRIPTION
Four changes:
1. update lib patch
2. change `main.yaml` to `ci` , `ci` is a more descriptive name
3. update `ci` to no longer run on merge to main, `release.yaml` already does this and this saves us extra computation
4. 4. parallelize `release` workflow for faster runs