### PR TITLE
ci: update charming-actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,11 +20,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Select charmhub channel
-        uses: canonical/charming-actions/upload-charm@2.1.1
-        id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc
+        uses: canonical/charming-actions/upload-charm@2.1.1
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Talking to @taurus-forever about the recently merged change, I noticed that we didn't bump the actual upload action, and also that we weren't actually using the `charming-actions/channel` action.