### PR TITLE
LIBPATCHES are too advanced on some files

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 1
 
 
 class ClusterProvider(Object):

--- a/lib/charms/mongodb/v1/shards_interface.py
+++ b/lib/charms/mongodb/v1/shards_interface.py
@@ -51,7 +51,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 2
 KEYFILE_KEY = "key-file"
 HOSTS_KEY = "host"
 OPERATOR_PASSWORD_KEY = MongoDBUser.get_password_key_name_for_user(OperatorUser.get_username())


### PR DESCRIPTION
The publishing workflows are failing [on GitHub](https://github.com/canonical/mongodb-operator/actions/runs/7197560677/job/19607662510) this was caused by
1. the first time publishing failed due to unrelated issue
2. then the libpatch was bumped on subsequent PRs as that is standard practice
3. then publish libs fails because of 2.