### PR TITLE
[DPE-3297] Display audit logs in Canonical Observability Stack

### DIFF
--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -44,6 +44,7 @@ MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
 MONGO_SHELL = "charmed-mongodb.mongosh"
 
 DATA_DIR = "/var/lib/mongodb"
+LOG_DIR = "/var/log/mongodb"
 CONF_DIR = "/etc/mongod"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
@@ -130,9 +131,10 @@ def get_mongod_args(
     """
     full_data_dir = f"{MONGODB_COMMON_DIR}{DATA_DIR}" if snap_install else DATA_DIR
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
+    full_log_dir = f"{MONGODB_COMMON_DIR}{LOG_DIR}" if snap_install else LOG_DIR
     # in k8s the default logging options that are used for the vm charm are ignored and logs are
     # the output of the container. To enable logging to a file it must be set explicitly
-    logging_options = f"--logpath={full_data_dir}/{MONGODB_LOG_FILENAME}" if snap_install else ""
+    logging_options = f"--logpath={full_log_dir}/{MONGODB_LOG_FILENAME}" if snap_install else ""
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -29,7 +29,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -55,6 +55,8 @@ def _get_logging_options(snap_install: bool) -> str:
     # TODO sending logs to syslog until we have a separate mount point for logs
     if LOG_TO_SYSLOG:
         return ""
+    # in k8s the default logging options that are used for the vm charm are ignored and logs are
+    # the output of the container. To enable logging to a file it must be set explicitly
     return f"--logpath={LOG_DIR}/{MONGODB_LOG_FILENAME}" if snap_install else ""
 
 
@@ -139,8 +141,6 @@ def get_mongod_args(
     """
     full_data_dir = f"{MONGODB_COMMON_DIR}{DATA_DIR}" if snap_install else DATA_DIR
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
-    # in k8s the default logging options that are used for the vm charm are ignored and logs are
-    # the output of the container. To enable logging to a file it must be set explicitly
     logging_options = _get_logging_options(snap_install)
     cmd = [
         # bind to localhost and external interfaces

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -45,9 +45,17 @@ MONGO_SHELL = "charmed-mongodb.mongosh"
 
 DATA_DIR = "/var/lib/mongodb"
 LOG_DIR = "/var/log/mongodb"
+LOG_TO_SYSLOG = True
 CONF_DIR = "/etc/mongod"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
+
+
+def _get_logging_options(snap_install: bool) -> str:
+    # TODO sending logs to syslog until we have a separate mount point for logs
+    if LOG_TO_SYSLOG:
+        return ""
+    return f"--logpath={LOG_DIR}/{MONGODB_LOG_FILENAME}" if snap_install else ""
 
 
 # noinspection GrazieInspection
@@ -131,10 +139,9 @@ def get_mongod_args(
     """
     full_data_dir = f"{MONGODB_COMMON_DIR}{DATA_DIR}" if snap_install else DATA_DIR
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
-    full_log_dir = f"{MONGODB_COMMON_DIR}{LOG_DIR}" if snap_install else LOG_DIR
     # in k8s the default logging options that are used for the vm charm are ignored and logs are
     # the output of the container. To enable logging to a file it must be set explicitly
-    logging_options = f"--logpath={full_log_dir}/{MONGODB_LOG_FILENAME}" if snap_install else ""
+    logging_options = _get_logging_options(snap_install)
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",
@@ -145,9 +152,8 @@ def get_mongod_args(
         # for simplicity we run the mongod daemon on shards, configsvrs, and replicas on the same
         # port
         f"--port={Config.MONGODB_PORT}",
-        "--auditDestination=file",
+        "--auditDestination=syslog",  # TODO sending logs to syslog until we have a separate mount point for logs
         f"--auditFormat={Config.AuditLog.FORMAT}",
-        f"--auditPath={full_data_dir}/{Config.AuditLog.FILE_NAME}",
         logging_options,
     ]
     if auth:

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -132,7 +132,7 @@ def get_mongod_args(
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
     # in k8s the default logging options that are used for the vm charm are ignored and logs are
     # the output of the container. To enable logging to a file it must be set explicitly
-    logging_options = "" if snap_install else f"--logpath={full_data_dir}/{MONGODB_LOG_FILENAME}"
+    logging_options = f"--logpath={full_data_dir}/{MONGODB_LOG_FILENAME}" if snap_install else ""
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,7 @@ class Config:
     MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
     MONGOD_CONF_DIR = f"{MONGODB_SNAP_DATA_DIR}/etc/mongod"
     MONGOD_CONF_FILE_PATH = f"{MONGOD_CONF_DIR}/mongod.conf"
-    SNAP_PACKAGES = [("charmed-mongodb", "6/edge", 87)]
+    SNAP_PACKAGES = [("charmed-mongodb", "6/edge", 93)]
 
     # Keep these alphabetically sorted
     class Actions:
@@ -29,7 +29,7 @@ class Config:
         """Audit log related configuration."""
 
         FORMAT = "JSON"
-        FILE_NAME = "audit.json"
+        FILE_NAME = "audit.log"
 
     class Backup:
         """Backup related config for MongoDB Charm."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -340,11 +340,12 @@ async def test_exactly_one_primary_reported_by_juju(ops_test: OpsTest) -> None:
     await ops_test.model.destroy_unit(target_unit)
 
 
+@pytest.mark.skip("Skipping until write to log files enabled")
 async def test_audit_log(ops_test: OpsTest) -> None:
     """Test that audit log was created and contains actual audit data."""
     app_name = await get_app_name(ops_test)
     leader_unit = await find_unit(ops_test, leader=True, app_name=app_name)
-    audit_log_snap_path = "/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json"
+    audit_log_snap_path = "/var/snap/charmed-mongodb/common/var/log/mongodb/audit.log"
     audit_log = check_output(
         f"JUJU_MODEL={ops_test.model_full_name} juju ssh {leader_unit.name} 'sudo cat {audit_log_snap_path}'",
         stderr=subprocess.PIPE,

--- a/tests/unit/test_mongodb_helpers.py
+++ b/tests/unit/test_mongodb_helpers.py
@@ -14,10 +14,8 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--replSet=my_repl_set",
             "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
             "--port=27017",
-            "--auditDestination=file",
+            "--auditDestination=syslog",
             "--auditFormat=JSON",
-            "--auditPath=/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json",
-            "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
             "--auth",
             "--clusterAuthMode=keyFile",
             "--keyFile=/var/snap/charmed-mongodb/current/etc/mongod/keyFile",
@@ -40,10 +38,8 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--replSet=my_repl_set",
             "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
             "--port=27017",
-            "--auditDestination=file",
+            "--auditDestination=syslog",
             "--auditFormat=JSON",
-            "--auditPath=/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json",
-            "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
         ]
 
         self.assertEqual(
@@ -58,9 +54,8 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--replSet=my_repl_set",
             "--dbpath=/var/lib/mongodb",
             "--port=27017",
-            "--auditDestination=file",
+            "--auditDestination=syslog",
             "--auditFormat=JSON",
-            "--auditPath=/var/lib/mongodb/audit.json",
         ]
 
         self.assertEqual(

--- a/tests/unit/test_mongodb_helpers.py
+++ b/tests/unit/test_mongodb_helpers.py
@@ -17,6 +17,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--auditDestination=file",
             "--auditFormat=JSON",
             "--auditPath=/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json",
+            "--logpath=/var/snap/charmed-mongodb/common/var/lib/mongodb/mongodb.log",
             "--auth",
             "--clusterAuthMode=keyFile",
             "--keyFile=/var/snap/charmed-mongodb/current/etc/mongod/keyFile",
@@ -42,6 +43,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--auditDestination=file",
             "--auditFormat=JSON",
             "--auditPath=/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json",
+            "--logpath=/var/snap/charmed-mongodb/common/var/lib/mongodb/mongodb.log",
         ]
 
         self.assertEqual(
@@ -59,7 +61,6 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--auditDestination=file",
             "--auditFormat=JSON",
             "--auditPath=/var/lib/mongodb/audit.json",
-            "--logpath=/var/lib/mongodb/mongodb.log",
         ]
 
         self.assertEqual(

--- a/tests/unit/test_mongodb_helpers.py
+++ b/tests/unit/test_mongodb_helpers.py
@@ -17,7 +17,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--auditDestination=file",
             "--auditFormat=JSON",
             "--auditPath=/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json",
-            "--logpath=/var/snap/charmed-mongodb/common/var/lib/mongodb/mongodb.log",
+            "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
             "--auth",
             "--clusterAuthMode=keyFile",
             "--keyFile=/var/snap/charmed-mongodb/current/etc/mongod/keyFile",
@@ -43,7 +43,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--auditDestination=file",
             "--auditFormat=JSON",
             "--auditPath=/var/snap/charmed-mongodb/common/var/lib/mongodb/audit.json",
-            "--logpath=/var/snap/charmed-mongodb/common/var/lib/mongodb/mongodb.log",
+            "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
         ]
 
         self.assertEqual(


### PR DESCRIPTION
## Issue
A user\admin should be able to see audit logs in CoS

## Solution
As a first iteration of the feature - write audit logs to syslog 

<img width="1918" alt="Screenshot 2024-01-17 at 17 32 26" src="https://github.com/canonical/mongodb-operator/assets/132273757/56be76fe-6233-4c88-818b-70cd14b1aba1">


<img width="1812" alt="Screenshot 2024-01-17 at 17 34 08" src="https://github.com/canonical/mongodb-operator/assets/132273757/f45a7270-e100-454b-80af-707aeb52745e">
