### PR TITLE
[DPE-3314] remove secrets on broken

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 class ClusterProvider(Object):
@@ -182,8 +182,13 @@ class ClusterRequirer(Object):
         self.framework.observe(
             charm.on[self.relation_name].relation_changed, self._on_relation_changed
         )
-
-        # TODO Future PRs handle scale down
+        self.framework.observe(
+            charm.on[self.relation_name].relation_departed,
+            self.charm.check_relation_broken_or_scale_down,
+        )
+        self.framework.observe(
+            charm.on[self.relation_name].relation_broken, self._on_relation_broken
+        )
 
     def _on_database_created(self, event) -> None:
         if not self.charm.unit.is_leader():
@@ -227,6 +232,31 @@ class ClusterRequirer(Object):
             return
 
         self.charm.unit.status = ActiveStatus()
+
+    def _on_relation_broken(self, event) -> None:
+        # Only relation_deparated events can check if scaling down
+        departed_relation_id = event.relation.id
+        if not self.charm.has_departed_run(departed_relation_id):
+            logger.info(
+                "Deferring, must wait for relation departed hook to decide if relation should be removed."
+            )
+            event.defer()
+            return
+
+        if not self.charm.proceed_on_broken_event(event):
+            logger.info("Skipping relation broken event, broken event due to scale down")
+            return
+
+        self.charm.stop_mongos_service()
+        logger.info("Stopped mongos daemon")
+
+        if not self.charm.unit.is_leader():
+            return
+
+        logger.info("Database and user removed for mongos application")
+        self.charm.remove_secret(Config.Relations.APP_SCOPE, Config.Secrets.USERNAME)
+        self.charm.remove_secret(Config.Relations.APP_SCOPE, Config.Secrets.PASSWORD)
+        self.charm.remove_connection_info()
 
     # BEGIN: helper functions
 

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -14,7 +14,7 @@ from charms.data_platform_libs.v0.data_interfaces import (
 )
 from charms.mongodb.v1.helpers import add_args_to_env, get_mongos_args
 from charms.mongodb.v1.mongos import MongosConnection
-from ops.charm import CharmBase, EventBase
+from ops.charm import CharmBase, EventBase, RelationBrokenEvent
 from ops.framework import Object
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 
@@ -233,10 +233,9 @@ class ClusterRequirer(Object):
 
         self.charm.unit.status = ActiveStatus()
 
-    def _on_relation_broken(self, event) -> None:
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
         # Only relation_deparated events can check if scaling down
-        departed_relation_id = event.relation.id
-        if not self.charm.has_departed_run(departed_relation_id):
+        if not self.charm.has_departed_run(event.relation.id):
             logger.info(
                 "Deferring, must wait for relation departed hook to decide if relation should be removed."
             )

--- a/lib/charms/mongodb/v1/shards_interface.py
+++ b/lib/charms/mongodb/v1/shards_interface.py
@@ -147,8 +147,7 @@ class ShardingProvider(Object):
             return False
 
         if isinstance(event, RelationBrokenEvent):
-            departed_relation_id = event.relation.id
-            if not self.charm.has_departed_run(departed_relation_id):
+            if not self.charm.has_departed_run(event.relation.id):
                 logger.info(
                     "Deferring, must wait for relation departed hook to decide if relation should be removed."
                 )

--- a/src/charm.py
+++ b/src/charm.py
@@ -1334,16 +1334,16 @@ class MongodbOperatorCharm(CharmBase):
                 "Deferring, must wait for relation departed hook to decide if relation should be removed."
             )
             event.defer()
-            return
+            return False
 
         # check if were scaling down and add a log message
         if self.is_scaling_down(departed_relation_id):
             logger.info(
                 "Relation broken event occurring due to scale down, do not proceed to remove users."
             )
-            return
+            return False
 
-        return departed_relation_id
+        return True
 
     @staticmethod
     def _generate_relation_departed_key(rel_id: int) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -1323,10 +1323,8 @@ class MongodbOperatorCharm(CharmBase):
         self.unit_peer_data[rel_departed_key] = json.dumps(scaling_down)
         return scaling_down
 
-    def proceed_on_broken_event(self, event) -> int:
+    def proceed_on_broken_event(self, event) -> bool:
         """Returns relation_id if relation broken event occurred due to a removed relation."""
-        departed_relation_id = None
-
         # Only relation_deparated events can check if scaling down
         departed_relation_id = event.relation.id
         if not self.has_departed_run(departed_relation_id):


### PR DESCRIPTION
## FYI
most of the work here is done on the `mongos` side, but some changes are needed in the libs that are owned by this charm

## Issue
Secretes associated with username, password, uri are still present on the `host-application` and `mongos sub-charm` relation after relation with `config-server` and `mongos sub-charm` is broken

## Solution
Call appropriate functions from mongos charm

## Future PRs
1. Implementation + Integration tests added on mongos side

