### PR TITLE
charm creates the PBM user which is needed for backups

### DIFF
--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -306,6 +306,16 @@ class MongoDBConnection:
             pwd=password,
         )
 
+    def create_role(self, role_name: str, privileges: dict, roles: dict = None):
+        """Creates a new role.
+
+        Args:
+            role_name: name of the role to be added.
+            privileges: privledges to be associated with the role.
+            roles: List of roles from which this role inherits privileges.
+        """
+        self.client.admin.command("createRole", role_name, privileges=[privileges], roles=[roles])
+
     @staticmethod
     def _get_roles(config: MongoDBConfiguration) -> List[dict]:
         """Generate roles List."""
@@ -314,6 +324,13 @@ class MongoDBConnection:
                 {"role": "userAdminAnyDatabase", "db": "admin"},
                 {"role": "readWriteAnyDatabase", "db": "admin"},
                 {"role": "userAdmin", "db": "admin"},
+            ],
+            "pbm": [
+                {"db": "admin", "role": "readWrite", "collection": ""},
+                {"db": "admin", "role": "backup"},
+                {"db": "admin", "role": "clusterMonitor"},
+                {"db": "admin", "role": "restore"},
+                {"db": "admin", "role": "pbmAnyAction"},
             ],
             "default": [
                 {"role": "readWrite", "db": config.database},

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -1,0 +1,99 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In this class, we manage client database relations.
+
+This class creates a user and database for each application relation
+and expose needed information for client connection via fields in
+external relation.
+"""
+import logging
+
+from charms.mongodb.v0.helpers import generate_password
+from charms.mongodb.v0.mongodb import MongoDBConfiguration, MongoDBConnection
+from charms.operator_libs_linux.v1 import snap
+from ops.framework import Object
+
+# The unique Charmhub library identifier, never change it
+LIBID = "asdfl29130831jkh20apj09q1dkos0"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 0
+
+logger = logging.getLogger(__name__)
+
+
+PBM_S3_CONFIGS = [
+    ("storage.s3.region", "s3-storage-region"),
+    ("storage.s3.bucket", "s3-storage-bucket"),
+    ("storage.s3.prefix", "s3-storage-prefix"),
+    ("storage.s3.credentials.access-key-id", "s3-access-key-id"),
+    ("storage.s3.credentials.secret-access-key", "s3-secret-access-key"),
+    ("storage.s3.serverSideEncryption.kmsKeyID", "s3-kms-key-id"),
+]
+
+PBM_PRIVILEGES = {"resource": {"anyResource": True}, "actions": ["anyAction"]}
+
+
+class MongoDBBackups(Object):
+    """In this class, we manage client database relations."""
+
+    def __init__(self, charm, substrate="k8s"):
+        """Manager of MongoDB client relations."""
+        super().__init__(charm, "client-relations")
+        self.charm = charm
+        self.substrate = substrate
+        self.framework.observe(self.charm.on.config_changed, self._on_pbm_config_changed)
+
+    def _on_pbm_config_changed(self, event) -> None:
+        """Handles PBM configurations."""
+        # handling PBM configurations requires that the pbm snap is installed.
+        if "db_initialised" not in self.charm.app_peer_data:
+            logger.debug("Cannot set PBM configurations, MongoDB has not yet started.")
+            event.defer()
+            return
+
+        snap_cache = snap.SnapCache()
+        pbm_snap = snap_cache["percona-backup-mongodb"]
+
+        if not pbm_snap.present:
+            logger.debug("Cannot set PBM configurations, PBM snap is not yet installed.")
+            event.defer()
+            return
+
+        if not "pbm_user_created" not in self.charm.app_peer_data:
+            self.create_pbm_user()
+
+        # TODO handle PBM configurations set by the user
+
+    def create_pbm_user(self):
+        """Creates the PBM user on the MongoDB database."""
+        with MongoDBConnection(self.charm.mongodb_config) as mongo:
+            # first we must create the necessary roles for PBM
+            logger.debug("creating the PBM user roles...")
+            mongo.create_role(role_name="pbmAnyAction", privileges=PBM_PRIVILEGES)
+            logger.debug("creating the PBM user...")
+            mongo.create_user(self._pbm_config())
+
+            self.charm.app_peer_data["pbm_user_created"] = "True"
+
+    @property
+    def _pbm_config(self) -> MongoDBConfiguration:
+        """Construct the config object for pbm user and creates user if necessary."""
+        if not self.charm.get_secret("app", "pbm_password"):
+            self.charm.set_secret("app", "pbm_password", generate_password())
+
+        return MongoDBConfiguration(
+            replset=self.charm.app.name,
+            database="admin",
+            username="pbmuser",
+            password=self.charm.get_secret("app", "pbm_password"),
+            hosts=self.charm.mongodb_config.hosts,
+            roles="pbm",
+            tls_external=self.charm.tls.get_tls_files("unit") is not None,
+            tls_internal=self.charm.tls.get_tls_files("unit") is not None,
+        )

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,6 +28,7 @@ from charms.mongodb.v0.mongodb import (
     NotReadyError,
     PyMongoError,
 )
+from charms.mongodb.v0.mongodb_backups import MongoDBBackups
 from charms.mongodb.v0.mongodb_provider import MongoDBProvider
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.mongodb_vm_legacy_provider import MongoDBLegacyProvider
@@ -79,7 +80,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self._port = MONGODB_PORT
 
         self.framework.observe(self.on.install, self._on_install)
-        self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
         self.framework.observe(self.on[PEER].relation_joined, self._on_mongodb_relation_joined)
         self.framework.observe(self.on[PEER].relation_changed, self._on_mongodb_relation_handler)
@@ -101,6 +101,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         self.client_relations = MongoDBProvider(self, substrate="vm")
         self.legacy_client_relations = MongoDBLegacyProvider(self)
         self.tls = MongoDBTLS(self, PEER, substrate="vm")
+        self.backups = MongoDBBackups(self)
 
     def _generate_passwords(self) -> None:
         """Generate passwords and put them into peer relation.
@@ -294,13 +295,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         update_mongod_service(
             auth=auth, machine_ip=self._unit_ip(self.unit), config=self.mongodb_config
         )
-
-    def _on_config_changed(self, _) -> None:
-        """Event handler for configuration changed events."""
-        # TODO
-        # - update existing mongo configurations based on user preferences
-        # - add additional configurations as according to spec doc
-        pass
 
     def _on_start(self, event: ops.charm.StartEvent) -> None:
         """Enables MongoDB service and initialises replica set.


### PR DESCRIPTION
## Summary
For the reader, creating backups requires a bit of necessary infrastructure. The first step is to create the PBM user which is needed for backups. 

## Context
Backups for Charmed MongoDB make use of [PBM](https://docs.percona.com/percona-backup-mongodb/index.html). For this package to work correctly and to make backups a user needs to exist on the MongoDB database

## Future PRs
As mentioned this is the first PR of several to get the backup action up and running. The rest are:
- Configuration options for PBM configurations in S3 storage
- Implement the backup action
- Add unit tests
- Integration tests