### PR TITLE
release workflow now passes creds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,14 @@ on:
     secrets:
       CHARMHUB_TOKEN:
         required: true
+      AWS_ACCESS_KEY:
+        required: true
+      AWS_SECRET_KEY:
+        required: true
+      GCP_ACCESS_KEY:
+        required: true
+      GCP_SECRET_KEY:
+        required: true
 
 jobs:
   lint:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     secrets:
       CHARMHUB_TOKEN: "${{ secrets.CHARMHUB_TOKEN }}"
+      AWS_ACCESS_KEY: "${{ secrets.AWS_ACCESS_KEY }}"
+      AWS_SECRET_KEY: "${{ secrets.AWS_SECRET_KEY }}"
+      GCP_ACCESS_KEY: "${{ secrets.GCP_ACCESS_KEY }}"
+      GCP_SECRET_KEY: "${{ secrets.GCP_SECRET_KEY }}"
 
   release-to-charmhub:
     name: Release to CharmHub

--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -139,7 +139,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -249,6 +249,41 @@ class S3Provider(Object):
             except (json.decoder.JSONDecodeError, TypeError):
                 connection_data[key] = raw_relation_data[key]
         return connection_data
+
+    # def _diff(self, event: RelationChangedEvent) -> Diff:
+    #     """Retrieves the diff of the data in the relation changed databag.
+
+    #     Args:
+    #         event: relation changed event.
+
+    #     Returns:
+    #         a Diff instance containing the added, deleted and changed
+    #             keys from the event relation databag.
+    #     """
+    #     # Retrieve the old data from the data key in the application relation databag.
+    #     old_data = json.loads(event.relation.data[self.local_app].get("data", "{}"))
+    #     # Retrieve the new data from the event relation databag.
+    #     new_data = {
+    #         key: value for key, value in event.relation.data[event.app].items() if key != "data"
+    #     }
+
+    #     # These are the keys that were added to the databag and triggered this event.
+    #     added = new_data.keys() - old_data.keys()
+    #     # These are the keys that were removed from the databag and triggered this event.
+    #     deleted = old_data.keys() - new_data.keys()
+    #     # These are the keys that already existed in the databag,
+    #     # but had their values changed.
+    #     changed = {
+    #         key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]
+    #     }
+
+    #     # TODO: evaluate the possibility of losing the diff if some error
+    #     # happens in the charm before the diff is completely checked (DPE-412).
+    #     # Convert the new_data to a serializable format and save it for a next diff check.
+    #     event.relation.data[self.local_app].update({"data": json.dumps(new_data)})
+
+    #     # Return the diff with all possible changes.
+    #     return Diff(added, changed, deleted)
 
     def _diff(self, event: RelationChangedEvent) -> Diff:
         """Retrieves the diff of the data in the relation changed databag.

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,7 +60,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 class SystemdError(Exception):
@@ -131,7 +131,7 @@ def service_running(service_name: str) -> bool:
     """Determine whether a system service is running.
 
     Args:
-        service_name: the name of the service
+        service_name: the name of the service to check
     """
     return _systemctl("is-active", service_name, quiet=True)
 
@@ -140,7 +140,7 @@ def service_start(service_name: str) -> bool:
     """Start a system service.
 
     Args:
-        service_name: the name of the service to stop
+        service_name: the name of the service to start
     """
     return _systemctl("start", service_name)
 


### PR DESCRIPTION
## Problem:
Release workflow does not [pass credentials needed for the backup integration tests](https://github.com/canonical/mongodb-operator/actions/runs/4251129245/jobs/7393101693)

## Solution:
pass the credentials