### PR TITLE
bump lib api for 6/edge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,21 +50,23 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox run -e unit
-
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.4.0
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+  # current lib check is incompatible with bumped APIs - perform this manually. After merge +
+  # publish. It should be possible to comment this back in and for the workflow to resume normally.
+  # see issue: https://github.com/canonical/charming-actions/issues/97
+  # lib-check:
+  #   name: Check libraries
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 5
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Check libs
+  #       uses: canonical/charming-actions/check-libraries@2.4.0
+  #       with:
+  #         credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
+  #         github-token: "${{ secrets.GITHUB_TOKEN }}"
 
   build:
     name: Build charms

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.2.2
+        uses: canonical/charming-actions/check-libraries@2.4.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}" # FIXME: current token will expire in 2023-07-04
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Release any bumped charm libs
-        uses: canonical/charming-actions/release-libraries@2.2.2
+        uses: canonical/charming-actions/release-libraries@2.4.0
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,11 +26,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Release any bumped charm libs
-        uses: canonical/charming-actions/release-libraries@2.4.0
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      # current lib publish is incompatible with bumped APIs - perform this manually. After merge +
+      # publish. It should be possible to comment this back in and for the workflow to resume
+      # normally.
+      # see issue: https://github.com/canonical/charming-actions/issues/97
+      # - name: Release any bumped charm libs
+      #   uses: canonical/charming-actions/release-libraries@2.4.0
+      #   with:
+      #     credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+      #     github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Upload charm to charmhub
         uses: canonical/charming-actions/upload-charm@2.2.2
         with:

--- a/lib/charms/mongodb/v0/helpers.py
+++ b/lib/charms/mongodb/v0/helpers.py
@@ -25,11 +25,11 @@ from config import Config
 LIBID = "b9a7fe0c38d8486a9d1ce94c27d4758e"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 0
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"

--- a/lib/charms/mongodb/v0/mongodb.py
+++ b/lib/charms/mongodb/v0/mongodb.py
@@ -25,11 +25,11 @@ from tenacity import (
 LIBID = "49c69d9977574dd7942eb7b54f43355b"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 0
 
 # path to store mongodb ketFile
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v0/mongodb_backups.py
+++ b/lib/charms/mongodb/v0/mongodb_backups.py
@@ -36,11 +36,11 @@ from config import Config
 LIBID = "18c461132b824ace91af0d7abe85f40e"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 0
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v0/mongodb_provider.py
+++ b/lib/charms/mongodb/v0/mongodb_provider.py
@@ -25,11 +25,11 @@ from pymongo.errors import PyMongoError
 LIBID = "4067879ef7dd4261bf6c164bc29d94b1"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 0
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"

--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -35,12 +35,11 @@ Scopes = Config.Relations.Scopes
 LIBID = "e02a50f0795e4dd292f58e93b4f493dd"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
-LIBPATCH = 6
+LIBPATCH = 0
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v0/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb/v0/mongodb_vm_legacy_provider.py
@@ -17,11 +17,11 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 LIBID = "896a48bc89b84d30839335bb37170509"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 0
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
 

--- a/lib/charms/mongodb/v0/mongos.py
+++ b/lib/charms/mongodb/v0/mongos.py
@@ -16,11 +16,11 @@ from config import Config
 LIBID = "e20d5b19670d4c55a4934a21d3f3b29a"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 0
 
 # path to store mongodb ketFile
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v0/shards_interface.py
+++ b/lib/charms/mongodb/v0/shards_interface.py
@@ -38,11 +38,11 @@ logger = logging.getLogger(__name__)
 LIBID = "55fee8fa73364fb0a2dc16a954b2fd4a"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 0
 KEYFILE_KEY = "key-file"
 HOSTS_KEY = "host"
 OPERATOR_PASSWORD_KEY = MongoDBUser.get_password_key_name_for_user(OperatorUser.get_username())

--- a/lib/charms/mongodb/v0/users.py
+++ b/lib/charms/mongodb/v0/users.py
@@ -7,11 +7,11 @@ from typing import Set
 LIBID = "b74007eda21c453a89e4dcc6382aa2b3"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 0
 
 
 class MongoDBUser:


### PR DESCRIPTION
## Issue
Libraries will begin diverging for `5/edge` and `6/edge`

## Solution
create separate `LIB API` for `6/edge`

## Known issues with Charming Actions
Currently [charming actions does not support publishing/checking major libapi](https://github.com/canonical/charming-actions/issues/97), for this PR comment out the checks and manually publish libs on merge. In theory, we can comment them back in and have the workflows work again.