### PR TITLE
BUG update base

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Release to CharmHub
     needs:
       - ci-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # todo update to latest after changing to snap install
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Bug Description

From CI logs:
Run canonical/charming-actions/upload-charm@2.1.1
```shell
/usr/bin/sudo snap install charmcraft --classic --channel latest/stable
charmcraft 2.1.0 from Canonical** installed
/usr/bin/sudo charmcraft pack --destructive-mode --quiet
No suitable 'build-on' environment found in any 'bases' configuration.
```

Note that the difference between the CI runs is:
Last passing runs on Ubuntu 20.04.5 LTS
First failing runs on Ubuntu 22.04.1 LTS

(CI job `runs-on: ubuntu-latest`)

### Context
The way in which we install MongoDB is not suitable for 22.04, considering that we will install this later with a snap and it should work on 22.04, we will hold the release script to  20.04 for the time being. Once the snap is added we can change the release to latest and update the charmcraft yaml to use 22.04 as the base

### Solution
Hold release to 20.04