### PR TITLE
[DPE-2695] + [partial DPE-2700] POC Identify primary shard + Prevent removal of Primary shards

### DIFF
--- a/lib/charms/mongodb/v0/shards_interface.py
+++ b/lib/charms/mongodb/v0/shards_interface.py
@@ -22,6 +22,7 @@ from charms.mongodb.v0.mongos import (
     MongosConnection,
     ShardNotInClusterError,
     ShardNotPlannedForRemovalError,
+    RemovePrimaryShardError,
 )
 from charms.mongodb.v0.users import MongoDBUser, OperatorUser
 from ops.charm import CharmBase, EventBase, RelationBrokenEvent
@@ -170,6 +171,12 @@ class ShardingProvider(Object):
 
             logger.error("Deferring _on_relation_event for shards interface since: error=%r", e)
             event.defer()
+        except RemovePrimaryShardError:
+            cannot_proceed = (
+                "Attempt made to remove a primary shard, do not permit other hooks to execute."
+            )
+            logger.error(cannot_proceed)
+            raise (cannot_proceed)
         except (PyMongoError, NotReadyError) as e:
             logger.error("Deferring _on_relation_event for shards interface since: error=%r", e)
             event.defer()

--- a/lib/charms/mongodb/v0/shards_interface.py
+++ b/lib/charms/mongodb/v0/shards_interface.py
@@ -20,9 +20,9 @@ from charms.mongodb.v0.mongodb import (
 )
 from charms.mongodb.v0.mongos import (
     MongosConnection,
+    RemovePrimaryShardError,
     ShardNotInClusterError,
     ShardNotPlannedForRemovalError,
-    RemovePrimaryShardError,
 )
 from charms.mongodb.v0.users import MongoDBUser, OperatorUser
 from ops.charm import CharmBase, EventBase, RelationBrokenEvent
@@ -176,7 +176,7 @@ class ShardingProvider(Object):
                 "Attempt made to remove a primary shard, do not permit other hooks to execute."
             )
             logger.error(cannot_proceed)
-            raise (cannot_proceed)
+            raise
         except (PyMongoError, NotReadyError) as e:
             logger.error("Deferring _on_relation_event for shards interface since: error=%r", e)
             event.defer()


### PR DESCRIPTION
## Issue
Primary shards are not identified, this can pose problems if removing a primary shard

## Solution
Identify primary shards and prevent their removal

## Follow up PR
move databases that use a primary shard to a different shard if removing primary (I don't want to add this to this PR as to reduce the complexity in the review)

## Testing
As this is a POC there are no integration tests added, instead tests were performed by hand 
```
# deploy shards + config server
juju deploy ./*charm --config role="config-server" config-server-one 
juju deploy ./*charm --config role="shard" shard-one 
juju deploy ./*charm --config role="shard" shard-two 

# relate shards
juju integrate config-server-one:config-server shard-one:sharding
juju integrate config-server-one:config-server shard-two:sharding

# write data to shard-one
juju ssh config-server-one/0
charmed-mongodb.mongosh <URI>
use test_db
db.createCollection("cool_animals")
db.cool_animals.insertOne({"horses":"unicorn"})
sh.enableSharding("test_db")

# write data to shard-two
use test_db_2
db.createCollection("cool_animals")
db.cool_animals.insertOne({"horses":"unicorn"})
sh.enableSharding("test_db")
db.adminCommand( { movePrimary : "test_db_2", to : "shard-one" } )

# show both shards
use config 
show collections 
db.databases.find()

# exit
exit
exit

# remove shard and verify error in config server and forever wait in shard 
juju remove-relation config-server-one:config-server shard-two:sharding
juju status --watch 1s
```
