### PR TITLE
Network HA test fix

### DIFF
--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -768,7 +768,7 @@ def instance_ip(model: str, instance: str) -> str:
             return line.split()[2]
 
 
-@retry(stop=stop_after_attempt(15), wait=wait_fixed(15))
+@retry(stop=stop_after_attempt(30), wait=wait_fixed(15))
 def wait_network_restore(model_name: str, hostname: str, old_ip: str) -> None:
     """Wait until network is restored.
 

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -584,6 +584,7 @@ async def test_network_cut(ops_test, continuous_writes):
     model_name = ops_test.model.info.name
 
     primary_hostname = await helpers.unit_hostname(ops_test, primary.name)
+    primary_unit_ip = await helpers.get_unit_ip(ops_test, primary.name)
 
     # before cutting network verify that connection is possible
     assert await helpers.mongod_ready(
@@ -629,7 +630,7 @@ async def test_network_cut(ops_test, continuous_writes):
     helpers.restore_network_for_unit(primary_hostname)
 
     # wait until network is reestablished for the unit
-    helpers.wait_network_restore(model_name, primary_hostname, primary.public_address)
+    helpers.wait_network_restore(model_name, primary_hostname, primary_unit_ip)
 
     # self healing is performed with update status hook
     async with ops_test.fast_forward():


### PR DESCRIPTION
## Problem
Network HA test consisentently fails to verify that the host has connection after restarting. (ie the host recieves a new ip address)

## Solution
Update check to use the correct IP address. And adding a longer retry period. After some observing it was clear that the ip addresses get updated (as expected) but this requires a longer period

## Context
Juju had issues on how it reports IP address so a workaround is needed