### PR TITLE
Bump PyYaml and ops libraries verion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pycparser==2.2
 pkgutil-resolve-name==1.3.10
 pydantic==1.10.7
 pyrsistent==0.19.3 
-pyyaml==6.0
+pyyaml>6.0
 zipp==3.11.0
 pyOpenSSL==22.1.0
 typing-extensions==4.5.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cosl==0.0.5
 importlib-resources==5.10.2
 tenacity==8.1.0
 pymongo==4.3.3
-ops==2.0.0
+ops==2.4.1
 jsonschema==4.17.3
 cryptography==38.0.4
 pure-sasl==0.6.2
@@ -12,7 +12,7 @@ pycparser==2.2
 pkgutil-resolve-name==1.3.10
 pydantic==1.10.7
 pyrsistent==0.19.3 
-pyyaml>6.0
+pyyaml==6.0.1
 zipp==3.11.0
 pyOpenSSL==22.1.0
 typing-extensions==4.5.0 

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -86,7 +86,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -100,7 +100,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -114,7 +114,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -128,7 +128,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -147,7 +147,7 @@ pass_env =
     GCP_SECRET_KEY
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -161,7 +161,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =
@@ -176,7 +176,7 @@ pass_env =
     CI_PACKED_CHARMS
 deps =
     pytest
-    juju==2.9.38.1 # juju 3.3.0 has issues with retrieving action results
+    juju==2.9.44.0 # The latest python-libjuju that supports both juju 2.9 and 3.0
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =


### PR DESCRIPTION
## Issue
Building of charm is failed with juju 3.1.5 which is installed by default with snap

PyYaml pinned to version 6.0.0 causes issues with building charm due to incompatibility with cython 3.


## Solution
Bump PyYaml and ops library versions