### PR TITLE
Follow up PR: update connection uri for monitoring when changes occur

### DIFF
--- a/lib/charms/operator_libs_linux/v1/snap.py
+++ b/lib/charms/operator_libs_linux/v1/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -439,8 +439,9 @@ class Snap(object):
           cohort: optionally, specify a cohort.
           leave_cohort: leave the current cohort.
         """
-        channel = '--channel="{}"'.format(channel) if channel else ""
-        args = [channel]
+        args = []
+        if channel:
+            args.append('--channel="{}"'.format(channel))
 
         if not cohort:
             cohort = self._cohort

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,7 +60,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class SystemdError(Exception):
@@ -111,16 +111,16 @@ def _systemctl(
 
     proc.wait()
 
-    if sub_cmd == "is-active":
-        # If we are just checking whether a service is running, return True/False, rather
-        # than raising an error.
-        if proc.returncode < 1:
-            return True
-        if proc.returncode == 3:  # Code returned when service is not active.
-            return False
-
     if proc.returncode < 1:
         return True
+
+    # If we are just checking whether a service is running, return True/False, rather
+    # than raising an error.
+    if sub_cmd == "is-active" and proc.returncode == 3:  # Code returned when service not active.
+        return False
+
+    if sub_cmd == "is-failed":
+        return False
 
     raise SystemdError(
         "Could not {}{}: systemd output: {}".format(
@@ -136,6 +136,15 @@ def service_running(service_name: str) -> bool:
         service_name: the name of the service to check
     """
     return _systemctl("is-active", service_name, quiet=True)
+
+
+def service_failed(service_name: str) -> bool:
+    """Determine whether a system service has failed.
+
+    Args:
+        service_name: the name of the service to check
+    """
+    return _systemctl("is-failed", service_name, quiet=True)
 
 
 def service_start(service_name: str) -> bool:

--- a/src/charm.py
+++ b/src/charm.py
@@ -277,8 +277,8 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         ):
             return
 
-        # changing the monitor password will lead to non-leader units recieving a relation changed
-        # event. We must update the monitor URI if the password changes so that COS can contiue to
+        # changing the monitor password will lead to non-leader units receiving a relation changed
+        # event. We must update the monitor URI if the password changes so that COS can continue to
         # work
         self._connect_mongodb_exporter()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -277,6 +277,11 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         ):
             return
 
+        # changing the monitor password will lead to non-leader units recieving a relation changed
+        # event. We must update the monitor URI if the password changes so that COS can contiue to
+        # work
+        self._connect_mongodb_exporter()
+
         with MongoDBConnection(self.mongodb_config) as mongo:
             try:
                 replset_members = mongo.get_replset_members()
@@ -422,6 +427,9 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         if self.unit.is_leader():
             self._handle_reconfigure(event)
 
+        # in case of a network cut and a new IP address is used we must update mongodb exporter
+        self._connect_mongodb_exporter()
+
         # update the units status based on it's replica set config and backup status. An error in
         # the status of MongoDB takes precedence over pbm status.
         mongodb_status = build_unit_status(self.mongodb_config, self._unit_ip(self.unit))
@@ -509,6 +517,9 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                 event.fail(f"Failed changing the password: {e}")
                 return
 
+        if username == "monitor":
+            self._connect_mongodb_exporter()
+
         self.set_secret("app", f"{username}-password", new_password)
         event.set_results({"password": new_password})
 
@@ -585,8 +596,22 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
 
     def _connect_mongodb_exporter(self) -> None:
         """Exposes the endpoint to mongodb_exporter."""
+        # must wait for leader to set URI before connecting
+        if not self.get_secret("app", "monitor-password"):
+            return
+
+        # avoid unnecessary restarts if the URI mongodb exporter is using is up to date.
         snap_cache = snap.SnapCache()
         mongodb_snap = snap_cache["charmed-mongodb"]
+        try:
+            if mongodb_snap.get("monitor-uri") == self.monitor_config.uri:
+                return
+        except snap.SnapError:
+            # TODO remove try/except when issue is resolved:
+            # https://github.com/canonical/operator-libs-linux/issues/87
+            # SnapError occurs when the config option `monitor-uri` is not set.
+            pass
+
         mongodb_snap.set({"monitor-uri": self.monitor_config.uri})
         mongodb_snap.restart(services=["mongodb-exporter"])
 
@@ -739,7 +764,8 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             database="",
             username="monitor",
             password=self.get_secret("app", "monitor-password"),
-            hosts=set(self._unit_ips),
+            # MongoDB Exporter can only connect to one replica - not the entire set.
+            hosts=[self._unit_ip(self.unit)],
             roles={"monitor"},
             tls_external=self.tls.get_tls_files("unit") is not None,
             tls_internal=self.tls.get_tls_files("app") is not None,

--- a/src/charm.py
+++ b/src/charm.py
@@ -517,10 +517,11 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
                 event.fail(f"Failed changing the password: {e}")
                 return
 
+        self.set_secret("app", f"{username}-password", new_password)
+
         if username == "monitor":
             self._connect_mongodb_exporter()
 
-        self.set_secret("app", f"{username}-password", new_password)
         event.set_results({"password": new_password})
 
     def _open_port_tcp(self, port: int) -> None:
@@ -765,7 +766,7 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             username="monitor",
             password=self.get_secret("app", "monitor-password"),
             # MongoDB Exporter can only connect to one replica - not the entire set.
-            hosts=[self._unit_ip(self.unit)],
+            hosts=["127.0.0.1"],
             roles={"monitor"},
             tls_external=self.tls.get_tls_files("unit") is not None,
             tls_internal=self.tls.get_tls_files("app") is not None,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -192,7 +192,8 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
-    def test_mongodb_relation_joined_all_replicas_not_ready(self, connection):
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
+    def test_mongodb_relation_joined_all_replicas_not_ready(self, _, connection):
         """Tests that we go into waiting when current ReplicaSet hosts are not ready.
 
         Tests the scenario that if current replica set hosts are not ready, the leader goes into
@@ -219,7 +220,8 @@ class TestCharm(unittest.TestCase):
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
     @patch("charms.mongodb.v0.mongodb.MongoClient")
-    def test_relation_joined_get_members_failure(self, client, connection, defer):
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
+    def test_relation_joined_get_members_failure(self, _, client, connection, defer):
         """Tests reconfigure does not execute when unable to get the replica set members.
 
         Verifies in case of relation_joined and relation departed, that when the the database
@@ -253,7 +255,8 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("ops.framework.EventBase.defer")
     @patch("charm.MongoDBConnection")
-    def test_reconfigure_add_member_failure(self, connection, defer):
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
+    def test_reconfigure_add_member_failure(self, _, connection, defer):
         """Tests reconfigure does not proceed when unable to add a member.
 
         Verifies in relation joined events, that when the database cannot add a member that the
@@ -320,8 +323,9 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
     @patch("charm.build_unit_status")
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
     def test_update_status_mongodb_error(
-        self, get_mongodb_status, get_pbm_status, connection, status_connection
+        self, _, get_mongodb_status, get_pbm_status, connection, status_connection
     ):
         """Tests that when MongoDB is not active, that is reported instead of pbm."""
         # assume leader has already initialised the replica set
@@ -354,8 +358,9 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
     @patch("charm.build_unit_status")
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
     def test_update_status_pbm_error(
-        self, get_mongodb_status, get_pbm_status, connection, status_connection
+        self, _, get_mongodb_status, get_pbm_status, connection, status_connection
     ):
         """Tests when MongoDB is active and pbm is in the error state, pbm status is reported."""
         # assume leader has already initialised the replica set
@@ -383,8 +388,9 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
     @patch("charm.build_unit_status")
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
     def test_update_status_pbm_and_mongodb_ready(
-        self, get_mongodb_status, get_pbm_status, connection, status_connection
+        self, _, get_mongodb_status, get_pbm_status, connection, status_connection
     ):
         """Tests when both Mongodb and pbm are ready that MongoDB status is reported."""
         # assume leader has already initialised the replica set
@@ -404,8 +410,9 @@ class TestCharm(unittest.TestCase):
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
     @patch("charm.build_unit_status")
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
     def test_update_status_no_s3(
-        self, get_mongodb_status, get_pbm_status, connection, status_connection
+        self, _, get_mongodb_status, get_pbm_status, connection, status_connection
     ):
         """Tests when the s3 relation isn't present that the MongoDB status is reported."""
         # assume leader has already initialised the replica set
@@ -422,7 +429,8 @@ class TestCharm(unittest.TestCase):
     @patch("charms.mongodb.v0.helpers.MongoDBConnection")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
-    def test_update_status_primary(self, pbm_status, connection, status_connection):
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
+    def test_update_status_primary(self, _, pbm_status, connection, status_connection):
         """Tests that update status identifies the primary unit and updates status."""
         # assume leader has already initialised the replica set
         self.harness.set_leader(True)
@@ -441,7 +449,8 @@ class TestCharm(unittest.TestCase):
     @patch("charms.mongodb.v0.helpers.MongoDBConnection")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
-    def test_update_status_secondary(self, pbm_status, connection, status_connection):
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
+    def test_update_status_secondary(self, _, pbm_status, connection, status_connection):
         """Tests that update status identifies secondary units and doesn't update status."""
         # assume leader has already initialised the replica set
         self.harness.set_leader(True)
@@ -460,7 +469,8 @@ class TestCharm(unittest.TestCase):
     @patch("charms.mongodb.v0.helpers.MongoDBConnection")
     @patch("charm.MongoDBConnection")
     @patch("charm.MongoDBBackups._get_pbm_status")
-    def test_update_status_additional_messages(self, pbm_status, connection, status_connection):
+    @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
+    def test_update_status_additional_messages(self, _, pbm_status, connection, status_connection):
         """Tests status updates are correct for non-primary and non-secondary cases."""
         # assume leader has already initialised the replica set
         self.harness.set_leader(True)


### PR DESCRIPTION
### Problem
<!-- What issue is this PR trying to solve? -->
When a host's IP address changes (network cut) the monitor URI will be out of date and logs will not be retrieved
When the monitor user's password changes the monitor URI will be out of date and logs will not be retrieved

### Context
<!-- What is some specialized knowledge relevant to this project/technology -->
follow up from #192 

For password changes on the leader we update the URI via `set-password` action - for non-leader units we update this when the relation data changes. (the relation data will change when the leader updates the password)

### Solution
<!-- A summary of the solution addressing the above issue -->
Update the monitor URI an IP address or password changes


### Testing
<!-- What steps need to be taken to test this PR? -->
```
juju deploy ./*charm -n3
curl  http://<unit-ip-0>:9216/metrics | grep mongo
curl  http://<unit-ip-1>:9216/metrics | grep mongo
curl  http://<unit-ip-2>:9216/metrics | grep mongo
juju run-action mongodb/leader set-password --wait
curl  http://<unit-ip-0>:9216/metrics | grep mongo
curl  http://<unit-ip-1>:9216/metrics | grep mongo
curl  http://<unit-ip-2>:9216/metrics | grep mongo
```

### Future PRs
<!-- A digestable summary of the change in this PR -->
Future PRs will include:
- unit tests
- int tests
- updates for cos sidecar log pattern
- grafana

