### PR TITLE
set lib patch to correct vs

### DIFF
--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -19,7 +19,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 4
 
 
 # path to store mongodb ketFile

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -43,7 +43,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb/v0/mongodb_vm_legacy_provider.py
@@ -21,7 +21,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 3
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
 


### PR DESCRIPTION
### Problem
<!-- What issue is this PR trying to solve? -->
lib patch versions were incorrectly updated (i.e. lib patch was too high) [release CI reported](https://github.com/canonical/mongodb-operator/actions/runs/4414747786/jobs/7738041500):
```
Library charms.mongodb.v0.mongodb_vm_legacy_provider has a wrong LIBPATCH number, it's too high and needs to be consecutive, Charmhub highest version is 0.2.
Library charms.mongodb.v0.mongodb_backups has a wrong LIBPATCH number, it's too high and needs to be consecutive, Charmhub highest version is 0.1.
Library charms.mongodb.v0.helpers has a wrong LIBPATCH number, it's too high and needs to be consecutive, Charmhub highest version is 0.3.
```

### Solution
<!-- A summary of the solution addressing the above issue -->
Put the lib patch to a correct number
