### PR TITLE
Update backup uri on password change

### DIFF
--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -487,9 +487,7 @@ class MongoDBBackups(Object):
             database="",
             username="backup",
             password=self.charm.get_secret("app", "backup-password"),
-            hosts=[
-                self.charm._unit_ip(self.charm.unit)
-            ],  # pbm cannot make a direct connection if multiple hosts are used
+            hosts=["127.0.0.1"],  # pbm cannot make a direct connection if multiple hosts are used
             roles=["backup"],
             tls_external=self.charm.tls.get_tls_files("unit") is not None,
             tls_internal=self.charm.tls.get_tls_files("app") is not None,

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -116,265 +116,290 @@ async def test_ready_correct_conf(ops_test: OpsTest) -> None:
     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
 
     # after applying correct config options and creds the applications should both be active
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
-        ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-    )
+    ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active", timeout=TIMEOUT)
+    ops_test.model.wait_for_idle(apps=[db_app_name], status="active", timeout=TIMEOUT)
+
+
+# @pytest.mark.abort_on_fail
+# async def test_create_and_list_backups(ops_test: OpsTest) -> None:
+#     db_unit = await helpers.get_leader_unit(ops_test)
+
+#     # verify backup list works
+#     action = await db_unit.run_action(action_name="list-backups")
+#     list_result = await action.wait()
+#     backups = list_result.results["backups"]
+#     assert backups, "backups not outputted"
+
+#     # verify backup is started
+#     action = await db_unit.run_action(action_name="create-backup")
+#     backup_result = await action.wait()
+#     assert backup_result.results["backup-status"] == "backup started", "backup didn't start"
+
+#     # verify backup is present in the list of backups
+#     # the action `create-backup` only confirms that the command was sent to the `pbm`. Creating a
+#     # backup can take a lot of time so this function returns once the command was successfully
+#     # sent to pbm. Therefore we should retry listing the backup several times
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(20), wait=wait_fixed(3)):
+#             with attempt:
+#                 backups = await helpers.count_logical_backups(db_unit)
+#                 assert backups == 1
+#     except RetryError:
+#         assert backups == 1, "Backup not created."
+
+
+# @pytest.mark.abort_on_fail
+# async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
+#     """With writes in the DB test creating a backup while another one is running.
+
+#     Note that before creating the second backup we change the bucket and change the s3 storage
+#     from AWS to GCP. This test verifies that the first backup in AWS is made, the second backup
+#     in GCP is made, and that before the second backup is made that pbm correctly resyncs.
+#     """
+#     db_app_name = await helpers.app_name(ops_test)
+#     db_unit = await helpers.get_leader_unit(ops_test)
+
+#     # create first backup once ready
+#     async with ops_test.fast_forward():
+#         await asyncio.gather(
+#             ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+#         )
+
+#     action = await db_unit.run_action(action_name="create-backup")
+#     first_backup = await action.wait()
+#     assert first_backup.status == "completed", "First backup not started."
+
+#     # while first backup is running change access key, secret keys, and bucket name
+#     # for GCP
+#     await helpers.set_credentials(ops_test, cloud="GCP")
+
+#     # change to GCP configs and wait for PBM to resync
+#     configuration_parameters = {
+#         "bucket": "data-charms-testing",
+#         "endpoint": "https://storage.googleapis.com",
+#         "region": "",
+#     }
+#     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
+
+#     await asyncio.gather(
+#         ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+#     )
+
+#     # create a backup as soon as possible. might not be immediately possible since only one backup
+#     # can happen at a time.
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(40), wait=wait_fixed(5)):
+#             with attempt:
+#                 action = await db_unit.run_action(action_name="create-backup")
+#                 second_backup = await action.wait()
+#                 assert second_backup.status == "completed"
+#     except RetryError:
+#         assert second_backup.status == "completed", "Second backup not started."
+
+#     # the action `create-backup` only confirms that the command was sent to the `pbm`. Creating a
+#     # backup can take a lot of time so this function returns once the command was successfully
+#     # sent to pbm. Therefore before checking, wait for Charmed MongoDB to finish creating the
+#     # backup
+#     async with ops_test.fast_forward():
+#         await asyncio.gather(
+#             ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+#         )
+
+#     # verify that backups was made in GCP bucket
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5)):
+#             with attempt:
+#                 backups = await helpers.count_logical_backups(db_unit)
+#                 assert backups == 1, "Backup not created in bucket on GCP."
+#     except RetryError:
+#         assert backups == 1, "Backup not created in first bucket on GCP."
+
+#     # set AWS credentials, set configs for s3 storage, and wait to resync
+#     await helpers.set_credentials(ops_test, cloud="AWS")
+#     configuration_parameters = {
+#         "bucket": "data-charms-testing",
+#         "region": "us-east-1",
+#         "endpoint": "https://s3.amazonaws.com",
+#     }
+#     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
+#     await asyncio.gather(
+#         ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+#     )
+
+#     # verify that backups was made on the AWS bucket
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5)):
+#             with attempt:
+#                 backups = await helpers.count_logical_backups(db_unit)
+#                 assert backups == 2, "Backup not created in bucket on AWS."
+#     except RetryError:
+#         assert backups == 2, "Backup not created in bucket on AWS."
+
+
+# @pytest.mark.abort_on_fail
+# async def test_restore(ops_test: OpsTest, add_writes_to_db) -> None:
+#     """Simple backup tests that verifies that writes are correctly restored."""
+#     # count total writes
+#     number_writes = await ha_helpers.count_writes(ops_test)
+#     assert number_writes > 0, "no writes to backup"
+
+#     # create a backup in the AWS bucket
+#     db_app_name = await helpers.app_name(ops_test)
+#     db_unit = await helpers.get_leader_unit(ops_test)
+#     prev_backups = await helpers.count_logical_backups(db_unit)
+#     action = await db_unit.run_action(action_name="create-backup")
+#     first_backup = await action.wait()
+#     assert first_backup.status == "completed", "First backup not started."
+
+#     # verify that backup was made on the bucket
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5)):
+#             with attempt:
+#                 backups = await helpers.count_logical_backups(db_unit)
+#                 assert backups == prev_backups + 1, "Backup not created."
+#     except RetryError:
+#         assert backups == prev_backups + 1, "Backup not created."
+
+#     # add writes to be cleared after restoring the backup. Note these are written to the same
+#     # collection that was backed up.
+#     await helpers.insert_unwanted_data(ops_test)
+#     new_number_of_writes = await ha_helpers.count_writes(ops_test)
+#     assert new_number_of_writes > number_writes, "No writes to be cleared after restoring."
+
+#     # find most recent backup id and restore
+#     action = await db_unit.run_action(action_name="list-backups")
+#     list_result = await action.wait()
+#     list_result = list_result.results["backups"]
+#     most_recent_backup = list_result.split("\n")[-1]
+#     backup_id = most_recent_backup.split()[0]
+#     action = await db_unit.run_action(action_name="restore", **{"backup-id": backup_id})
+#     restore = await action.wait()
+#     assert restore.results["restore-status"] == "restore started", "restore not successful"
+
+#     async with ops_test.fast_forward():
+#         await asyncio.gather(
+#             ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+#         )
+
+#     # verify all writes are present
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(20)):
+#             with attempt:
+#                 number_writes_restored = await ha_helpers.count_writes(ops_test)
+#                 assert number_writes == number_writes_restored, "writes not correctly restored"
+#     except RetryError:
+#         assert number_writes == number_writes_restored, "writes not correctly restored"
+
+
+# @pytest.mark.parametrize("cloud_provider", ["AWS", "GCP"])
+# async def test_restore_new_cluster(ops_test: OpsTest, add_writes_to_db, cloud_provider):
+#     # configure test for the cloud provider
+#     db_app_name = await helpers.app_name(ops_test)
+#     await helpers.set_credentials(ops_test, cloud=cloud_provider)
+#     if cloud_provider == "AWS":
+#         configuration_parameters = {
+#             "bucket": "data-charms-testing",
+#             "region": "us-east-1",
+#             "endpoint": "https://s3.amazonaws.com",
+#         }
+#     else:
+#         configuration_parameters = {
+#             "bucket": "data-charms-testing",
+#             "endpoint": "https://storage.googleapis.com",
+#             "region": "",
+#         }
+
+#     await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
+#     await asyncio.gather(
+#         ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
+#         ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+#     )
+
+#     # create a backup
+#     writes_in_old_cluster = await ha_helpers.count_writes(ops_test, db_app_name)
+#     assert writes_in_old_cluster > 0, "old cluster has no writes."
+#     await helpers.create_and_verify_backup(ops_test)
+
+#     # save old password, since after restoring we will need this password to authenticate.
+#     old_password = await ha_helpers.get_password(ops_test, db_app_name)
+
+#     # deploy a new cluster with a different name
+#     db_charm = await ops_test.build_charm(".")
+#     await ops_test.model.deploy(db_charm, num_units=3, application_name=NEW_CLUSTER)
+#     await asyncio.gather(
+#         ops_test.model.wait_for_idle(apps=[NEW_CLUSTER], status="active"),
+#     )
+
+#     db_unit = await helpers.get_leader_unit(ops_test, db_app_name=NEW_CLUSTER)
+#     action = await db_unit.run_action("set-password", **{"password": old_password})
+#     action = await action.wait()
+#     assert action.status == "completed"
+
+#     # relate to s3 - s3 has the necessary configurations
+#     await ops_test.model.add_relation(S3_APP_NAME, NEW_CLUSTER)
+#     await ops_test.model.block_until(
+#         lambda: helpers.is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
+#         timeout=TIMEOUT,
+#     )
+
+#     # wait for new cluster to sync
+#     await asyncio.gather(
+#         ops_test.model.wait_for_idle(apps=[NEW_CLUSTER], status="active"),
+#     )
+
+#     # verify that the listed backups from the old cluster are not listed as failed.
+#     assert (
+#         await helpers.count_failed_backups(db_unit) == 0
+#     ), "Backups from old cluster are listed as failed"
+
+#     # find most recent backup id and restore
+#     action = await db_unit.run_action(action_name="list-backups")
+#     list_result = await action.wait()
+#     list_result = list_result.results["backups"]
+#     most_recent_backup = list_result.split("\n")[-1]
+#     backup_id = most_recent_backup.split()[0]
+#     action = await db_unit.run_action(action_name="restore", **{"backup-id": backup_id})
+#     restore = await action.wait()
+#     assert restore.results["restore-status"] == "restore started", "restore not successful"
+
+#     # verify all writes are present
+#     try:
+#         for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(20)):
+#             with attempt:
+#                 writes_in_new_cluster = await ha_helpers.count_writes(ops_test, NEW_CLUSTER)
+#                 assert (
+#                     writes_in_new_cluster == writes_in_old_cluster
+#                 ), "new cluster writes do not match old cluster writes after restore"
+#     except RetryError:
+#         assert (
+#             writes_in_new_cluster == writes_in_old_cluster
+#         ), "new cluster writes do not match old cluster writes after restore"
+
+#     await helpers.destroy_cluster(ops_test, cluster_name=NEW_CLUSTER)
 
 
 @pytest.mark.abort_on_fail
-async def test_create_and_list_backups(ops_test: OpsTest) -> None:
+async def test_update_backup_password(ops_test: OpsTest) -> None:
+    """Verifies that after changing the backup password the pbm tool is updated and functional."""
+    db_app_name = await helpers.app_name(ops_test)
     db_unit = await helpers.get_leader_unit(ops_test)
 
-    # verify backup list works
-    action = await db_unit.run_action(action_name="list-backups")
-    list_result = await action.wait()
-    backups = list_result.results["backups"]
-    assert backups, "backups not outputted"
+    # wait for charm to be idle before setting password
+    await asyncio.gather(
+        ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+    )
 
-    # verify backup is started
+    parameters = {"username": "backup"}
+    action = await db_unit.run_action("set-password", **parameters)
+    action = await action.wait()
+    assert action.status == "completed", "failed to set backup password"
+
+    # wait for charm to be idle after setting password
+    await asyncio.gather(
+        ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
+    )
+
+    # verify we still have connection to pbm via creating a backup
     action = await db_unit.run_action(action_name="create-backup")
     backup_result = await action.wait()
     assert backup_result.results["backup-status"] == "backup started", "backup didn't start"
-
-    # verify backup is present in the list of backups
-    # the action `create-backup` only confirms that the command was sent to the `pbm`. Creating a
-    # backup can take a lot of time so this function returns once the command was successfully
-    # sent to pbm. Therefore we should retry listing the backup several times
-    try:
-        for attempt in Retrying(stop=stop_after_delay(20), wait=wait_fixed(3)):
-            with attempt:
-                backups = await helpers.count_logical_backups(db_unit)
-                assert backups == 1
-    except RetryError:
-        assert backups == 1, "Backup not created."
-
-
-@pytest.mark.abort_on_fail
-async def test_multi_backup(ops_test: OpsTest, continuous_writes_to_db) -> None:
-    """With writes in the DB test creating a backup while another one is running.
-
-    Note that before creating the second backup we change the bucket and change the s3 storage
-    from AWS to GCP. This test verifies that the first backup in AWS is made, the second backup
-    in GCP is made, and that before the second backup is made that pbm correctly resyncs.
-    """
-    db_app_name = await helpers.app_name(ops_test)
-    db_unit = await helpers.get_leader_unit(ops_test)
-
-    # create first backup once ready
-    async with ops_test.fast_forward():
-        await asyncio.gather(
-            ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-        )
-
-    action = await db_unit.run_action(action_name="create-backup")
-    first_backup = await action.wait()
-    assert first_backup.status == "completed", "First backup not started."
-
-    # while first backup is running change access key, secret keys, and bucket name
-    # for GCP
-    await helpers.set_credentials(ops_test, cloud="GCP")
-
-    # change to GCP configs and wait for PBM to resync
-    configuration_parameters = {
-        "bucket": "data-charms-testing",
-        "endpoint": "https://storage.googleapis.com",
-        "region": "",
-    }
-    await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
-
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-    )
-
-    # create a backup as soon as possible. might not be immediately possible since only one backup
-    # can happen at a time.
-    try:
-        for attempt in Retrying(stop=stop_after_delay(40), wait=wait_fixed(5)):
-            with attempt:
-                action = await db_unit.run_action(action_name="create-backup")
-                second_backup = await action.wait()
-                assert second_backup.status == "completed"
-    except RetryError:
-        assert second_backup.status == "completed", "Second backup not started."
-
-    # the action `create-backup` only confirms that the command was sent to the `pbm`. Creating a
-    # backup can take a lot of time so this function returns once the command was successfully
-    # sent to pbm. Therefore before checking, wait for Charmed MongoDB to finish creating the
-    # backup
-    async with ops_test.fast_forward():
-        await asyncio.gather(
-            ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-        )
-
-    # verify that backups was made in GCP bucket
-    try:
-        for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5)):
-            with attempt:
-                backups = await helpers.count_logical_backups(db_unit)
-                assert backups == 1, "Backup not created in bucket on GCP."
-    except RetryError:
-        assert backups == 1, "Backup not created in first bucket on GCP."
-
-    # set AWS credentials, set configs for s3 storage, and wait to resync
-    await helpers.set_credentials(ops_test, cloud="AWS")
-    configuration_parameters = {
-        "bucket": "data-charms-testing",
-        "region": "us-east-1",
-        "endpoint": "https://s3.amazonaws.com",
-    }
-    await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-    )
-
-    # verify that backups was made on the AWS bucket
-    try:
-        for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5)):
-            with attempt:
-                backups = await helpers.count_logical_backups(db_unit)
-                assert backups == 2, "Backup not created in bucket on AWS."
-    except RetryError:
-        assert backups == 2, "Backup not created in bucket on AWS."
-
-
-@pytest.mark.abort_on_fail
-async def test_restore(ops_test: OpsTest, add_writes_to_db) -> None:
-    """Simple backup tests that verifies that writes are correctly restored."""
-    # count total writes
-    number_writes = await ha_helpers.count_writes(ops_test)
-    assert number_writes > 0, "no writes to backup"
-
-    # create a backup in the AWS bucket
-    db_app_name = await helpers.app_name(ops_test)
-    db_unit = await helpers.get_leader_unit(ops_test)
-    prev_backups = await helpers.count_logical_backups(db_unit)
-    action = await db_unit.run_action(action_name="create-backup")
-    first_backup = await action.wait()
-    assert first_backup.status == "completed", "First backup not started."
-
-    # verify that backup was made on the bucket
-    try:
-        for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5)):
-            with attempt:
-                backups = await helpers.count_logical_backups(db_unit)
-                assert backups == prev_backups + 1, "Backup not created."
-    except RetryError:
-        assert backups == prev_backups + 1, "Backup not created."
-
-    # add writes to be cleared after restoring the backup. Note these are written to the same
-    # collection that was backed up.
-    await helpers.insert_unwanted_data(ops_test)
-    new_number_of_writes = await ha_helpers.count_writes(ops_test)
-    assert new_number_of_writes > number_writes, "No writes to be cleared after restoring."
-
-    # find most recent backup id and restore
-    action = await db_unit.run_action(action_name="list-backups")
-    list_result = await action.wait()
-    list_result = list_result.results["backups"]
-    most_recent_backup = list_result.split("\n")[-1]
-    backup_id = most_recent_backup.split()[0]
-    action = await db_unit.run_action(action_name="restore", **{"backup-id": backup_id})
-    restore = await action.wait()
-    assert restore.results["restore-status"] == "restore started", "restore not successful"
-
-    async with ops_test.fast_forward():
-        await asyncio.gather(
-            ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-        )
-
-    # verify all writes are present
-    try:
-        for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(20)):
-            with attempt:
-                number_writes_restored = await ha_helpers.count_writes(ops_test)
-                assert number_writes == number_writes_restored, "writes not correctly restored"
-    except RetryError:
-        assert number_writes == number_writes_restored, "writes not correctly restored"
-
-
-@pytest.mark.parametrize("cloud_provider", ["AWS", "GCP"])
-async def test_restore_new_cluster(ops_test: OpsTest, add_writes_to_db, cloud_provider):
-    # configure test for the cloud provider
-    db_app_name = await helpers.app_name(ops_test)
-    await helpers.set_credentials(ops_test, cloud=cloud_provider)
-    if cloud_provider == "AWS":
-        configuration_parameters = {
-            "bucket": "data-charms-testing",
-            "region": "us-east-1",
-            "endpoint": "https://s3.amazonaws.com",
-        }
-    else:
-        configuration_parameters = {
-            "bucket": "data-charms-testing",
-            "endpoint": "https://storage.googleapis.com",
-            "region": "",
-        }
-
-    await ops_test.model.applications[S3_APP_NAME].set_config(configuration_parameters)
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
-        ops_test.model.wait_for_idle(apps=[db_app_name], status="active"),
-    )
-
-    # create a backup
-    writes_in_old_cluster = await ha_helpers.count_writes(ops_test, db_app_name)
-    assert writes_in_old_cluster > 0, "old cluster has no writes."
-    await helpers.create_and_verify_backup(ops_test)
-
-    # save old password, since after restoring we will need this password to authenticate.
-    old_password = await ha_helpers.get_password(ops_test, db_app_name)
-
-    # deploy a new cluster with a different name
-    db_charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(db_charm, num_units=3, application_name=NEW_CLUSTER)
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[NEW_CLUSTER], status="active"),
-    )
-
-    db_unit = await helpers.get_leader_unit(ops_test, db_app_name=NEW_CLUSTER)
-    action = await db_unit.run_action("set-password", **{"password": old_password})
-    action = await action.wait()
-    assert action.status == "completed"
-
-    # relate to s3 - s3 has the necessary configurations
-    await ops_test.model.add_relation(S3_APP_NAME, NEW_CLUSTER)
-    await ops_test.model.block_until(
-        lambda: helpers.is_relation_joined(ops_test, ENDPOINT, ENDPOINT) is True,
-        timeout=TIMEOUT,
-    )
-
-    # wait for new cluster to sync
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[NEW_CLUSTER], status="active"),
-    )
-
-    # verify that the listed backups from the old cluster are not listed as failed.
-    assert (
-        await helpers.count_failed_backups(db_unit) == 0
-    ), "Backups from old cluster are listed as failed"
-
-    # find most recent backup id and restore
-    action = await db_unit.run_action(action_name="list-backups")
-    list_result = await action.wait()
-    list_result = list_result.results["backups"]
-    most_recent_backup = list_result.split("\n")[-1]
-    backup_id = most_recent_backup.split()[0]
-    action = await db_unit.run_action(action_name="restore", **{"backup-id": backup_id})
-    restore = await action.wait()
-    assert restore.results["restore-status"] == "restore started", "restore not successful"
-
-    # verify all writes are present
-    try:
-        for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(20)):
-            with attempt:
-                writes_in_new_cluster = await ha_helpers.count_writes(ops_test, NEW_CLUSTER)
-                assert (
-                    writes_in_new_cluster == writes_in_old_cluster
-                ), "new cluster writes do not match old cluster writes after restore"
-    except RetryError:
-        assert (
-            writes_in_new_cluster == writes_in_old_cluster
-        ), "new cluster writes do not match old cluster writes after restore"
-
-    await helpers.destroy_cluster(ops_test, cluster_name=NEW_CLUSTER)

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -41,7 +41,7 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
     # Relate it to the PostgreSQL to enable TLS.
     await ops_test.model.relate(DATABASE_APP_NAME, TLS_CERTIFICATES_APP_NAME)
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(status="active", timeout=1000, idle_period=60)
+        await ops_test.model.wait_for_idle(status="active", timeout=1000)
 
     # Wait for all units enabling TLS.
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
@@ -76,10 +76,8 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         assert action.status == "completed", "setting external and internal key failed."
 
     # wait for certificate to be available and processed. Can get receive two certificate
-    # available events and restart twice so we want to ensure we are idle for atleast 1 minute
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME], status="active", timeout=1000, idle_period=60
-    )
+    # available events and restart twice so we do not wait for idle here
+    time.sleep(60)
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
@@ -154,10 +152,8 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
         assert action.status == "completed", "setting external and internal key failed."
 
     # wait for certificate to be available and processed. Can get receive two certificate
-    # available events and restart twice so we want to ensure we are idle for atleast 1 minute
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME], status="active", timeout=1000, idle_period=60
-    )
+    # available events and restart twice so we do not wait for idle here
+    time.sleep(60)
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
@@ -193,9 +189,7 @@ async def test_disable_tls(ops_test: OpsTest) -> None:
         f"{DATABASE_APP_NAME}:certificates", f"{TLS_CERTIFICATES_APP_NAME}:certificates"
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[DATABASE_APP_NAME], status="active", timeout=1000, idle_period=60
-    )
+    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
 
     # Wait for all units disabling TLS.
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -41,7 +41,7 @@ async def test_enable_tls(ops_test: OpsTest) -> None:
     # Relate it to the PostgreSQL to enable TLS.
     await ops_test.model.relate(DATABASE_APP_NAME, TLS_CERTIFICATES_APP_NAME)
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(status="active", timeout=1000)
+        await ops_test.model.wait_for_idle(status="active", timeout=1000, idle_period=60)
 
     # Wait for all units enabling TLS.
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:
@@ -76,8 +76,10 @@ async def test_rotate_tls_key(ops_test: OpsTest) -> None:
         assert action.status == "completed", "setting external and internal key failed."
 
     # wait for certificate to be available and processed. Can get receive two certificate
-    # available events and restart twice so we do not wait for idle here
-    time.sleep(60)
+    # available events and restart twice so we want to ensure we are idle for atleast 1 minute
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME], status="active", timeout=1000, idle_period=60
+    )
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
@@ -152,8 +154,10 @@ async def test_set_tls_key(ops_test: OpsTest) -> None:
         assert action.status == "completed", "setting external and internal key failed."
 
     # wait for certificate to be available and processed. Can get receive two certificate
-    # available events and restart twice so we do not wait for idle here
-    time.sleep(60)
+    # available events and restart twice so we want to ensure we are idle for atleast 1 minute
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME], status="active", timeout=1000, idle_period=60
+    )
 
     # After updating both the external key and the internal key a new certificate request will be
     # made; then the certificates should be available and updated.
@@ -189,7 +193,9 @@ async def test_disable_tls(ops_test: OpsTest) -> None:
         f"{DATABASE_APP_NAME}:certificates", f"{TLS_CERTIFICATES_APP_NAME}:certificates"
     )
 
-    await ops_test.model.wait_for_idle(apps=[DATABASE_APP_NAME], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle(
+        apps=[DATABASE_APP_NAME], status="active", timeout=1000, idle_period=60
+    )
 
     # Wait for all units disabling TLS.
     for unit in ops_test.model.applications[DATABASE_APP_NAME].units:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -630,9 +630,11 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
-    def test_set_password(self, connection):
+    @patch("charm.MongoDBBackups._get_pbm_status")
+    def test_set_password(self, pbm_status, connection):
         """Tests that a new admin password is generated and is returned to the user."""
         self.harness.set_leader(True)
+        pbm_status.return_value = ActiveStatus("pbm")
         original_password = self.harness.charm.app_peer_data["operator-password"]
         action_event = mock.Mock()
         action_event.params = {}
@@ -645,9 +647,11 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
-    def test_set_password_provided(self, connection):
+    @patch("charm.MongoDBBackups._get_pbm_status")
+    def test_set_password_provided(self, pbm_status, connection):
         """Tests that a given password is set as the new mongodb password."""
         self.harness.set_leader(True)
+        pbm_status.return_value = ActiveStatus("pbm")
         action_event = mock.Mock()
         action_event.params = {"password": "canonical123"}
         self.harness.charm._on_set_password(action_event)
@@ -659,9 +663,11 @@ class TestCharm(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBConnection")
-    def test_set_password_failure(self, connection):
+    @patch("charm.MongoDBBackups._get_pbm_status")
+    def test_set_password_failure(self, pbm_status, connection):
         """Tests failure to reset password does not update app data and failure is reported."""
         self.harness.set_leader(True)
+        pbm_status.return_value = ActiveStatus("pbm")
         original_password = self.harness.charm.app_peer_data["operator-password"]
         action_event = mock.Mock()
         action_event.params = {}
@@ -680,22 +686,17 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongoDBBackups._get_pbm_status")
     def test_set_backup_password_pbm_busy(self, pbm_status):
-        """Tests that attempts to change pbm password fail when pbm is busy."""
+        """Tests changes to passwords fail when pbm is restoring/backing up."""
         self.harness.set_leader(True)
         original_password = "pass123"
-        self.harness.charm.app_peer_data["backup-password"] = "pass123"
         action_event = mock.Mock()
-        action_event.params = {"username": "backup"}
 
-        not_ready_states = [
-            BlockedStatus("pbm"),
-            MaintenanceStatus("pbm"),
-            WaitingStatus("pbm"),
-        ]
-        for pbm_state in not_ready_states:
-            pbm_status.return_value = pbm_state
+        for username in ["backup", "monitor", "operator"]:
+            self.harness.charm.app_peer_data[f"{username}-password"] = original_password
+            action_event.params = {"username": username}
+            pbm_status.return_value = MaintenanceStatus("pbm")
             self.harness.charm._on_set_password(action_event)
-            current_password = self.harness.charm.app_peer_data["backup-password"]
+            current_password = self.harness.charm.app_peer_data[f"{username}-password"]
             action_event.fail.assert_called()
             self.assertEqual(current_password, original_password)
 


### PR DESCRIPTION
## Issue
1. Users can change passwords while backup/restore is running leading to a failed backup/restore
2. After updating pbm password the pbm-agent isn't notified about the password change

## Solution
1. dont allow password changes if pbm is busy
2. update pbm tool after the password changes
