### PR TITLE
correct removal retry

### DIFF
--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -242,15 +242,13 @@ class MongoDBConnection:
         self.client.admin.command("replSetReconfig", rs_config["config"])
 
     @retry(
-        stop=stop_after_attempt(120),
-        wait=wait_fixed(5),
+        stop=stop_after_attempt(20),
+        wait=wait_fixed(3),
         reraise=True,
         before=before_log(logger, logging.DEBUG),
     )
     def remove_replset_member(self, hostname: str) -> None:
         """Remove member from replica set config inside MongoDB.
-
-        Retries up to ten minutes when failure occurs during removal.
 
         Raises:
             ConfigurationError, ConfigurationError, OperationFailure, NotReadyError

--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -263,8 +263,7 @@ class MongoDBConnection:
             # before giving up.
             raise NotReadyError
 
-        # avoid downtime we need to reelect new primary
-        # if removable member is the primary.
+        # avoid downtime we need to reelect new primary if removable member is the primary.
         logger.debug("primary: %r", self._is_primary(rs_status, hostname))
         if self._is_primary(rs_status, hostname):
             self.client.admin.command("replSetStepDown", {"stepDownSecs": "60"})

--- a/src/charm.py
+++ b/src/charm.py
@@ -146,6 +146,14 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         If the removing unit is primary also allow it to step down and elect another unit as
         primary while it still has access to its storage.
         """
+        # if we are removing the last replica it will not be able to step down as primary and we
+        # cannot reconfigure the replica set to have 0 members. To prevent retrying for 10 minutes
+        # set this flag to True. please note that planned_units will always be >=1. When planned
+        # units is 1 that means there are no other peers expected.
+        single_node_replica_set = self.app.planned_units() == 1 and len(self._peers.units) == 0
+        if single_node_replica_set:
+            return
+
         try:
             # retries over a period of 10 minutes in an attempt to resolve race conditions it is
             # not possible to defer in storage detached.

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,7 +43,7 @@ from ops.model import (
     Relation,
     WaitingStatus,
 )
-from tenacity import before_log, retry, stop_after_attempt, wait_fixed
+from tenacity import Retrying, before_log, retry, stop_after_attempt, wait_fixed
 
 from machine_helpers import (
     MONGOD_SERVICE_DEFAULT_PATH,
@@ -147,11 +147,18 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         primary while it still has access to its storage.
         """
         try:
-            # remove_replset_member retries for ten minutes in an attempt to resolve race
-            # conditions it is not possible to defer in storage detached.
-            with MongoDBConnection(self.mongodb_config) as mongo:
-                logger.debug("Removing %s from replica set", self._unit_ip(self.unit))
-                mongo.remove_replset_member(self._unit_ip(self.unit))
+            # retries over a period of 10 minutes in an attempt to resolve race conditions it is
+            # not possible to defer in storage detached.
+            logger.debug("Removing %s from replica set", self._unit_ip(self.unit))
+            for attempt in Retrying(
+                stop=stop_after_attempt(10),
+                wait=wait_fixed(1),
+                reraise=True,
+            ):
+                with attempt:
+                    # remove_replset_member retries for 60 seconds
+                    with MongoDBConnection(self.mongodb_config) as mongo:
+                        mongo.remove_replset_member(self._unit_ip(self.unit))
         except NotReadyError:
             logger.info(
                 "Failed to remove %s from replica set, another member is syncing", self.unit.name
@@ -356,6 +363,8 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             if not direct_mongo.is_ready:
                 logger.debug("mongodb service is not ready yet, restarting.")
                 self.restart_mongod_service()
+                # ensure that the correct port is open for the service
+                self._open_port_tcp(self._port)
                 self.unit.status = WaitingStatus("Waiting for MongoDB to start")
                 event.defer()
                 return

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,6 +10,7 @@ from charms.operator_libs_linux.v1 import snap, systemd
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
+from tenacity import stop_after_attempt
 
 from charm import MongodbOperatorCharm, NotReadyError, URLError, apt, subprocess
 from tests.unit.helpers import patch_network_get
@@ -621,7 +622,8 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongodbOperatorCharm.restart_mongod_service")
-    def test_update_status_not_ready(self, restart, connection):
+    @patch("charm.MongodbOperatorCharm._open_port_tcp")
+    def test_update_status_not_ready(self, tcp, restart, connection):
         """Tests that if mongod is not running on this unit it restarts it."""
         connection.return_value.__enter__.return_value.is_ready = False
 
@@ -687,14 +689,18 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
-    def test_storage_detaching_failure_does_not_defer(self, connection):
+    @patch("charm.stop_after_attempt")
+    def test_storage_detaching_failure_does_not_defer(self, retry_stop, connection):
         """Test that failure in removing replica does not defer the hook.
 
         Deferring Storage Detached hooks can result in un-predicable behavior and while it is
         technically possible to defer the event, it shouldn't be. This test verifies that no
         attempt to defer storage detached as made.
         """
-        for exception in [PYMONGO_EXCEPTIONS, NotReadyError]:
+        retry_stop.return_value = stop_after_attempt(1)
+        exceptions = PYMONGO_EXCEPTIONS
+        exceptions.append(NotReadyError)
+        for exception in exceptions:
             connection.return_value.__enter__.return_value.remove_replset_member.side_effect = (
                 exception
             )


### PR DESCRIPTION
## Problem
1. The PR #159 was misguided. When the retry period was added for `remove_replset_member ` that meant other calling functions would also have a timeout of 10 minutes. Meaning that when a unit scales from 1 unit to 0, instead of waiting 10 minutes, it would wait 20 minutes since `remove_replset_member` gets called **twice** in the removal sequence. 
2. Removing an entire replica set hangs. This is because you cannot step down a primary in a single node replica set and you cannot configure a replica set to have 0 nodes

## Solution
1. Move the long timeout period to `storage_detached`
2. Do not attempt to step down primary or reconfigure to a 0 node replica set if the entire replica set is getting removed.