### PR TITLE
[DPE-2157]Rename users secret keys names to make them compatible with juju 3.1

### DIFF
--- a/lib/charms/mongodb/v0/users.py
+++ b/lib/charms/mongodb/v0/users.py
@@ -70,7 +70,7 @@ class _OperatorUser(MongoDBUser):
     """Operator user for MongoDB."""
 
     _username = "operator"
-    _password_key_name = f"{_username}_password"
+    _password_key_name = f"{_username}-password"
     _database_name = "admin"
     _roles = ["default"]
     _hosts = []
@@ -80,7 +80,7 @@ class _MonitorUser(MongoDBUser):
     """Monitor user for MongoDB."""
 
     _username = "monitor"
-    _password_key_name = f"{_username}_password"
+    _password_key_name = f"{_username}-password"
     _database_name = "admin"
     _roles = ["monitor"]
     _privileges = {
@@ -97,7 +97,7 @@ class _BackupUser(MongoDBUser):
     """Backup user for MongoDB."""
 
     _username = "backup"
-    _password_key_name = f"{_username}_password"
+    _password_key_name = f"{_username}-password"
     _database_name = ""
     _roles = ["backup"]
     _mongodb_role = "pbmAnyAction"

--- a/src/charm.py
+++ b/src/charm.py
@@ -624,10 +624,10 @@ class MongodbOperatorCharm(CharmBase):
 
     # BEGIN: helper functions
     def _is_user_created(self, user: MongoDBUser) -> bool:
-        return f"{user.get_username()}_user_created" in self.app_peer_data
+        return f"{user.get_username()}-user-created" in self.app_peer_data
 
     def _user_created(self, user: MongoDBUser) -> None:
-        self.app_peer_data[f"{user.get_username()}_user_created"] = "True"
+        self.app_peer_data[f"{user.get_username()}-user-created"] = "True"
 
     def _get_mongodb_config_for_user(
         self, user: MongoDBUser, hosts: Set[str]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -622,7 +622,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader(True)
 
         self.harness.charm._init_operator_user()
-        self.assertEqual("operator_user_created" in self.harness.charm.app_peer_data, True)
+        self.assertEqual("operator-user-created" in self.harness.charm.app_peer_data, True)
 
         self.harness.charm._init_operator_user()
         run.assert_called_once()
@@ -634,11 +634,11 @@ class TestCharm(unittest.TestCase):
         """Tests that a new admin password is generated and is returned to the user."""
         self.harness.set_leader(True)
         pbm_status.return_value = ActiveStatus("pbm")
-        original_password = self.harness.charm.app_peer_data["operator_password"]
+        original_password = self.harness.charm.app_peer_data["operator-password"]
         action_event = mock.Mock()
         action_event.params = {}
         self.harness.charm._on_set_password(action_event)
-        new_password = self.harness.charm.app_peer_data["operator_password"]
+        new_password = self.harness.charm.app_peer_data["operator-password"]
 
         # verify app data is updated and results are reported to user
         self.assertNotEqual(original_password, new_password)
@@ -654,7 +654,7 @@ class TestCharm(unittest.TestCase):
         action_event = mock.Mock()
         action_event.params = {"password": "canonical123"}
         self.harness.charm._on_set_password(action_event)
-        new_password = self.harness.charm.app_peer_data["operator_password"]
+        new_password = self.harness.charm.app_peer_data["operator-password"]
 
         # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
@@ -667,7 +667,7 @@ class TestCharm(unittest.TestCase):
         """Tests failure to reset password does not update app data and failure is reported."""
         self.harness.set_leader(True)
         pbm_status.return_value = ActiveStatus("pbm")
-        original_password = self.harness.charm.app_peer_data["operator_password"]
+        original_password = self.harness.charm.app_peer_data["operator-password"]
         action_event = mock.Mock()
         action_event.params = {}
 
@@ -676,7 +676,7 @@ class TestCharm(unittest.TestCase):
                 exception
             )
             self.harness.charm._on_set_password(action_event)
-            current_password = self.harness.charm.app_peer_data["operator_password"]
+            current_password = self.harness.charm.app_peer_data["operator-password"]
 
             # verify passwords are not updated.
             self.assertEqual(current_password, original_password)


### PR DESCRIPTION
## Issue
User's secrets key were not in a format that is supported by juju 3.1
This PR resolves the issue

## Solution
Rename keys 

## Related issues
DPE-2157