### PR TITLE
revert TLS changes + update TLS to show failures

### DIFF
--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -29,7 +29,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -174,7 +174,7 @@ def get_mongod_args(
                 f"--tlsCAFile={full_conf_dir}/{TLS_EXT_CA_FILE}",
                 f"--tlsCertificateKeyFile={full_conf_dir}/{TLS_EXT_PEM_FILE}",
                 # allow non-TLS connections
-                "--tlsMode=requireTLS",
+                "--tlsMode=preferTLS",
                 "--tlsDisabledProtocols=TLS1_0,TLS1_1",
             ]
         )
@@ -184,6 +184,7 @@ def get_mongod_args(
         cmd.extend(
             [
                 "--clusterAuthMode=x509",
+                "--tlsAllowInvalidCertificates",
                 f"--tlsClusterCAFile={full_conf_dir}/{TLS_INT_CA_FILE}",
                 f"--tlsClusterFile={full_conf_dir}/{TLS_INT_PEM_FILE}",
             ]


### PR DESCRIPTION
## Issue
Current TLS options result in the charm not being functional
TLS tests pass even though the charm is not functional

## Solution
Revert options
Update TLS code to prevent the tests from succeeding when the charm is in-fact broken 