### PR TITLE
Reset libpatch to fix publishing

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 1
 
 
 class ClusterProvider(Object):


### PR DESCRIPTION
## Issue
Charm has not successfully released the recent changes to 6/edge. This means library `config_server_interface.py` has never been publish so lib patch must be reset to 0

## Solution
Change lib patch