### PR TITLE
Fix backup logging 6 edge

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_backups.py
+++ b/lib/charms/mongodb/v1/mongodb_backups.py
@@ -40,7 +40,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 
@@ -421,15 +421,14 @@ class MongoDBBackups(Object):
                 except ExecError as e:
                     self.charm.unit.status = BlockedStatus(self.process_pbm_error(e.stdout))
 
-    def get_pbm_status(self) -> StatusBase:
+    def get_pbm_status(self) -> Optional[StatusBase]:
         """Retrieve pbm status."""
         if not self.charm.has_backup_service():
             return WaitingStatus("waiting for pbm to start")
 
         if not self.model.get_relation(S3_RELATION):
             logger.info("No configurations for backups, not relation to s3-charm.")
-            return BlockedStatus("Backups require relation to s3-integrator")
-
+            return None
         try:
             previous_pbm_status = self.charm.unit.status
             pbm_status = self.charm.run_pbm_command(PBM_STATUS_CMD)

--- a/lib/charms/mongodb/v1/mongodb_backups.py
+++ b/lib/charms/mongodb/v1/mongodb_backups.py
@@ -426,6 +426,10 @@ class MongoDBBackups(Object):
         if not self.charm.has_backup_service():
             return WaitingStatus("waiting for pbm to start")
 
+        if not self.model.get_relation(S3_RELATION):
+            logger.info("No configurations for backups, not relation to s3-charm.")
+            return BlockedStatus("Backups require relation to s3-integrator")
+
         try:
             previous_pbm_status = self.charm.unit.status
             pbm_status = self.charm.run_pbm_command(PBM_STATUS_CMD)

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,7 @@ from charms.mongodb.v1.helpers import (
     generate_password,
     get_create_user_cmd,
 )
-from charms.mongodb.v1.mongodb_backups import S3_RELATION, MongoDBBackups
+from charms.mongodb.v1.mongodb_backups import MongoDBBackups
 from charms.mongodb.v1.mongodb_provider import MongoDBProvider
 from charms.mongodb.v1.mongodb_vm_legacy_provider import MongoDBLegacyProvider
 from charms.mongodb.v1.mongos import MongosConfiguration
@@ -1363,9 +1363,7 @@ class MongodbOperatorCharm(CharmBase):
             if self.is_role(Config.Role.CONFIG_SERVER)
             else None
         )
-        pbm_status = (
-            self.backups.get_pbm_status() if self.model.get_relation(S3_RELATION) else None
-        )
+        pbm_status = self.backups.get_pbm_status()
 
         # failure in mongodb takes precedence over sharding and config server
         if not isinstance(mongodb_status, ActiveStatus):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -422,19 +422,19 @@ class TestCharm(unittest.TestCase):
     @patch_network_get(private_address="1.1.1.1")
     @patch("charms.mongodb.v1.helpers.MongoDBConnection")
     @patch("charm.MongoDBConnection")
-    @patch("charm.MongoDBBackups.get_pbm_status")
     @patch("charm.build_unit_status")
+    @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm._connect_mongodb_exporter")
     def test_update_status_no_s3(
-        self, _, get_mongodb_status, get_pbm_status, connection, status_connection
+        self, _, has_backup_service, get_mongodb_status, connection, status_connection
     ):
         """Tests when the s3 relation isn't present that the MongoDB status is reported."""
         # assume leader has already initialised the replica set
         self.harness.set_leader(True)
         self.harness.charm.app_peer_data["db_initialised"] = "True"
         connection.return_value.__enter__.return_value.is_ready = True
+        has_backup_service.return_value = True
 
-        get_pbm_status.return_value = BlockedStatus("pbm")
         get_mongodb_status.return_value = ActiveStatus("mongodb")
         self.harness.charm.on.update_status.emit()
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus("mongodb"))

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -43,15 +43,21 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm.run_pbm_command")
-    def testget_pbm_status_snap_not_present(self, pbm_command, service):
+    def test_get_pbm_status_snap_not_present(self, pbm_command, service):
         """Tests that when the snap is not present pbm is in blocked state."""
+        relation_id = self.harness.add_relation(RELATION_NAME, "s3-integrator")
+        self.harness.add_relation_unit(relation_id, "s3-integrator/0")
+
         pbm_command.side_effect = ModelError("service pbm-agent not found")
         self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), BlockedStatus))
 
     @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm.run_pbm_command")
-    def testget_pbm_status_resync(self, pbm_command, service):
+    def test_get_pbm_status_resync(self, pbm_command, service):
         """Tests that when pbm is resyncing that pbm is in waiting state."""
+        relation_id = self.harness.add_relation(RELATION_NAME, "s3-integrator")
+        self.harness.add_relation_unit(relation_id, "s3-integrator/0")
+
         service.return_value = True
         pbm_command.return_value = (
             '{"running":{"type":"resync","opID":"64f5cc22a73b330c3880e3b2"}}'
@@ -60,16 +66,22 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm.run_pbm_command")
-    def testget_pbm_status_running(self, pbm_command, service):
+    def test_get_pbm_status_running(self, pbm_command, service):
         """Tests that when pbm not running an op that pbm is in active state."""
+        relation_id = self.harness.add_relation(RELATION_NAME, "s3-integrator")
+        self.harness.add_relation_unit(relation_id, "s3-integrator/0")
+
         service.return_value = True
         pbm_command.return_value = '{"running":{}}'
         self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), ActiveStatus))
 
     @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm.run_pbm_command")
-    def testget_pbm_status_incorrect_cred(self, pbm_command, service):
+    def test_get_pbm_status_incorrect_cred(self, pbm_command, service):
         """Tests that when pbm has incorrect credentials that pbm is in blocked state."""
+        relation_id = self.harness.add_relation(RELATION_NAME, "s3-integrator")
+        self.harness.add_relation_unit(relation_id, "s3-integrator/0")
+
         service.return_value = True
         pbm_command.side_effect = ExecError(
             command=["/usr/bin/pbm", "status"], exit_code=1, stdout="status code: 403", stderr=""
@@ -78,13 +90,22 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm.run_pbm_command")
-    def testget_pbm_status_incorrect_conf(self, pbm_command, service):
+    def test_get_pbm_status_incorrect_conf(self, pbm_command, service):
         """Tests that when pbm has incorrect configs that pbm is in blocked state."""
+        relation_id = self.harness.add_relation(RELATION_NAME, "s3-integrator")
+        self.harness.add_relation_unit(relation_id, "s3-integrator/0")
+
         service.return_value = True
         pbm_command.side_effect = ExecError(
             command=["/usr/bin/pbm", "status"], exit_code=1, stdout="status code: 404", stderr=""
         )
         self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), BlockedStatus))
+
+    @patch("charm.MongodbOperatorCharm.has_backup_service")
+    @patch("charm.MongodbOperatorCharm.run_pbm_command")
+    def test_get_pbm_status_no_config(self, pbm_command, service):
+        """Tests when configurations for pbm are not given through S3 there is no status."""
+        self.assertTrue(self.harness.charm.backups.get_pbm_status() is None)
 
     @patch("charm.snap.SnapCache")
     @patch("charms.mongodb.v1.mongodb_backups.wait_fixed")
@@ -643,8 +664,11 @@ class TestMongoBackups(unittest.TestCase):
 
     @patch("charm.MongodbOperatorCharm.has_backup_service")
     @patch("charm.MongodbOperatorCharm.run_pbm_command")
-    def testget_pbm_status_backup(self, run_pbm_command, service):
+    def test_get_pbm_status_backup(self, run_pbm_command, service):
         """Tests that when pbm running a backup that pbm is in maintenance state."""
+        relation_id = self.harness.add_relation(RELATION_NAME, "s3-integrator")
+        self.harness.add_relation_unit(relation_id, "s3-integrator/0")
+
         service.return_value = "pbm"
         run_pbm_command.return_value = '{"running":{"type":"backup","name":"2023-09-04T12:15:58Z","startTS":1693829759,"status":"oplog backup","opID":"64f5ca7e777e294530289465"}}'
         self.assertTrue(isinstance(self.harness.charm.backups.get_pbm_status(), MaintenanceStatus))


### PR DESCRIPTION
## Issue
Backup status logs error message, when not related to S3. Instead this should be info

## Context
Reported as a bug in [the k8s charm](https://github.com/canonical/mongodb-k8s-operator/issues/212)

## Solution
Update the libs here so they may be updated in k8s
