### PR TITLE
Update pbm uri

### DIFF
--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -101,7 +101,7 @@ class MongoDBBackups(Object):
             logger.debug("Cannot update pbm-uri, backup configurations do not exist.")
             return
 
-        if not self._get_pbm_status() == ActiveStatus:
+        if self._get_pbm_status() != ActiveStatus:
             logger.debug("Cannot update pbm-uri, pbm is busy.")
             raise PBMBusyError
 

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -92,7 +92,7 @@ class MongoDBBackups(Object):
 
     def update_pbm_uri(self) -> None:
         """Updates the URI used by the pbm tool if possible."""
-        if S3_RELATION not in self.charm.model.relations:
+        if self.charm.model.get_relation(S3_RELATION) is None:
             logger.debug("Cannot update pbm-uri, backup configurations do not exist.")
             return
 

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -92,7 +92,7 @@ class MongoDBBackups(Object):
 
     def update_pbm_uri(self) -> None:
         """Updates the URI used by the pbm tool if possible."""
-        if self.charm.model.get_relation(S3_RELATION) is None:
+        if self.charm.model.relations.get(S3_RELATION) == []:
             logger.debug("Cannot update pbm-uri, backup configurations do not exist.")
             return
 

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -92,7 +92,7 @@ class MongoDBBackups(Object):
 
     def update_pbm_uri(self) -> None:
         """Updates the URI used by the pbm tool if possible."""
-        if self.charm.model.relations.get(S3_RELATION) == []:
+        if not self.charm.model.relations.get(S3_RELATION):
             logger.debug("Cannot update pbm-uri, backup configurations do not exist.")
             return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cffi==1.15.1
 importlib-resources==5.10.2
 tenacity==8.1.0
 pymongo==4.3.3
-ops==2.0.0
+ops==2.1.1
 jsonschema==4.17.3
 cryptography==38.0.4
 pure-sasl==0.6.2

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,7 @@ from charms.mongodb.v0.mongodb import (
     NotReadyError,
     PyMongoError,
 )
-from charms.mongodb.v0.mongodb_backups import PBMBusyError, S3_RELATION, MongoDBBackups
+from charms.mongodb.v0.mongodb_backups import S3_RELATION, MongoDBBackups, PBMBusyError
 from charms.mongodb.v0.mongodb_provider import MongoDBProvider
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.mongodb_vm_legacy_provider import MongoDBLegacyProvider

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,7 @@ from charms.mongodb.v0.mongodb import (
     NotReadyError,
     PyMongoError,
 )
-from charms.mongodb.v0.mongodb_backups import S3_RELATION, MongoDBBackups
+from charms.mongodb.v0.mongodb_backups import PBMBusyError, S3_RELATION, MongoDBBackups
 from charms.mongodb.v0.mongodb_provider import MongoDBProvider
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.mongodb_vm_legacy_provider import MongoDBLegacyProvider
@@ -121,11 +121,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self._update_hosts(event)
 
-        # app relations should be made aware of the new set of hosts
+        # app relations and backup configurations should be made aware of the new set of hosts
         try:
             self.update_app_relation_data()
+            self.backups.update_pbm_uri()
         except PyMongoError as e:
             logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
+        except PBMBusyError as e:
+            logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
 
@@ -203,11 +208,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self._update_hosts(event)
 
-        # app relations should be made aware of the new set of hosts
+        # app relations and backup configurations should be made aware of the new set of hosts
         try:
             self.update_app_relation_data()
+            self.backups.update_pbm_uri()
         except PyMongoError as e:
             logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
+        except PBMBusyError as e:
+            logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
 
@@ -237,11 +247,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
         self._on_mongodb_relation_handler(event)
 
-        # app relations should be made aware of the new set of hosts
+        # app relations and backup configurations should be made aware of the new set of hosts
         try:
             self.update_app_relation_data()
+            self.backups.update_pbm_uri()
         except PyMongoError as e:
             logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
+        except PBMBusyError as e:
+            logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
 
@@ -418,11 +433,16 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         event.unit = self.unit
         self._on_mongodb_relation_handler(event)
 
-        # app relations should be made aware of the new set of hosts
+        # app relations and backup configurations should be made aware of the new set of hosts
         try:
             self.update_app_relation_data()
+            self.backups.update_pbm_uri()
         except PyMongoError as e:
             logger.error("Deferring on updating app relation data since: error: %r", e)
+            event.defer()
+            return
+        except PBMBusyError as e:
+            logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -27,7 +27,12 @@ from charms.mongodb.v0.mongodb import (
     NotReadyError,
     PyMongoError,
 )
-from charms.mongodb.v0.mongodb_backups import S3_RELATION, MongoDBBackups, PBMBusyError
+from charms.mongodb.v0.mongodb_backups import (
+    S3_RELATION,
+    MongoDBBackups,
+    PBMBusyError,
+    SetPBMConfigError,
+)
 from charms.mongodb.v0.mongodb_provider import MongoDBProvider
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
 from charms.mongodb.v0.mongodb_vm_legacy_provider import MongoDBLegacyProvider
@@ -129,7 +134,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             logger.error("Deferring on updating app relation data since: error: %r", e)
             event.defer()
             return
-        except PBMBusyError as e:
+        except (PBMBusyError, SetPBMConfigError) as e:
             logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
@@ -216,7 +221,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             logger.error("Deferring on updating app relation data since: error: %r", e)
             event.defer()
             return
-        except PBMBusyError as e:
+        except (PBMBusyError, SetPBMConfigError) as e:
             logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
@@ -255,7 +260,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             logger.error("Deferring on updating app relation data since: error: %r", e)
             event.defer()
             return
-        except PBMBusyError as e:
+        except (PBMBusyError, SetPBMConfigError) as e:
             logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return
@@ -441,7 +446,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             logger.error("Deferring on updating app relation data since: error: %r", e)
             event.defer()
             return
-        except PBMBusyError as e:
+        except (PBMBusyError, SetPBMConfigError) as e:
             logger.error("Deferring on updating pbm uri since: error: %r", e)
             event.defer()
             return

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -108,7 +108,8 @@ async def test_ready_correct_conf(ops_test: OpsTest) -> None:
     configuration_parameters = {
         "bucket": "data-charms-testing",
         "path": f"mongodb-vm/test-{unique_path}",
-        "region": "us-west-2",
+        "endpoint": "https://s3.amazonaws.com",
+        "region": "us-east-1",
     }
 
     # apply new configuration options
@@ -219,8 +220,8 @@ async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
     await helpers.set_credentials(ops_test, cloud="AWS")
     configuration_parameters = {
         "bucket": "data-charms-testing",
-        "region": "us-west-2",
-        "endpoint": "",
+        "region": "us-east-1",
+        "endpoint": "https://s3.amazonaws.com",
     }
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
     await asyncio.gather(
@@ -300,8 +301,8 @@ async def test_restore_new_cluster(ops_test: OpsTest, add_writes_to_db, cloud_pr
     if cloud_provider == "AWS":
         configuration_parameters = {
             "bucket": "data-charms-testing",
-            "region": "us-west-2",
-            "endpoint": "",
+            "region": "us-east-1",
+            "endpoint": "https://s3.amazonaws.com",
         }
     else:
         configuration_parameters = {

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -106,7 +106,7 @@ async def test_ready_correct_conf(ops_test: OpsTest) -> None:
     choices = string.ascii_letters + string.digits
     unique_path = "".join([secrets.choice(choices) for _ in range(4)])
     configuration_parameters = {
-        "bucket": "pbm-test-bucket-1",
+        "bucket": "data-charms-testing",
         "path": f"mongodb-vm/test-{unique_path}",
         "region": "us-west-2",
     }
@@ -218,7 +218,7 @@ async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
     # set AWS credentials, set configs for s3 storage, and wait to resync
     await helpers.set_credentials(ops_test, cloud="AWS")
     configuration_parameters = {
-        "bucket": "pbm-test-bucket-1",
+        "bucket": "data-charms-testing",
         "region": "us-west-2",
         "endpoint": "",
     }
@@ -299,7 +299,7 @@ async def test_restore_new_cluster(ops_test: OpsTest, add_writes_to_db, cloud_pr
     await helpers.set_credentials(ops_test, cloud=cloud_provider)
     if cloud_provider == "AWS":
         configuration_parameters = {
-            "bucket": "pbm-test-bucket-1",
+            "bucket": "data-charms-testing",
             "region": "us-west-2",
             "endpoint": "",
         }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -603,7 +603,8 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConfiguration")
     @patch("charm.subprocess.run")
-    def test_start_init_user_after_second_call(self, run, config):
+    @patch("charm.MongoDBBackups.update_pbm_uri")
+    def test_start_init_user_after_second_call(self, update_uri, run, config):
         """Tests that the creation of the admin user is only performed once.
 
         Verifies that if the user is already set up, that no attempts to set it up again are

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -35,7 +35,8 @@ class TestMongoProvider(unittest.TestCase):
 
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBProvider.oversee_users")
-    def test_relation_event_db_not_initialised(self, oversee_users, defer):
+    @patch("charm.MongoDBBackups.update_pbm_uri")
+    def test_relation_event_db_not_initialised(self, update_uri, oversee_users, defer):
         """Tests no database relations are handled until the database is initialised.
 
         Users should not be "overseen" until the database has been initialised, no matter the


### PR DESCRIPTION
### Problem
<!-- What issue is this PR trying to solve? -->
1. Uri in snap is now set with `pbm-uri` not as `uri`
2. When hosts are updated the URI that `pbm` should be updated
3. When password is rotated the URI that pbm uses should be updated

### Solution
1. Replace setting the `uri` with setting the `pbm-uri`
2. Update the hosts in the pbm uri whenever they get changed
3. When password is rotated the URI that pbm is updated

### Future PR
Will do something similar for TLS 