### PR TITLE
[DPE-3216] Bump workflow version for CI to version 8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
 
   build:
     name: Build charms
-    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v7
+    uses: canonical/data-platform-workflows/.github/workflows/build_charms_with_cache.yaml@v8
 
   integration-test:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v5.1.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v8
     with:
       charmcraft-snap-channel: "latest/stable"
 
@@ -26,7 +26,7 @@ jobs:
     needs:
       - ci-tests
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v5
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v8
     with:
       channel: 6/edge
       artifact-name: ${{ needs.build.outputs.artifact-name }}

--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   sync:
     name: Sync GitHub issue to Jira
-    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v2
+    uses: canonical/data-platform-workflows/.github/workflows/sync_issue_to_jira.yaml@v8
     with:
       jira-base-url: https://warthogs.atlassian.net
       jira-project-key: DPE

--- a/tox.ini
+++ b/tox.ini
@@ -94,7 +94,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical \#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -vvv --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ha_tests/test_ha.py

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ deps =
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
     pytest-mock
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/test_charm.py
@@ -94,7 +94,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical \#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -vvv --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/ha_tests/test_ha.py
@@ -110,7 +110,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/new_relations/test_charm_relations.py
@@ -126,7 +126,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/relation_tests/legacy_relations/test_charm_legacy_relations.py
@@ -142,7 +142,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/tls_tests/test_tls.py
@@ -163,7 +163,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/backup_tests/test_backups.py
@@ -179,7 +179,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/metrics_tests/test_metrics.py
@@ -195,7 +195,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/sharding_tests/test_sharding.py
@@ -211,7 +211,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/sharding_tests/test_sharding_relations.py
@@ -228,7 +228,7 @@ deps =
     pytest-mock
     pytest-operator
     protobuf==3.20 # temporary fix until new libjuju is released
-    git+https://github.com/canonical/data-platform-workflows@v5.1.2\#subdirectory=python/pytest_plugins/pytest_operator_cache
+    git+https://github.com/canonical/data-platform-workflows@v8\#subdirectory=python/pytest_plugins/pytest_operator_cache
     -r {tox_root}/requirements.txt
 commands =
     pytest -v --tb native --log-cli-level=INFO -s --durations=0 {posargs} {[vars]tests_path}/integration/


### PR DESCRIPTION
## Issue
We need to keep our github workflows up-to date with data platform ones

## Solution
Update the workflows to latest version

## Related issue
https://warthogs.atlassian.net/browse/DPE-3216