### PR TITLE
hold snap revision to prevent refresh

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -810,13 +810,11 @@ class MongodbOperatorCharm(CharmBase):
             try:
                 snap_cache = snap.SnapCache()
                 snap_package = snap_cache[snap_name]
-
-                if not snap_package.present:
-                    snap_package.ensure(
-                        snap.SnapState.Latest, channel=snap_channel, revision=snap_revision
-                    )
-                    # snaps will auto refresh so it is necessary to hold the current revision
-                    snap_package.hold()
+                snap_package.ensure(
+                    snap.SnapState.Latest, channel=snap_channel, revision=snap_revision
+                )
+                # snaps will auto refresh so it is necessary to hold the current revision
+                snap_package.hold()
 
             except snap.SnapError as e:
                 logger.error(

--- a/src/charm.py
+++ b/src/charm.py
@@ -815,6 +815,8 @@ class MongodbOperatorCharm(CharmBase):
                     snap_package.ensure(
                         snap.SnapState.Latest, channel=snap_channel, revision=snap_revision
                     )
+                    # snaps will auto refresh so it is necessary to hold the current revision
+                    snap_package.hold()
 
             except snap.SnapError as e:
                 logger.error(


### PR DESCRIPTION
## Issue
Snaps will auto refresh, meaning that snaps installed inside a charm and pinned to a specific revision won't necessarily be kept at that revision. This means a refresh will update the snap, leading to potential errors within the charm 


## Solution
hold the snap revision