### PR TITLE
Enable 'fail-build' for check-libraries action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,7 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          fail-build: true
 
   build:
     name: Build charms


### PR DESCRIPTION
### Problem
We are shaning shared libraries without proper LIBPATCH bumping.
As a result changes are not published to charmhub.io store and not shared properly, it affects further libs update issues:

Exampl:
> Library charms.mongodb.v0.helpers has local changes, cannot be updated.
> Library charms.mongodb.v0.mongodb_backups has local changes, cannot be updated.
> Library charms.mongodb.v0.mongodb_vm_legacy_provider has local changes, cannot be updated.

### Solution
The GitHub action `check-libraries` should notice such cases are report Author about forgotten LIBPATCH bump.

### Testing
Testing here in this PR. It should fail until this [PR comment](https://github.com/canonical/mongodb-operator/pull/176#discussion_r1130678873) is addressed merged.

### Release Notes
Not necessary.