### PR TITLE
Metrics int tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,7 @@ jobs:
           - legacy-integration
           - tls-integration
           - backup-integration
+          - metric-integration
     name: ${{ matrix.tox-environments }}
     needs:
       - lint

--- a/src/charm.py
+++ b/src/charm.py
@@ -267,6 +267,11 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
         Args:
             event: The triggering relation joined/changed event.
         """
+        # changing the monitor password will lead to non-leader units receiving a relation changed
+        # event. We must update the monitor URI if the password changes so that COS can continue to
+        # work
+        self._connect_mongodb_exporter()
+
         # only leader should configure replica set and app-changed-events can trigger the relation
         # changed hook resulting in no JUJU_REMOTE_UNIT if this is the case we should return
         # further reconfiguration can be successful only if a replica set is initialised.
@@ -276,11 +281,6 @@ class MongodbOperatorCharm(ops.charm.CharmBase):
             or "db_initialised" not in self.app_peer_data
         ):
             return
-
-        # changing the monitor password will lead to non-leader units receiving a relation changed
-        # event. We must update the monitor URI if the password changes so that COS can continue to
-        # work
-        self._connect_mongodb_exporter()
 
         with MongoDBConnection(self.mongodb_config) as mongo:
             try:

--- a/tests/integration/metrics_tests/__init__.py
+++ b/tests/integration/metrics_tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -6,8 +6,8 @@ import time
 import ops
 import pytest
 import urllib3
-
 from pytest_operator.plugin import OpsTest
+
 from ..ha_tests import helpers as ha_helpers
 from ..helpers import find_unit
 

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -3,25 +3,24 @@
 # See LICENSE file for licensing details.
 import time
 
+import ops
 import pytest
-from pytest_operator.plugin import OpsTest
-
-from ..ha_tests import helpers as ha_helpers
-from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
-
-from ..helpers import find_unit
 import urllib3
+
+from pytest_operator.plugin import OpsTest
+from ..ha_tests import helpers as ha_helpers
+from ..helpers import find_unit
 
 NODE_EXPORTER_PORT = 9100
 MONGODB_EXPORTER_PORT = 9216
 MEDIAN_REELECTION_TIME = 12
 
 
-async def verify_endpoints(unit) -> str:
+async def verify_endpoints(ops_test: OpsTest, unit: ops.model.Unit) -> str:
     """Verifies node exporter and mongodb endpoints are functional on a given unit."""
     http = urllib3.PoolManager()
 
-    unit_address = await unit.get_public_address()
+    unit_address = await ha_helpers.get_unit_ip(ops_test, unit.name)
     node_exporter_url = f"http://{unit_address}:{NODE_EXPORTER_PORT}/metrics"
     mongodb_exporter_url = f"http://{unit_address}:{MONGODB_EXPORTER_PORT}/metrics"
 
@@ -32,7 +31,6 @@ async def verify_endpoints(unit) -> str:
     assert mongo_resp.status == 200
 
     # if configured correctly there should be more than one mongodb metric present
-    print(unit.name)
     mongodb_metrics = mongo_resp._body.decode("utf8")
     assert mongodb_metrics.count("mongo") > 1
 
@@ -54,7 +52,7 @@ async def test_endpoints(ops_test: OpsTest):
     application = ops_test.model.applications[app]
 
     for unit in application.units:
-        await verify_endpoints(unit)
+        await verify_endpoints(ops_test, unit)
 
 
 async def test_endpoints_new_password(ops_test: OpsTest):
@@ -64,22 +62,25 @@ async def test_endpoints_new_password(ops_test: OpsTest):
     leader_unit = await find_unit(ops_test, leader=True)
     action = await leader_unit.run_action("set-password", **{"username": "monitor"})
     action = await action.wait()
-    # wait for non-leader units to recieve relation changed event.
+    # wait for non-leader units to receive relation changed event.
     time.sleep(3)
     await ops_test.model.wait_for_idle()
     for unit in application.units:
-        await verify_endpoints(unit)
+        await verify_endpoints(ops_test, unit)
 
 
-# async def test_endpoints_network_cut(ops_test: OpsTest):
-#     """Verify that endpoint still function correctly after a network cut."""
-#     app = await ha_helpers.app_name(ops_test)
-#     unit = ops_test.model.applications[app].units[0]
-#     hostname = await ha_helpers.unit_hostname(ops_test, unit.name)
+async def test_endpoints_network_cut(ops_test: OpsTest):
+    """Verify that endpoint still function correctly after a network cut."""
+    app = await ha_helpers.app_name(ops_test)
+    unit = ops_test.model.applications[app].units[0]
+    hostname = await ha_helpers.unit_hostname(ops_test, unit.name)
+    unit_ip = await ha_helpers.get_unit_ip(ops_test, unit.name)
 
-#     ha_helpers.cut_network_from_unit(hostname)
-#     # sleep for twice the median election time
-#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+    ha_helpers.cut_network_from_unit(hostname)
+    # sleep for twice the median election time
+    time.sleep(MEDIAN_REELECTION_TIME * 2)
 
-#     ha_helpers.restore_network_for_unit(hostname)
-#     await verify_endpoints(unit)
+    # wait until network is reestablished for the unit
+    ha_helpers.restore_network_for_unit(hostname)
+    ha_helpers.wait_network_restore(ops_test.model.info.name, hostname, unit_ip)
+    await verify_endpoints(ops_test, unit)

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import time
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..ha_tests import helpers as ha_helpers
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
+
+from ..helpers import find_unit
+import urllib3
+
+NODE_EXPORTER_PORT = 9100
+MONGODB_EXPORTER_PORT = 9216
+MEDIAN_REELECTION_TIME = 12
+
+
+async def verify_endpoints(unit) -> str:
+    """Verifies node exporter and mongodb endpoints are functional on a given unit."""
+    http = urllib3.PoolManager()
+
+    unit_address = await unit.get_public_address()
+    node_exporter_url = f"http://{unit_address}:{NODE_EXPORTER_PORT}/metrics"
+    mongodb_exporter_url = f"http://{unit_address}:{MONGODB_EXPORTER_PORT}/metrics"
+
+    node_resp = http.request("GET", node_exporter_url)
+    mongo_resp = http.request("GET", mongodb_exporter_url)
+
+    assert node_resp.status == 200
+    assert mongo_resp.status == 200
+
+    # if configured correctly there should be more than one mongodb metric present
+    print(unit.name)
+    mongodb_metrics = mongo_resp._body.decode("utf8")
+    assert mongodb_metrics.count("mongo") > 1
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest) -> None:
+    """Build and deploy one unit of MongoDB."""
+    if await ha_helpers.app_name(ops_test):
+        return
+
+    my_charm = await ops_test.build_charm(".")
+    await ops_test.model.deploy(my_charm, num_units=3)
+    await ops_test.model.wait_for_idle()
+
+
+async def test_endpoints(ops_test: OpsTest):
+    """Sanity check that endpoints are running."""
+    app = await ha_helpers.app_name(ops_test)
+    application = ops_test.model.applications[app]
+
+    for unit in application.units:
+        await verify_endpoints(unit)
+
+
+async def test_endpoints_new_password(ops_test: OpsTest):
+    """Verify that endpoints still function correctly after the monitor user password changes."""
+    app = await ha_helpers.app_name(ops_test)
+    application = ops_test.model.applications[app]
+    leader_unit = await find_unit(ops_test, leader=True)
+    action = await leader_unit.run_action("set-password", **{"username": "monitor"})
+    action = await action.wait()
+    # wait for non-leader units to recieve relation changed event.
+    time.sleep(3)
+    await ops_test.model.wait_for_idle()
+    for unit in application.units:
+        await verify_endpoints(unit)
+
+
+# async def test_endpoints_network_cut(ops_test: OpsTest):
+#     """Verify that endpoint still function correctly after a network cut."""
+#     app = await ha_helpers.app_name(ops_test)
+#     unit = ops_test.model.applications[app].units[0]
+#     hostname = await ha_helpers.unit_hostname(ops_test, unit.name)
+
+#     ha_helpers.cut_network_from_unit(hostname)
+#     # sleep for twice the median election time
+#     time.sleep(MEDIAN_REELECTION_TIME * 2)
+
+#     ha_helpers.restore_network_for_unit(hostname)
+#     await verify_endpoints(unit)

--- a/tox.ini
+++ b/tox.ini
@@ -152,6 +152,20 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/backup_tests/test_backups.py
 
+[testenv:metrics-integration]
+description = Run metrics integration tests
+pass_env =
+    {[testenv]pass_env}
+    CI
+    CI_PACKED_CHARMS
+deps =
+    pytest
+    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    pytest-operator
+    -r {tox_root}/requirements.txt
+commands =
+    pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/metrics_tests/test_metrics.py
+
 
 [testenv:integration]
 description = Run all integration tests

--- a/tox.ini
+++ b/tox.ini
@@ -152,7 +152,7 @@ deps =
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/backup_tests/test_backups.py
 
-[testenv:metrics-integration]
+[testenv:metric-integration]
 description = Run metrics integration tests
 pass_env =
     {[testenv]pass_env}


### PR DESCRIPTION
### Problem
<!-- What issue is this PR trying to solve? -->
1. No integration tests for metrics integration 
2. The call to update monitor connection in relation_changed events was being skipped due to the if statement before it

### Solution
<!-- A summary of the solution addressing the above issue -->
1. fix for code to correctly update connection uri when the password is changed on non-leader units
2. sanity check that endpoints are running test
3. endpoints still function correctly after the monitor user password changes test
4. endpoints still function correctly after a network cut