### PR TITLE
ci: inherit secrets properly in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: Tests
 on:
   pull_request:
   workflow_call:
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
 
 jobs:
   lint:


### PR DESCRIPTION
when using workflow_call, secrets used must be explicitly included or they will not be passed from the calling workflow, causing the workflow to ultimately fail.