### PR TITLE
only leader should be able to restore backups

### DIFF
--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -43,7 +43,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -358,13 +358,13 @@ class MongoDBBackups(Object):
         if not backup_id:
             event.fail("Missing backup-id to restore")
             return
-        
+
         # only leader can restore backups. This prevents multiple restores from being attempted at
         # once.
         if not self.charm.unit.is_leader():
             event.fail("The action can be run only on leader unit.")
             return
-        
+
         # cannot restore backup if pbm is not ready. This could be due to: resyncing, incompatible,
         # options, incorrect credentials, creating a backup, or already performing a restore.
         pbm_status = self._get_pbm_status()

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -358,7 +358,13 @@ class MongoDBBackups(Object):
         if not backup_id:
             event.fail("Missing backup-id to restore")
             return
-
+        
+        # only leader can restore backups. This prevents multiple restores from being attempted at
+        # once.
+        if not self.charm.unit.is_leader():
+            event.fail("The action can be run only on leader unit.")
+            return
+        
         # cannot restore backup if pbm is not ready. This could be due to: resyncing, incompatible,
         # options, incorrect credentials, creating a backup, or already performing a restore.
         pbm_status = self._get_pbm_status()
@@ -371,7 +377,7 @@ class MongoDBBackups(Object):
             logger.debug("Sync-ing configurations needs more time, must wait before restoring.")
             return
         if isinstance(pbm_status, BlockedStatus):
-            event.fail(f"Cannot create backup {pbm_status.message}.")
+            event.fail(f"Cannot restore backup {pbm_status.message}.")
             return
 
         try:

--- a/lib/charms/mongodb/v0/mongodb_provider.py
+++ b/lib/charms/mongodb/v0/mongodb_provider.py
@@ -76,8 +76,7 @@ class MongoDBProvider(Object):
             return
 
         # legacy relations have auth disabled, which new relations require
-        legacy_relation_users = self._get_users_from_relations(None, rel=LEGACY_REL_NAME)
-        if len(legacy_relation_users) > 0:
+        if self.model.get_relation(LEGACY_REL_NAME):
             self.charm.unit.status = BlockedStatus("cannot have both legacy and new relations")
             logger.error("Auth disabled due to existing connections to legacy relations")
             return
@@ -117,6 +116,13 @@ class MongoDBProvider(Object):
         relation is still on the list of all relations. Therefore, for proper
         work of the function, we need to exclude departed relation from the list.
         """
+        # This hook gets called from other contexts within the charm so it is necessary to check
+        # for legacy relations which have auth disabled, which new relations require
+        if self.model.get_relation(LEGACY_REL_NAME):
+            self.charm.unit.status = BlockedStatus("cannot have both legacy and new relations")
+            logger.error("Auth disabled due to existing connections to legacy relations")
+            return
+
         with MongoDBConnection(self.charm.mongodb_config) as mongo:
             database_users = mongo.get_users()
             relation_users = self._get_users_from_relations(departed_relation_id)


### PR DESCRIPTION
only leader should allow restores - this prevents multiple restores from occurring at a time which can be destructive 
