### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release to latest/edge
+name: Release to 6/edge
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v5
     with:
-      charmcraft-snap-channel: "latest/edge"
+      charmcraft-snap-channel: "latest/stable"
 
   release:
     name: Release charm


### PR DESCRIPTION
## Issue
1. Currently the ci job for releasing charm named in a confusing manner
2. Publishing charm to 6/edge is failing with `latest/edge` charmcraft

## Solution
1. Rename ci workflow for releasing 
2. Use `latest/stable` for release charm
