### PR TITLE
[DPE-3181] fix flakey backup tets

### DIFF
--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -73,11 +73,12 @@ async def test_blocked_incorrect_creds(ops_test: OpsTest) -> None:
     )
 
     # verify that Charmed MongoDB is blocked and reports incorrect credentials
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
-        ops_test.model.wait_for_idle(apps=[db_app_name], status="blocked", idle_period=20),
-    )
-    db_unit = ops_test.model.applications[db_app_name].units[0]
+    async with ops_test.fast_forward():
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
+            ops_test.model.wait_for_idle(apps=[db_app_name], status="blocked", idle_period=20),
+        )
+        db_unit = ops_test.model.applications[db_app_name].units[0]
 
     assert db_unit.workload_status_message == "s3 credentials are incorrect."
 
@@ -91,10 +92,12 @@ async def test_blocked_incorrect_conf(ops_test: OpsTest) -> None:
     await helpers.set_credentials(ops_test, cloud="AWS")
 
     # wait for both applications to be idle with the correct statuses
-    await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
-        ops_test.model.wait_for_idle(apps=[db_app_name], status="blocked", idle_period=20),
-    )
+    async with ops_test.fast_forward():
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active"),
+            ops_test.model.wait_for_idle(apps=[db_app_name], status="blocked", idle_period=20),
+        )
+
     db_unit = ops_test.model.applications[db_app_name].units[0]
     assert db_unit.workload_status_message == "s3 configurations are incompatible."
 


### PR DESCRIPTION
## Issue
Fixes #249 . Backup tests flakey due to [workload status mismatch](https://github.com/canonical/mongodb-operator/actions/runs/7455337393/job/20284353585)

## Solution
Wait for all units to execute their `update_status` hook