### PR TITLE
[DPE-2995] Create mongos user

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -32,7 +32,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 class ClusterProvider(Object):

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -6,15 +6,14 @@
 This class handles the sharing of secrets between sharded components, adding shards, and removing
 shards.
 """
-import logging
 import json
+import logging
 
+from charms.mongodb.v1.helpers import add_args_to_env, get_mongos_args
+from charms.mongodb.v1.mongos import MongosConnection
 from ops.charm import CharmBase, EventBase
 from ops.framework import Object
-from ops.model import WaitingStatus, MaintenanceStatus, ActiveStatus
-
-from charms.mongodb.v1.helpers import get_mongos_args, add_args_to_env
-from charms.mongodb.v1.mongos import MongosConnection
+from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 
 from config import Config
 
@@ -51,7 +50,7 @@ class ClusterProvider(Object):
         )
 
         # TODO Future PRs handle scale down
-        # TODO Future PRs handle changing of units/passwords to be propogated to mongos
+        # TODO Future PRs handle changing of units/passwords to be propagated to mongos
 
     def pass_hook_checks(self, event: EventBase) -> bool:
         """Runs the pre-hooks checks for ClusterProvider, returns True if all pass."""
@@ -71,7 +70,7 @@ class ClusterProvider(Object):
 
         return True
 
-    def _on_relation_joined(self, event):
+    def _on_relation_joined(self, event) -> None:
         """Handles providing mongos with KeyFile and hosts."""
         if not self.pass_hook_checks(event):
             logger.info("Skipping relation joined event: hook checks did not pass")
@@ -133,7 +132,7 @@ class ClusterRequirer(Object):
         )
         # TODO Future PRs handle scale down
 
-    def _on_relation_changed(self, event):
+    def _on_relation_changed(self, event) -> None:
         """Starts/restarts monogs with config server information."""
         relation_data = event.relation.data[event.app]
         if not relation_data.get(KEYFILE_KEY) or not relation_data.get(CONFIG_SERVER_DB_KEY):
@@ -158,7 +157,7 @@ class ClusterRequirer(Object):
 
         # restart on high loaded databases can be very slow (e.g. up to 10-20 minutes).
         if not self.is_mongos_running():
-            logger.info("mongos has not started, deferfing")
+            logger.info("mongos has not started, deferring")
             self.charm.unit.status = WaitingStatus("Waiting for mongos to start")
             event.defer()
             return

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -7,10 +7,14 @@ This class handles the sharing of secrets between sharded components, adding sha
 shards.
 """
 import logging
+import json
 
 from ops.charm import CharmBase, EventBase
 from ops.framework import Object
-from ops.model import WaitingStatus
+from ops.model import WaitingStatus, MaintenanceStatus, ActiveStatus
+
+from charms.mongodb.v1.helpers import get_mongos_args, add_args_to_env
+from charms.mongodb.v1.mongos import MongosConnection
 
 from config import Config
 
@@ -18,7 +22,7 @@ logger = logging.getLogger(__name__)
 KEYFILE_KEY = "key-file"
 KEY_FILE = "keyFile"
 HOSTS_KEY = "host"
-CONFIG_SERVER_URI_KEY = "config-server-uri"
+CONFIG_SERVER_DB_KEY = "config-server-db"
 
 # The unique Charmhub library identifier, never change it
 LIBID = "58ad1ccca4974932ba22b97781b9b2a0"
@@ -47,6 +51,7 @@ class ClusterProvider(Object):
         )
 
         # TODO Future PRs handle scale down
+        # TODO Future PRs handle changing of units/passwords to be propogated to mongos
 
     def pass_hook_checks(self, event: EventBase) -> bool:
         """Runs the pre-hooks checks for ClusterProvider, returns True if all pass."""
@@ -72,7 +77,8 @@ class ClusterProvider(Object):
             logger.info("Skipping relation joined event: hook checks did not pass")
             return
 
-        # TODO Future PR, provide URI
+        config_server_db = self.generate_config_server_db()
+
         # TODO Future PR, use secrets
         self._update_relation_data(
             event.relation.id,
@@ -80,6 +86,7 @@ class ClusterProvider(Object):
                 KEYFILE_KEY: self.charm.get_secret(
                     Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME
                 ),
+                CONFIG_SERVER_DB_KEY: config_server_db,
             },
         )
 
@@ -98,6 +105,16 @@ class ClusterProvider(Object):
             relation = self.charm.model.get_relation(self.relation_name, relation_id)
             if relation:
                 relation.data[self.charm.model.app].update(data)
+
+    def generate_config_server_db(self) -> str:
+        """Generates the config server database for mongos to connect to."""
+        replica_set_name = self.charm.app.name
+        hosts = []
+        for host in self.charm._unit_ips:
+            hosts.append(f"{host}:{Config.MONGODB_PORT}")
+
+        hosts = ",".join(hosts)
+        return f"{replica_set_name}/{hosts}"
 
 
 class ClusterRequirer(Object):
@@ -119,32 +136,71 @@ class ClusterRequirer(Object):
     def _on_relation_changed(self, event):
         """Starts/restarts monogs with config server information."""
         relation_data = event.relation.data[event.app]
-        if not relation_data.get(KEYFILE_KEY):
+        if not relation_data.get(KEYFILE_KEY) or not relation_data.get(CONFIG_SERVER_DB_KEY):
             event.defer()
             self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
             return
 
-        self.update_keyfile(key_file_contents=relation_data.get(KEYFILE_KEY))
+        updated_keyfile = self.update_keyfile(key_file_contents=relation_data.get(KEYFILE_KEY))
+        updated_config = self.update_config_server_db(
+            config_server_db=relation_data.get(CONFIG_SERVER_DB_KEY)
+        )
 
-        # TODO: Follow up PR. Start mongos with the config-server URI
+        # avoid restarting mongos when possible
+        if not updated_keyfile and not updated_config and self.charm.monogs_initialised:
+            return
+
+        # mongos is not available until it is using new secrets
+        del self.charm.unit_peer_data["mongos_initialised"]
+        logger.info("Restarting mongos with new secrets")
+        self.charm.unit.status = MaintenanceStatus("starting mongos")
+        self.charm.restart_mongos_service()
+
+        # restart on high loaded databases can be very slow (e.g. up to 10-20 minutes).
+        if not self.is_mongos_running():
+            logger.info("mongos has not started, deferfing")
+            self.charm.unit.status = WaitingStatus("Waiting for mongos to start")
+            event.defer()
+            return
+
         # TODO: Follow up PR. Add a user for mongos once it has been started
+        self.charm.unit_peer_data["mongos_initialised"] = json.dumps(True)
+        self.charm.unit.status = ActiveStatus()
 
-    def update_keyfile(self, key_file_contents: str) -> None:
-        """Updates keyfile on all units."""
+    def is_mongos_running(self) -> bool:
+        """Returns true if mongos service is running."""
+        with MongosConnection(None, "mongodb://localhost:27018") as mongo:
+            return mongo.is_ready
+
+    def update_config_server_db(self, config_server_db) -> bool:
+        """Updates config server str when necessary."""
+        if self.charm.config_server_db == config_server_db:
+            return False
+
+        mongos_config = self.charm.mongos_config
+        mongos_start_args = get_mongos_args(
+            mongos_config, snap_install=True, config_server_db=config_server_db
+        )
+        add_args_to_env("MONGOS_ARGS", mongos_start_args)
+        self.charm.unit_peer_data["config_server_db"] = json.dumps(config_server_db)
+        return True
+
+    def update_keyfile(self, key_file_contents: str) -> bool:
+        """Updates keyfile when necessary."""
         # keyfile is set by leader in application data, application data does not necessarily
         # match what is on the machine.
         current_key_file = self.charm.get_keyfile_contents()
         if not key_file_contents or key_file_contents == current_key_file:
-            return
+            return False
 
         # put keyfile on the machine with appropriate permissions
         self.charm.push_file_to_unit(
             parent_dir=Config.MONGOD_CONF_DIR, file_name=KEY_FILE, file_contents=key_file_contents
         )
 
-        if not self.charm.unit.is_leader():
-            return
+        if self.charm.unit.is_leader():
+            self.charm.set_secret(
+                Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME, key_file_contents
+            )
 
-        self.charm.set_secret(
-            Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME, key_file_contents
-        )
+        return True

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -162,6 +162,7 @@ class ClusterRequirer(Object):
             event.defer()
             return
 
+        # TODO: Follow up PR. Create an "operator" user for this mongos
         # TODO: Follow up PR. Add a user for mongos once it has been started
         self.charm.unit_peer_data["mongos_initialised"] = json.dumps(True)
         self.charm.unit.status = ActiveStatus()

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -6,7 +6,6 @@
 This class handles the sharing of secrets between sharded components, adding shards, and removing
 shards.
 """
-import json
 import logging
 
 from charms.mongodb.v1.helpers import add_args_to_env, get_mongos_args
@@ -201,7 +200,6 @@ class ClusterRequirer(Object):
             mongos_config, snap_install=True, config_server_db=config_server_db
         )
         add_args_to_env("MONGOS_ARGS", mongos_start_args)
-        self.charm.unit_peer_data["config_server_db"] = json.dumps(config_server_db)
         return True
 
     def update_keyfile(self, key_file_contents: str) -> bool:

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -79,6 +79,9 @@ class ClusterProvider(Object):
 
         config_server_db = self.generate_config_server_db()
 
+        # create user and set secrets for mongos relation
+        self.charm.client_relations.oversee_users(None, None)
+
         # TODO Future PR, use secrets
         self._update_relation_data(
             event.relation.id,

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -81,8 +81,9 @@ def get_create_user_cmd(config: MongoDBConfiguration, mongo_path=MONGO_SHELL) ->
 
 
 def get_mongos_args(
-    config: MongoDBConfiguration,
+    config,
     snap_install: bool = False,
+    config_server_db: str = None,
 ) -> str:
     """Returns the arguments used for starting mongos on a config-server side application.
 
@@ -91,14 +92,14 @@ def get_mongos_args(
     """
     # mongos running on the config server communicates through localhost
     # use constant for port
-    config_server_uri = f"{config.replset}/localhost:27017"
+    config_server_db = config_server_db or f"{config.replset}/localhost:27017"
 
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
     cmd = [
         # mongos on config server side should run on 0.0.0.0 so it can be accessed by other units
         # in the sharded cluster
         "--bind_ip_all",
-        f"--configdb {config_server_uri}",
+        f"--configdb {config_server_db}",
         # config server is already using 27017
         f"--port {Config.MONGOS_PORT}",
         f"--keyFile={full_conf_dir}/{KEY_FILE}",

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -29,7 +29,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"

--- a/src/charm.py
+++ b/src/charm.py
@@ -1119,8 +1119,8 @@ class MongodbOperatorCharm(CharmBase):
                 self._init_backup_user()
                 self._init_monitor_user()
 
-                # in sharding, user management is handled by mongos subordinate charm
-                if self.is_role(Config.Role.REPLICATION):
+                # Bare replicas can create users or config-servers for related mongos apps
+                if not self.is_role(Config.Role.SHARD):
                     logger.info("Manage user")
                     self.client_relations.oversee_users(None, None)
 

--- a/tests/unit/test_config_server_lib.py
+++ b/tests/unit/test_config_server_lib.py
@@ -22,8 +22,8 @@ class TestConfigServerInterface(unittest.TestCase):
         self.charm = self.harness.charm
         self.addCleanup(self.harness.cleanup)
 
-    @patch("charm.ClusterProvider._update_relation_data")
-    def test_on_relation_joined_failed_hook_checks(self, _update_relation_data):
+    @patch("charm.ClusterProvider.update_relation_data")
+    def test_on_relation_joined_failed_hook_checks(self, update_relation_data):
         """Tests that no relation data is set when cluster joining conditions are not met."""
 
         def is_not_config_mock_call(*args):
@@ -36,7 +36,7 @@ class TestConfigServerInterface(unittest.TestCase):
         self.harness.charm.is_role = is_not_config_mock_call
         relation_id = self.harness.add_relation("cluster", "mongos")
         self.harness.add_relation_unit(relation_id, "mongos/0")
-        _update_relation_data.assert_not_called()
+        update_relation_data.assert_not_called()
 
         # fails because db has not been initialized
         del self.harness.charm.app_peer_data["db_initialised"]
@@ -47,9 +47,9 @@ class TestConfigServerInterface(unittest.TestCase):
 
         self.harness.charm.is_role = is_config_mock_call
         self.harness.add_relation_unit(relation_id, "mongos/1")
-        _update_relation_data.assert_not_called()
+        update_relation_data.assert_not_called()
 
         # fails because not leader
         self.harness.set_leader(False)
         self.harness.add_relation_unit(relation_id, "mongos/2")
-        _update_relation_data.assert_not_called()
+        update_relation_data.assert_not_called()


### PR DESCRIPTION
## Issue
related mongos suboridinate charm doesn't have its own user

## Solution
Create a user for related monogs subordinate charm

## Future PRs
1. implement relation on mongos suboridinate charm
2. enable mongos charm to change its requested database / roles 
3. share URI with hosting charm of mongos
4. add int tests once both charms are up to date on charmhub

## Testing
```

# deploy shards + config server
juju add-model test-0
cd ~/mongodb-operator
charmcraft pack
juju deploy ./*charm --config role="config-server" config-server
juju deploy ./*charm --config role="shard" shard

cd ~/mongos-operator
cp ~/mongodb-operator/lib/charms/mongodb/v0/config_server_interface.py lib/charms/mongodb/v0/config_server_interface.py
cp ~/mongodb-operator/lib/charms/mongodb/v1/helpers.py lib/charms/mongodb/v1/helpers.py
tox -e build
juju deploy ./*charm
cd ~/mongos-operator/tests/integration/application
juju deploy ./*charm


# relate
juju integrate mongos application
juju integrate config-server:config-server shard:sharding
juju integrate config-server:cluster mongos:cluster


juju ssh mongos/0
sudo charmed-mongodb.mongosh mongodb://relation-5:DOVn0liQ2taeIaLyL3yii8pYO4fsjoRW@%2Fvar%2Fsnap%2Fcharmed-mongodb%2Fcommon%2Fvar%2Fmongodb-27018.sock

```