### PR TITLE
Running tests in parallel across multiple CPUs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,11 @@ deps =
     pytest
     requests
     coverage[toml]
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit
+        -m pytest -v --tb native -s {posargs} {[vars]tests_path}/unit -n auto
     coverage report
 
 [testenv:charm-integration]
@@ -73,9 +74,10 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/test_charm.py
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/test_charm.py -n auto
 
 [testenv:ha-integration]
 description = Run high availability integration tests
@@ -87,9 +89,10 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -vvv --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ha_tests/test_ha.py
+    pytest -vvv --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ha_tests/test_ha.py -n auto
 
 [testenv:relation-integration]
 description = Run new relation integration tests
@@ -101,9 +104,10 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/new_relations/test_charm_relations.py
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/new_relations/test_charm_relations.py -n auto
 
 [testenv:legacy-integration]
 description = Run legacy relation integration tests
@@ -115,9 +119,10 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/legacy_relations/test_charm_legacy_relations.py
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/legacy_relations/test_charm_legacy_relations.py -n auto
 
 [testenv:tls-integration]
 description = Run tls integration tests
@@ -129,9 +134,10 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/tls_tests/test_tls.py
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/tls_tests/test_tls.py -n auto
 
 
 [testenv:backup-integration]
@@ -148,9 +154,10 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/backup_tests/test_backups.py
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/backup_tests/test_backups.py -n auto
 
 
 [testenv:integration]
@@ -163,6 +170,7 @@ deps =
     pytest
     juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
     pytest-operator
+    pytest-xdist
     -r {tox_root}/requirements.txt
 commands =
-    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ -n auto


### PR DESCRIPTION
### Problem
Slow test execution.

### Solution
Running tests in parallel across multiple CPUs with [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/).