### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       charmcraft-snap-channel: "latest/stable"
 
-  release:
+  release-charm:
     name: Release charm
     needs:
       - ci-tests


### PR DESCRIPTION
## Issue
The releae-library job had wrong dependency

## Solution
Change `release` job name to `release-charm` name