### PR TITLE
enable logging for mongod for k8s

### DIFF
--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -36,6 +36,7 @@ MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
 
 DATA_DIR = "/var/lib/mongodb"
 CONF_DIR = "/etc/mongod"
+MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
 
 
@@ -86,7 +87,7 @@ def get_mongod_args(
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
     # in k8s the default logging options that are used for the vm charm are ignored and logs are
     # the output of the container. To enable logging to a file it must be set explicitly
-    logging_options = "" if snap_install else f"--logpath={full_data_dir}/mongodb.log"
+    logging_options = "" if snap_install else f"--logpath={full_data_dir}/{MONGODB_LOG_FILENAME}"
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",

--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -20,7 +20,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 # path to store mongodb ketFile
@@ -82,9 +82,11 @@ def get_mongod_args(
     Returns:
         A string representing the command used to start MongoDB.
     """
-    #
     full_data_dir = f"{MONGODB_COMMON_DIR}{DATA_DIR}" if snap_install else DATA_DIR
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
+    # in k8s the default logging options that are used for the vm charm are ignored and logs are
+    # the output of the container. To enable logging to a file it must be set explicitly
+    logging_options = "" if snap_install else f"--logpath={full_data_dir}/mongodb.log"
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",
@@ -92,6 +94,7 @@ def get_mongod_args(
         f"--replSet={config.replset}",
         # db must be located within the snap common directory since the snap is strictly confined
         f"--dbpath={full_data_dir}",
+        logging_options,
     ]
     if auth:
         cmd.extend(["--auth"])

--- a/tests/unit/test_mongodb_helpers.py
+++ b/tests/unit/test_mongodb_helpers.py
@@ -9,17 +9,14 @@ from charms.mongodb.v0.helpers import get_mongod_args
 
 class TestMongoDBHelpers(unittest.TestCase):
     def test_get_mongod_args(self):
-        service_args_auth = " ".join(
-            [
-                "--bind_ip_all",
-                "--replSet=my_repl_set",
-                "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
-                "--auth",
-                "--clusterAuthMode=keyFile",
-                "--keyFile=/var/snap/charmed-mongodb/current/etc/mongod/keyFile",
-                "\n",
-            ]
-        )
+        service_args_auth = [
+            "--bind_ip_all",
+            "--replSet=my_repl_set",
+            "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
+            "--auth",
+            "--clusterAuthMode=keyFile",
+            "--keyFile=/var/snap/charmed-mongodb/current/etc/mongod/keyFile",
+        ]
 
         config = mock.Mock()
         config.replset = "my_repl_set"
@@ -27,22 +24,33 @@ class TestMongoDBHelpers(unittest.TestCase):
         config.tls_internal = False
 
         self.assertEqual(
-            get_mongod_args(config, auth=True, snap_install=True),
+            get_mongod_args(config, auth=True, snap_install=True).split(),
             service_args_auth,
         )
 
-        service_args = " ".join(
-            [
-                # bind to localhost and external interfaces
-                "--bind_ip_all",
-                # part of replicaset
-                "--replSet=my_repl_set",
-                "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
-                "\n",
-            ]
-        )
+        service_args = [
+            # bind to localhost and external interfaces
+            "--bind_ip_all",
+            # part of replicaset
+            "--replSet=my_repl_set",
+            "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
+        ]
 
         self.assertEqual(
-            get_mongod_args(config, auth=False, snap_install=True),
+            get_mongod_args(config, auth=False, snap_install=True).split(),
+            service_args,
+        )
+
+        service_args = [
+            # bind to localhost and external interfaces
+            "--bind_ip_all",
+            # part of replicaset
+            "--replSet=my_repl_set",
+            "--dbpath=/var/lib/mongodb",
+            "--logpath=/var/lib/mongodb/mongodb.log",
+        ]
+
+        self.assertEqual(
+            get_mongod_args(config, auth=False, snap_install=False).split(),
             service_args,
         )


### PR DESCRIPTION
## Issue
By default the MongoDB K8s charm has its logs printed as the output of running the container and are not saved on the container. This means that the logs cannot be ported over to the cos bundle.


## Solution
To enable logging we must change the start up arguments, these are generated within the shared library code and therefore the change library code change must be made in the VM charm first
