### PR TITLE
[DPE-2992] Part 1 - Provide Mongos with keyfile

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -8,7 +8,6 @@ shards.
 """
 import logging
 
-
 from ops.charm import CharmBase, EventBase
 from ops.framework import Object
 from ops.model import WaitingStatus
@@ -22,14 +21,14 @@ HOSTS_KEY = "host"
 CONFIG_SERVER_URI_KEY = "config-server-uri"
 
 # The unique Charmhub library identifier, never change it
-LIBID = "55fee8fa73364fb0a2dc16a954b2fd4a"
+LIBID = "58ad1ccca4974932ba22b97781b9b2a0"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 1
+LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 1
 
 
 class ClusterProvider(Object):

--- a/lib/charms/mongodb/v1/config_server_interface.py
+++ b/lib/charms/mongodb/v1/config_server_interface.py
@@ -6,20 +6,13 @@
 This class handles the sharing of secrets between sharded components, adding shards, and removing
 shards.
 """
-import json
 import logging
-
-from charms.operator_libs_linux.v1 import snap
-
-from charms.mongodb.v1.mongos import MongosConnection
 
 from ops.charm import CharmBase, EventBase
 from ops.framework import Object
+from ops.model import WaitingStatus
 
 from config import Config
-from charms.mongodb.v1.helpers import get_mongos_args, add_args_to_env
-
-from ops.model import BlockedStatus, WaitingStatus
 
 logger = logging.getLogger(__name__)
 KEYFILE_KEY = "key-file"
@@ -83,7 +76,7 @@ class ClusterProvider(Object):
             logger.info("Skipping relation joined event: hook checks did not pass")
             return
 
-        # TODO Future PR, sync tls secrets and PBM password
+        # TODO Future PR, provide URI
         # TODO Future PR, use secrets
         self._update_relation_data(
             event.relation.id,
@@ -129,7 +122,6 @@ class ClusterRequirer(Object):
 
     def _on_relation_changed(self, event):
         """Starts/restarts monogs with config server information."""
-
         relation_data = event.relation.data[event.app]
         if not relation_data.get(KEYFILE_KEY):
             event.defer()
@@ -138,32 +130,7 @@ class ClusterRequirer(Object):
 
         self.update_keyfile(key_file_contents=relation_data.get(KEYFILE_KEY))
 
-        # relation_data = event.relation.data[event.app]
-        # if not relation_data.get(CONFIG_SERVER_URI_KEY):
-        #     event.defer()
-        #     self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
-        #     return
-
-        # mongos_start_args = get_mongos_args(self.charm.mongos_config, snap_install=True, get_mongos_args=)
-        # add_args_to_env("MONGOS_ARGS", mongos_start_args)
-
-        # snap_cache = snap.SnapCache()
-        # mongodb_snap = snap_cache["charmed-mongodb"]
-
-        # try:
-        #     mongodb_snap.start(services=["mongos"], enable=True)
-        # except snap.SnapError as e:
-        #     logger.error("An exception occurred when starting mongos agent, error: %s.", str(e))
-        #     self.unit.status = BlockedStatus("couldn't start mongos")
-        #     return
-
-        # mongos_hosts = ",".join(self.charm._unit_ips)
-        # uri = f"mongodb://{mongos_hosts}"
-        # with MongosConnection(None, uri) as mongo:
-        #     if not mongo.is_ready:
-        #         self.unit.status = BlockedStatus("couldn't start mongos")
-        #         return
-
+        # TODO: Follow up PR. Start mongos with the config-server URI
         # TODO: Follow up PR. Add a user for mongos once it has been started
 
     def update_keyfile(self, key_file_contents: str) -> None:

--- a/lib/charms/mongodb/v1/config_server_interface.py
+++ b/lib/charms/mongodb/v1/config_server_interface.py
@@ -1,0 +1,187 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In this class, we manage relations between config-servers and shards.
+
+This class handles the sharing of secrets between sharded components, adding shards, and removing
+shards.
+"""
+import json
+import logging
+
+from charms.operator_libs_linux.v1 import snap
+
+from charms.mongodb.v1.mongos import MongosConnection
+
+from ops.charm import CharmBase, EventBase
+from ops.framework import Object
+
+from config import Config
+from charms.mongodb.v1.helpers import get_mongos_args, add_args_to_env
+
+from ops.model import BlockedStatus, WaitingStatus
+
+logger = logging.getLogger(__name__)
+KEYFILE_KEY = "key-file"
+KEY_FILE = "keyFile"
+HOSTS_KEY = "host"
+CONFIG_SERVER_URI_KEY = "config-server-uri"
+
+# The unique Charmhub library identifier, never change it
+LIBID = "55fee8fa73364fb0a2dc16a954b2fd4a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 4
+
+
+class ClusterProvider(Object):
+    """Manage relations between the config server and mongos router on the config-server side."""
+
+    def __init__(
+        self, charm: CharmBase, relation_name: str = Config.Relations.CLUSTER_RELATIONS_NAME
+    ) -> None:
+        """Constructor for ShardingProvider object."""
+        self.relation_name = relation_name
+        self.charm = charm
+
+        super().__init__(charm, self.relation_name)
+        self.framework.observe(
+            charm.on[self.relation_name].relation_joined, self._on_relation_joined
+        )
+
+        # TODO Future PRs handle scale down
+
+    def pass_hook_checks(self, event: EventBase) -> bool:
+        """Runs the pre-hooks checks for ClusterProvider, returns True if all pass."""
+        if not self.charm.is_relation_feasible(self.relation_name):
+            logger.info("Skipping event %s , relation not feasible.", type(event))
+            return False
+
+        if not self.charm.is_role(Config.Role.CONFIG_SERVER):
+            logger.info(
+                "Skipping %s. ShardingProvider is only be executed by config-server", type(event)
+            )
+            return False
+
+        if not self.charm.unit.is_leader():
+            return False
+
+        if not self.charm.db_initialised:
+            logger.info("Deferring %s. db is not initialised.", type(event))
+            event.defer()
+            return False
+
+        return True
+
+    def _on_relation_joined(self, event):
+        """Handles providing mongos with KeyFile and hosts."""
+        if not self.pass_hook_checks(event):
+            logger.info("Skipping relation joined event: hook checks did not pass")
+            return
+
+        # TODO Future PR, sync tls secrets and PBM password
+        # TODO Future PR, use secrets
+        self._update_relation_data(
+            event.relation.id,
+            {
+                KEYFILE_KEY: self.charm.get_secret(
+                    Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME
+                ),
+            },
+        )
+
+    def _update_relation_data(self, relation_id: int, data: dict) -> None:
+        """Updates a set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore, only the leader unit can call
+        it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            data: dict containing the key-value pairs
+                that should be updated in the relation.
+        """
+        if self.charm.unit.is_leader():
+            relation = self.charm.model.get_relation(self.relation_name, relation_id)
+            if relation:
+                relation.data[self.charm.model.app].update(data)
+
+
+class ClusterRequirer(Object):
+    """Manage relations between the config server and mongos router on the mongos side."""
+
+    def __init__(
+        self, charm: CharmBase, relation_name: str = Config.Relations.CLUSTER_RELATIONS_NAME
+    ) -> None:
+        """Constructor for ShardingProvider object."""
+        self.relation_name = relation_name
+        self.charm = charm
+
+        super().__init__(charm, self.relation_name)
+        self.framework.observe(
+            charm.on[self.relation_name].relation_changed, self._on_relation_changed
+        )
+        # TODO Future PRs handle scale down
+
+    def _on_relation_changed(self, event):
+        """Starts/restarts monogs with config server information."""
+
+        relation_data = event.relation.data[event.app]
+        if not relation_data.get(KEYFILE_KEY):
+            event.defer()
+            self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
+            return
+
+        self.update_keyfile(key_file_contents=relation_data.get(KEYFILE_KEY))
+
+        # relation_data = event.relation.data[event.app]
+        # if not relation_data.get(CONFIG_SERVER_URI_KEY):
+        #     event.defer()
+        #     self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
+        #     return
+
+        # mongos_start_args = get_mongos_args(self.charm.mongos_config, snap_install=True, get_mongos_args=)
+        # add_args_to_env("MONGOS_ARGS", mongos_start_args)
+
+        # snap_cache = snap.SnapCache()
+        # mongodb_snap = snap_cache["charmed-mongodb"]
+
+        # try:
+        #     mongodb_snap.start(services=["mongos"], enable=True)
+        # except snap.SnapError as e:
+        #     logger.error("An exception occurred when starting mongos agent, error: %s.", str(e))
+        #     self.unit.status = BlockedStatus("couldn't start mongos")
+        #     return
+
+        # mongos_hosts = ",".join(self.charm._unit_ips)
+        # uri = f"mongodb://{mongos_hosts}"
+        # with MongosConnection(None, uri) as mongo:
+        #     if not mongo.is_ready:
+        #         self.unit.status = BlockedStatus("couldn't start mongos")
+        #         return
+
+        # TODO: Follow up PR. Add a user for mongos once it has been started
+
+    def update_keyfile(self, key_file_contents: str) -> None:
+        """Updates keyfile on all units."""
+        # keyfile is set by leader in application data, application data does not necessarily
+        # match what is on the machine.
+        current_key_file = self.charm.get_keyfile_contents()
+        if not key_file_contents or key_file_contents == current_key_file:
+            return
+
+        # put keyfile on the machine with appropriate permissions
+        self.charm.push_file_to_unit(
+            parent_dir=Config.MONGOD_CONF_DIR, file_name=KEY_FILE, file_contents=key_file_contents
+        )
+
+        if not self.charm.unit.is_leader():
+            return
+
+        self.charm.set_secret(
+            Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME, key_file_contents
+        )

--- a/lib/charms/mongodb/v1/config_server_interface.py
+++ b/lib/charms/mongodb/v1/config_server_interface.py
@@ -8,6 +8,7 @@ shards.
 """
 import logging
 
+
 from ops.charm import CharmBase, EventBase
 from ops.framework import Object
 from ops.model import WaitingStatus
@@ -50,10 +51,6 @@ class ClusterProvider(Object):
 
     def pass_hook_checks(self, event: EventBase) -> bool:
         """Runs the pre-hooks checks for ClusterProvider, returns True if all pass."""
-        if not self.charm.is_relation_feasible(self.relation_name):
-            logger.info("Skipping event %s , relation not feasible.", type(event))
-            return False
-
         if not self.charm.is_role(Config.Role.CONFIG_SERVER):
             logger.info(
                 "Skipping %s. ShardingProvider is only be executed by config-server", type(event)

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -267,3 +267,23 @@ def process_pbm_status(pbm_status: str) -> StatusBase:
         return WaitingStatus("waiting to sync s3 configurations.")
 
     return ActiveStatus()
+
+
+def add_args_to_env(var: str, args: str):
+    """Adds the provided arguments to the environment as the provided variable."""
+    with open(Config.ENV_VAR_PATH, "r") as env_var_file:
+        env_vars = env_var_file.readlines()
+
+    args_added = False
+    for index, line in enumerate(env_vars):
+        if var in line:
+            args_added = True
+            env_vars[index] = f"{var}={args}"
+
+    # if it is the first time adding these args to the file - will will need to append them to the
+    # file
+    if not args_added:
+        env_vars.append(f"{var}={args}")
+
+    with open(Config.ENV_VAR_PATH, "w") as service_file:
+        service_file.writelines(env_vars)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,6 +27,8 @@ provides:
     interface: cos_agent
   config-server:
     interface: shards
+  cluster:
+    interface: config-server
 
 storage:
   mongodb:

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
+from charms.mongodb.v0.config_server_interface import ClusterProvider
 from charms.mongodb.v0.mongodb import (
     MongoDBConfiguration,
     MongoDBConnection,
@@ -20,7 +21,6 @@ from charms.mongodb.v0.mongodb import (
 )
 from charms.mongodb.v0.mongodb_secrets import SecretCache, generate_secret_label
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
-from charms.mongodb.v1.config_server_interface import ClusterProvider
 from charms.mongodb.v1.helpers import (
     KEY_FILE,
     TLS_EXT_CA_FILE,

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,8 @@ from charms.mongodb.v1.mongodb_provider import MongoDBProvider
 from charms.mongodb.v1.mongodb_vm_legacy_provider import MongoDBLegacyProvider
 from charms.mongodb.v1.mongos import MongosConfiguration
 from charms.mongodb.v1.shards_interface import ConfigServerRequirer, ShardingProvider
+from charms.mongodb.v1.config_server_interface import ClusterProvider
+
 from charms.mongodb.v1.users import (
     CHARM_USERS,
     BackupUser,
@@ -124,6 +126,7 @@ class MongodbOperatorCharm(CharmBase):
         self.tls = MongoDBTLS(self, Config.Relations.PEERS, substrate=Config.SUBSTRATE)
         self.backups = MongoDBBackups(self)
         self.config_server = ShardingProvider(self)
+        self.cluster = ClusterProvider(self)
         self.shard = ConfigServerRequirer(self)
 
         # relation events for Prometheus metrics are handled in the MetricsEndpointProvider

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,7 @@ from charms.mongodb.v0.mongodb import (
 )
 from charms.mongodb.v0.mongodb_secrets import SecretCache, generate_secret_label
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
+from charms.mongodb.v1.config_server_interface import ClusterProvider
 from charms.mongodb.v1.helpers import (
     KEY_FILE,
     TLS_EXT_CA_FILE,
@@ -37,8 +38,6 @@ from charms.mongodb.v1.mongodb_provider import MongoDBProvider
 from charms.mongodb.v1.mongodb_vm_legacy_provider import MongoDBLegacyProvider
 from charms.mongodb.v1.mongos import MongosConfiguration
 from charms.mongodb.v1.shards_interface import ConfigServerRequirer, ShardingProvider
-from charms.mongodb.v1.config_server_interface import ClusterProvider
-
 from charms.mongodb.v1.users import (
     CHARM_USERS,
     BackupUser,

--- a/src/config.py
+++ b/src/config.py
@@ -74,6 +74,7 @@ class Config:
         OBSOLETE_RELATIONS_NAME = "obsolete"
         SHARDING_RELATIONS_NAME = "sharding"
         CONFIG_SERVER_RELATIONS_NAME = "config-server"
+        CLUSTER_RELATIONS_NAME = "cluster"
         APP_SCOPE = "app"
         UNIT_SCOPE = "unit"
         DB_RELATIONS = [OBSOLETE_RELATIONS_NAME, NAME]

--- a/src/machine_helpers.py
+++ b/src/machine_helpers.py
@@ -4,7 +4,7 @@
 import logging
 
 from charms.mongodb.v0.mongodb import MongoDBConfiguration
-from charms.mongodb.v1.helpers import get_mongod_args, get_mongos_args, add_args_to_env
+from charms.mongodb.v1.helpers import add_args_to_env, get_mongod_args, get_mongos_args
 
 from config import Config
 

--- a/src/machine_helpers.py
+++ b/src/machine_helpers.py
@@ -4,7 +4,7 @@
 import logging
 
 from charms.mongodb.v0.mongodb import MongoDBConfiguration
-from charms.mongodb.v1.helpers import get_mongod_args, get_mongos_args
+from charms.mongodb.v1.helpers import get_mongod_args, get_mongos_args, add_args_to_env
 
 from config import Config
 
@@ -27,23 +27,3 @@ def update_mongod_service(
     if role == Config.Role.CONFIG_SERVER:
         mongos_start_args = get_mongos_args(config, snap_install=True)
         add_args_to_env("MONGOS_ARGS", mongos_start_args)
-
-
-def add_args_to_env(var: str, args: str):
-    """Adds the provided arguments to the environment as the provided variable."""
-    with open(Config.ENV_VAR_PATH, "r") as env_var_file:
-        env_vars = env_var_file.readlines()
-
-    args_added = False
-    for index, line in enumerate(env_vars):
-        if var in line:
-            args_added = True
-            env_vars[index] = f"{var}={args}"
-
-    # if it is the first time adding these args to the file - will will need to append them to the
-    # file
-    if not args_added:
-        env_vars.append(f"{var}={args}")
-
-    with open(Config.ENV_VAR_PATH, "w") as service_file:
-        service_file.writelines(env_vars)

--- a/tests/unit/test_config_server_lib.py
+++ b/tests/unit/test_config_server_lib.py
@@ -1,0 +1,55 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+import unittest
+from unittest.mock import patch
+
+from ops.model import BlockedStatus, ModelError
+from ops.testing import Harness
+
+from charm import MongodbOperatorCharm
+
+from .helpers import patch_network_get
+
+RELATION_NAME = "s3-credentials"
+
+
+class TestConfigServerInterface(unittest.TestCase):
+    @patch_network_get(private_address="1.1.1.1")
+    def setUp(self):
+        self.harness = Harness(MongodbOperatorCharm)
+        self.harness.begin()
+        self.harness.add_relation("database-peers", "database-peers")
+        self.harness.set_leader(True)
+        self.charm = self.harness.charm
+        self.addCleanup(self.harness.cleanup)
+
+    @patch("charm.ClusterProvider._update_relation_data")
+    def test_on_relation_joined_failed_hook_checks(self, _update_relation_data):
+        """Tests that no relation data is set when cluster joining conditions are not met."""
+
+        def is_role_mock_call(*args):
+            assert args == ("config-server",)
+            return False
+
+        self.harness.charm.app_peer_data["db_initialised"] = "True"
+
+        # fails due to being run on non-config-server
+        relation_id = self.harness.add_relation("cluster", "mongos")
+        self.harness.add_relation_unit(relation_id, "mongos/0")
+        _update_relation_data.assert_not_called()
+
+        # fails because db has not been initialized
+        del self.harness.charm.app_peer_data["db_initialised"]
+
+        def is_role_mock_call(*args):
+            assert args == ("config-server",)
+            return True
+
+        self.harness.charm.is_role = is_role_mock_call
+        self.harness.add_relation_unit(relation_id, "mongos/1")
+        _update_relation_data.assert_not_called()
+
+        # fails because not leader
+        self.harness.set_leader(False)
+        self.harness.add_relation_unit(relation_id, "mongos/2")
+        _update_relation_data.assert_not_called()


### PR DESCRIPTION
## Issue
DPE-2992 is to start the mongos subordinate charm with the provided config server. In order for the config server and for mongos to be connected they both must have the same keyfile

## Solution
Provide that key file

## Follow up PRs
1. A follow up PR on mongos charm that uses this library
2. Updating the library to actually start the mongos service with the information of the config server
3. Integration tests

## Testing
```
juju deploy ./*charm --config role="config-server" config-server
juju deploy application
juju deploy mongos
juju integrate application mongos
juju integrate mongos:cluster mongodb:cluster
juju ssh mongos
sudo cat KEY_FILE_PATH
```