### PR TITLE
fix (tests): ensure that the leader is managing secrets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cosl==0.0.7
 importlib-resources==5.10.2
 tenacity==8.1.0
 pymongo==4.3.3
-ops==2.4.1
+ops==2.12
 jsonschema==4.17.3
 cryptography==38.0.4
 pure-sasl==0.6.2

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -720,8 +720,8 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.get_secret("unit", "non-existing-secret") is None
 
     def test_set_reset_existing_password_app(self):
-        """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
         self._setup_secrets()
+        self.harness.set_leader(True)
 
         # Getting current password
         self.harness.charm.set_secret("app", "monitor-password", "bla")
@@ -737,7 +737,8 @@ class TestCharm(unittest.TestCase):
 
     @parameterized.expand([("app"), ("unit")])
     def test_set_reset_new_secret(self, scope):
-        """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
+        self.harness.set_leader(True)
+
         # Getting current password
         self.harness.charm.set_secret(scope, "new-secret", "bla")
         assert self.harness.charm.get_secret(scope, "new-secret") == "bla"
@@ -760,8 +761,8 @@ class TestCharm(unittest.TestCase):
 
     @pytest.mark.usefixtures("use_caplog")
     def test_delete_password(self):
-        """NOTE: currently ops.testing seems to allow for non-leader to remove secrets too!"""
         self._setup_secrets()
+        self.harness.set_leader(True)
 
         assert self.harness.charm.get_secret("app", "monitor-password")
         self.harness.charm.remove_secret("app", "monitor-password")


### PR DESCRIPTION
## Issue

As of ops 2.10+ `Harness` applies the same access controls to secrets as Juju does in production. This causes tests to fail that were ignoring these access restrictions (deliberately - they have docstrings that call it out).

## Solution

Set the unit to be leader in each of the applicable tests. It might be that you'd rather have tests for both cases, leader and (failing appropriately) non-leader - I can adjust to do that if you prefer.