### PR TITLE
[DPE-2613] fix rel tests (6/edge)

### DIFF
--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -10,8 +10,6 @@ import subprocess
 from typing import List
 
 from charms.mongodb.v0.mongodb import MongoDBConfiguration, MongoDBConnection
-from ops.charm import CharmBase, RelationDepartedEvent
-from ops.framework import Object
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
@@ -31,7 +29,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 8
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -49,50 +47,6 @@ DATA_DIR = "/var/lib/mongodb"
 CONF_DIR = "/etc/mongod"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
-
-
-class MongoDBHelper(Object):
-    """In this class, we manage client database relations."""
-
-    def __init__(self, charm: CharmBase) -> None:
-        """Constructor for MongoDBProvider object.
-
-        Args:
-            charm: the charm for which this relation is provided
-        """
-        super().__init__(charm, None)
-        self.charm = charm
-
-    def _is_departed_removed_relation(self, event: RelationDepartedEvent):
-        """Sets app metadata indicating if a relation should be removed.
-
-        Relation-broken executes after relation-departed, and it must know if it should remove the
-        related user. Relation-broken doesn't have access to `event.departing_unit`, so we make
-        use of it here.
-
-        We receive relation departed events when: the relation has been removed, units are scaling
-        down, or the application has been removed. Only proceed to process user removal if the
-        relation has been removed.
-        """
-        if not self.charm.unit.is_leader():
-            return
-
-        # assume relation departed is due to manual removal of relation.
-        relation_departed = True
-
-        # check if relation departed is due to current unit being removed. (i.e. scaling down the
-        # application.)
-        if event.departing_unit == self.charm.unit:
-            logger.info(
-                "Relation departed is due to scale down, no need to process removed relation in RelationBrokenEvent."
-            )
-            relation_departed = False
-
-        self.charm.app_peer_data[f"relation_{event.relation.id}_departed"] = json.dumps(
-            relation_departed
-        )
-
-        return relation_departed
 
 
 # noinspection GrazieInspection

--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -83,7 +83,7 @@ class MongoDBHelper(Object):
         # check if relation departed is due to current unit being removed. (i.e. scaling down the
         # application.)
         if event.departing_unit == self.charm.unit:
-            logger.debug(
+            logger.info(
                 "Relation departed is due to scale down, no need to process removed relation in RelationBrokenEvent."
             )
             relation_departed = False

--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -10,6 +10,8 @@ import subprocess
 from typing import List
 
 from charms.mongodb.v0.mongodb import MongoDBConfiguration, MongoDBConnection
+from ops.charm import CharmBase, RelationDepartedEvent
+from ops.framework import Object
 from ops.model import (
     ActiveStatus,
     BlockedStatus,
@@ -29,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -47,6 +49,50 @@ DATA_DIR = "/var/lib/mongodb"
 CONF_DIR = "/etc/mongod"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
+
+
+class MongoDBHelper(Object):
+    """In this class, we manage client database relations."""
+
+    def __init__(self, charm: CharmBase) -> None:
+        """Constructor for MongoDBProvider object.
+
+        Args:
+            charm: the charm for which this relation is provided
+        """
+        super().__init__(charm, None)
+        self.charm = charm
+
+    def _is_departed_removed_relation(self, event: RelationDepartedEvent):
+        """Sets app metadata indicating if a relation should be removed.
+
+        Relation-broken executes after relation-departed, and it must know if it should remove the
+        related user. Relation-broken doesn't have access to `event.departing_unit`, so we make
+        use of it here.
+
+        We receive relation departed events when: the relation has been removed, units are scaling
+        down, or the application has been removed. Only proceed to process user removal if the
+        relation has been removed.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        # assume relation departed is due to manual removal of relation.
+        relation_departed = True
+
+        # check if relation departed is due to current unit being removed. (i.e. scaling down the
+        # application.)
+        if event.departing_unit == self.charm.unit:
+            logger.debug(
+                "Relation departed is due to scale down, no need to process removed relation in RelationBrokenEvent."
+            )
+            relation_departed = False
+
+        self.charm.app_peer_data[f"relation_{event.relation.id}_departed"] = json.dumps(
+            relation_departed
+        )
+
+        return relation_departed
 
 
 # noinspection GrazieInspection

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,6 +19,7 @@ from charms.mongodb.v0.helpers import (
     TLS_EXT_PEM_FILE,
     TLS_INT_CA_FILE,
     TLS_INT_PEM_FILE,
+    MongoDBHelper,
     build_unit_status,
     copy_licenses_to_unit,
     generate_keyfile,
@@ -123,6 +124,7 @@ class MongodbOperatorCharm(CharmBase):
         self.framework.observe(self.on.secret_changed, self._on_secret_changed)
 
         # handle provider side of relations
+        self.mongodb_helpers = MongoDBHelper(self)
         self.client_relations = MongoDBProvider(self, substrate=Config.SUBSTRATE)
         self.legacy_client_relations = MongoDBLegacyProvider(self)
         self.tls = MongoDBTLS(self, Config.Relations.PEERS, substrate=Config.SUBSTRATE)

--- a/src/charm.py
+++ b/src/charm.py
@@ -1407,6 +1407,19 @@ class MongodbOperatorCharm(CharmBase):
         secret.set_content(secret_cache)
         logging.debug(f"Secret {scope}:{key}")
 
+    def check_relation_broken_or_scale_down(self, event: RelationDepartedEvent) -> None:
+        """Checks relation departed event is the result of removed relation or scale down.
+
+        Relation departed and relation broken events occur during scaling down or during relation
+        removal, only relation departed events have access to metadata to determine which case.
+        """
+        self.set_scaling_down(event)
+
+        if self.is_scaling_down(event.relation.id):
+            logger.info(
+                "Scaling down the application, no need to process removed relation in broken hook."
+            )
+
     def is_scaling_down(self, rel_id: int) -> bool:
         """Returns True if the application is scaling down."""
         rel_departed_key = self._generate_relation_departed_key(rel_id)


### PR DESCRIPTION
## Issue
After updating to Juju 3.1 the charm failed on its relation tests #247

This was due to when apps scale down in 3.1, they receive relation broken events. Thereby attempts to remove users were made when relations were actually not removed, but instead a unit was being removed.  

## Solution
Add a check in `relation-departed`. In this function we can tell if we are receiving the `relation-broken` event due to scale down or relation removal. 

## more
Once this PR is accepted, we will make another one for branch `5/edge`