### PR TITLE
[DPE-3180] Share secrets to host application

### DIFF
--- a/lib/charms/mongodb/v1/mongos.py
+++ b/lib/charms/mongodb/v1/mongos.py
@@ -52,8 +52,11 @@ class MongosConfiguration:
     @property
     def uri(self):
         """Return URI concatenated from fields."""
-        hosts = [f"{host}:{self.port}" for host in self.hosts]
-        hosts = ",".join(hosts)
+        # mongos using Unix Domain Socket to communicate do not use port
+        if self.port:
+            self.hosts = [f"{host}:{self.port}" for host in self.hosts]
+
+        hosts = ",".join(self.hosts)
         # Auth DB should be specified while user connects to application DB.
         auth_source = ""
         if self.database != "admin":


### PR DESCRIPTION
## Issue
1. Mongos charm needs to be notified of updated username/password
2. URI construction in mongos should consider connections made via the Unix Domain Socket 

## Future PR
Most of the work for `DPE-3180` is done on the `mongos` charm. But the `mongos` charm relies on the libraries hosted by `mongodb` charm to make the necessary changes future work:
1. updates libraries
2. shares connection info to the application hosting the subordinate `mongos` charm
3. integration tests verifying its functiondd