### PR TITLE
[DPE-3293] Changes external mongos

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -16,7 +16,7 @@ from charms.mongodb.v1.helpers import add_args_to_env, get_mongos_args
 from charms.mongodb.v1.mongos import MongosConnection
 from ops.charm import CharmBase, EventBase, RelationBrokenEvent
 from ops.framework import Object
-from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
 from config import Config
 
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class ClusterProvider(Object):
@@ -69,9 +69,12 @@ class ClusterProvider(Object):
             event.defer()
             return False
 
-        if not self.charm.is_role(Config.Role.CONFIG_SERVER):
+        is_integrated_to_mongos = len(
+            self.charm.model.relations[Config.Relations.CLUSTER_RELATIONS_NAME]
+        )
+        if not self.charm.is_role(Config.Role.CONFIG_SERVER) and is_integrated_to_mongos:
             logger.info(
-                "Skipping %s. ShardingProvider is only be executed by config-server", type(event)
+                "Skipping %s. ClusterProvider is only be executed by config-server", type(event)
             )
             return False
 
@@ -80,9 +83,20 @@ class ClusterProvider(Object):
 
         return True
 
+    def set_blocked_status_impossible_integration(self) -> None:
+        """Sets the status of the charm in the case that the integration is not possible."""
+        is_integrated_to_mongos = len(
+            self.charm.model.relations[Config.Relations.CLUSTER_RELATIONS_NAME]
+        )
+        if not self.charm.is_role(Config.Role.CONFIG_SERVER) and is_integrated_to_mongos:
+            self.charm.unit.status = BlockedStatus(
+                "Relation to mongos not supported, config role must be config-server"
+            )
+
     def _on_relation_changed(self, event) -> None:
         """Handles providing mongos with KeyFile and hosts."""
         if not self.pass_hook_checks(event):
+            self.set_blocked_status_impossible_integration()
             logger.info("Skipping relation joined event: hook checks did not pass")
             return
 
@@ -208,7 +222,6 @@ class ClusterRequirer(Object):
             event.relation.id, CONFIG_SERVER_DB_KEY
         )
         if not key_file_contents or not config_server_db:
-            event.defer()
             self.charm.unit.status = WaitingStatus("Waiting for secrets from config-server")
             return
 
@@ -261,7 +274,13 @@ class ClusterRequirer(Object):
 
     def is_mongos_running(self) -> bool:
         """Returns true if mongos service is running."""
-        with MongosConnection(None, f"mongodb://{MONGOS_SOCKET_URI_FMT}") as mongo:
+        connection_uri = f"mongodb://{self.charm.get_mongos_host()}"
+
+        # when running internally, connections through Unix Domain sockets do not need port.
+        if self.charm.is_external_client:
+            connection_uri = connection_uri + f":{Config.MONGOS_PORT}"
+
+        with MongosConnection(None, connection_uri) as mongo:
             return mongo.is_ready
 
     def update_config_server_db(self, config_server_db) -> bool:
@@ -271,7 +290,10 @@ class ClusterRequirer(Object):
 
         mongos_config = self.charm.mongos_config
         mongos_start_args = get_mongos_args(
-            mongos_config, snap_install=True, config_server_db=config_server_db
+            mongos_config,
+            snap_install=True,
+            config_server_db=config_server_db,
+            external_connectivity=self.charm.is_external_client,
         )
         add_args_to_env("MONGOS_ARGS", mongos_start_args)
         return True

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -1,4 +1,5 @@
 """Simple functions, which can be used in both K8s and VM charms."""
+
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 import json
@@ -29,7 +30,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 4
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -44,9 +45,20 @@ MONGODB_SNAP_DATA_DIR = "/var/snap/charmed-mongodb/current"
 MONGO_SHELL = "charmed-mongodb.mongosh"
 
 DATA_DIR = "/var/lib/mongodb"
+LOG_DIR = "/var/log/mongodb"
+LOG_TO_SYSLOG = True
 CONF_DIR = "/etc/mongod"
 MONGODB_LOG_FILENAME = "mongodb.log"
 logger = logging.getLogger(__name__)
+
+
+def _get_logging_options(snap_install: bool) -> str:
+    # TODO sending logs to syslog until we have a separate mount point for logs
+    if LOG_TO_SYSLOG:
+        return ""
+    # in k8s the default logging options that are used for the vm charm are ignored and logs are
+    # the output of the container. To enable logging to a file it must be set explicitly
+    return f"--logpath={LOG_DIR}/{MONGODB_LOG_FILENAME}" if snap_install else ""
 
 
 # noinspection GrazieInspection
@@ -131,9 +143,7 @@ def get_mongod_args(
     """
     full_data_dir = f"{MONGODB_COMMON_DIR}{DATA_DIR}" if snap_install else DATA_DIR
     full_conf_dir = f"{MONGODB_SNAP_DATA_DIR}{CONF_DIR}" if snap_install else CONF_DIR
-    # in k8s the default logging options that are used for the vm charm are ignored and logs are
-    # the output of the container. To enable logging to a file it must be set explicitly
-    logging_options = "" if snap_install else f"--logpath={full_data_dir}/{MONGODB_LOG_FILENAME}"
+    logging_options = _get_logging_options(snap_install)
     cmd = [
         # bind to localhost and external interfaces
         "--bind_ip_all",
@@ -144,6 +154,8 @@ def get_mongod_args(
         # for simplicity we run the mongod daemon on shards, configsvrs, and replicas on the same
         # port
         f"--port={Config.MONGODB_PORT}",
+        "--auditDestination=syslog",  # TODO sending logs to syslog until we have a separate mount point for logs
+        f"--auditFormat={Config.AuditLog.FORMAT}",
         logging_options,
     ]
     if auth:
@@ -165,6 +177,7 @@ def get_mongod_args(
                 f"--tlsCertificateKeyFile={full_conf_dir}/{TLS_EXT_PEM_FILE}",
                 # allow non-TLS connections
                 "--tlsMode=preferTLS",
+                "--tlsDisabledProtocols=TLS1_0,TLS1_1",
             ]
         )
 


### PR DESCRIPTION
## Issue
Mongos charm does not support external connections

## Solution
Enable mongos to provide an external connection when it is requested by the host charm

## Note
There are changes required in the shared MongoDB libs - but the bulk of this work will be done in the Mongos Charm