### PR TITLE
[DPE-3501] - add restore test for sharded cluster

### DIFF
--- a/tests/integration/backup_tests/helpers.py
+++ b/tests/integration/backup_tests/helpers.py
@@ -68,6 +68,15 @@ async def get_leader_unit(ops_test: OpsTest, db_app_name=None) -> ops.model.Unit
             return unit
 
 
+async def get_backup_list(ops_test: OpsTest, db_app_name=None) -> str:
+    """Count the number of logical backups."""
+    leader_unit = await get_leader_unit(ops_test, db_app_name=db_app_name)
+    action = await leader_unit.run_action(action_name="list-backups")
+    list_result = await action.wait()
+    list_result = list_result.results["backups"]
+    return list_result
+
+
 async def count_logical_backups(db_unit: ops.model.Unit) -> int:
     """Count the number of logical backups."""
     action = await db_unit.run_action(action_name="list-backups")

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -30,8 +30,7 @@ from ..helpers import get_app_name, get_unit_ip, instance_ip
 
 # TODO move these to a separate file for constants \ config
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-MONGOD_PORT = 27017
-MONGOS_PORT = 27018
+PORT = 27017
 APP_NAME = METADATA["name"]
 MONGO_COMMON_DIR = "/var/snap/charmed-mongodb/common"
 DB_PROCESS = "/usr/bin/mongod"
@@ -61,7 +60,7 @@ def replica_set_client(replica_ips: List[str], password: str, app_name: str) -> 
         password: password of database.
         app_name: name of application which hosts the cluster.
     """
-    hosts = ["{}:{}".format(replica_ip, MONGOD_PORT) for replica_ip in replica_ips]
+    hosts = ["{}:{}".format(replica_ip, PORT) for replica_ip in replica_ips]
     hosts = ",".join(hosts)
 
     replica_set_uri = f"mongodb://operator:" f"{password}@" f"{hosts}/admin?replicaSet={app_name}"
@@ -101,11 +100,7 @@ def unit_uri(ip_address: str, password, app_name=APP_NAME) -> str:
         password: password of database.
         app_name: name of application which has the cluster.
     """
-    return (
-        f"mongodb://operator:"
-        f"{password}@"
-        f"{ip_address}:{MONGOD_PORT}/admin?replicaSet={app_name}"
-    )
+    return f"mongodb://operator:" f"{password}@" f"{ip_address}:{PORT}/admin?replicaSet={app_name}"
 
 
 # TODO remove this duplicate with helpers.py
@@ -272,15 +267,10 @@ async def start_continous_writes(ops_test: OpsTest, starting_number: int) -> Non
     In the future this should be put in a dummy charm.
     """
     app_name = await get_app_name(ops_test)
-    port = MONGOS_PORT if "config-server" in app_name else MONGOD_PORT
-    repl_set = "" if "config-server" in app_name else f"?replicaSet={app_name}"
     password = await get_password(ops_test, app_name)
-    hosts = [
-        f"{unit.public_address}:{port}" for unit in ops_test.model.applications[app_name].units
-    ]
+    hosts = [unit.public_address for unit in ops_test.model.applications[app_name].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin{repl_set}"
-    print(connection_string)
+    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app_name}"
 
     # run continuous writes in the background.
     subprocess.Popen(
@@ -306,13 +296,9 @@ async def stop_continous_writes(ops_test: OpsTest, down_unit=None, app_name=None
 
     app_name = app_name or await get_app_name(ops_test)
     password = await get_password(ops_test, app_name, down_unit)
-    port = MONGOS_PORT if "config-server" in app_name else MONGOD_PORT
-    repl_set = "" if "config-server" in app_name else f"?replicaSet={app_name}"
-    hosts = [
-        f"{unit.public_address}:{port}" for unit in ops_test.model.applications[app_name].units
-    ]
+    hosts = [unit.public_address for unit in ops_test.model.applications[app_name].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin{repl_set}"
+    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app_name}"
 
     client = MongoClient(connection_string)
     db = client["new-db"]
@@ -328,13 +314,9 @@ async def count_writes(ops_test: OpsTest, down_unit=None, app_name=None) -> int:
     """New versions of pymongo no longer support the count operation, instead find is used."""
     app_name = app_name or await get_app_name(ops_test)
     password = await get_password(ops_test, app_name, down_unit)
-    port = MONGOS_PORT if "config-server" in app_name else MONGOD_PORT
-    repl_set = "" if "config-server" in app_name else f"?replicaSet={app_name}"
-    hosts = [
-        f"{unit.public_address}:{port}" for unit in ops_test.model.applications[app_name].units
-    ]
+    hosts = [unit.public_address for unit in ops_test.model.applications[app_name].units]
     hosts = ",".join(hosts)
-    connection_string = f"mongodb://operator:{password}@{hosts}/admin{repl_set}"
+    connection_string = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app_name}"
 
     client = MongoClient(connection_string)
     db = client["new-db"]
@@ -351,7 +333,7 @@ async def secondary_up_to_date(ops_test: OpsTest, unit_ip, expected_writes, app_
     """
     app_name = app_name or await get_app_name(ops_test)
     password = await get_password(ops_test, app_name)
-    connection_string = f"mongodb://operator:{password}@{unit_ip}:{MONGOD_PORT}/admin?"
+    connection_string = f"mongodb://operator:{password}@{unit_ip}:{PORT}/admin?"
     client = MongoClient(connection_string, directConnection=True)
 
     try:

--- a/tests/integration/sharding_tests/test_sharding_backups.py
+++ b/tests/integration/sharding_tests/test_sharding_backups.py
@@ -20,7 +20,7 @@ S3_APP_NAME = "s3-integrator"
 SHARD_ONE_APP_NAME = "shard-one"
 SHARD_TWO_APP_NAME = "shard-two"
 SHARD_APPS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME]
-CONFIG_SERVER_APP_NAME = "config-server-one"  # todo change to config_server
+CONFIG_SERVER_APP_NAME = "config-server"
 SHARD_REL_NAME = "sharding"
 CONFIG_SERVER_REL_NAME = "config-server"
 S3_REL_NAME = "s3-credentials"
@@ -201,8 +201,10 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
         assert backups == 2, "Backup not created after password rotation."
 
 
+@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_restore_backup(ops_test: OpsTest, add_writes_to_db) -> None:
+    """Tests that sharded Charmed MongoDB cluster supports restores."""
     # count total writes
     cluster_writes = await writes_helpers.get_cluster_writes_count(
         ops_test, shard_app_names=SHARD_APPS

--- a/tests/integration/sharding_tests/writes_helpers.py
+++ b/tests/integration/sharding_tests/writes_helpers.py
@@ -1,0 +1,132 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import subprocess
+from pathlib import Path
+
+import yaml
+from pymongo import MongoClient
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import get_password
+
+# TODO move these to a separate file for constants \ config
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+MONGOS_PORT = 27018
+APP_NAME = "config-server-one"  # todo change this back to config-server
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessError(Exception):
+    """Raised when a process fails."""
+
+
+class ProcessRunningError(Exception):
+    """Raised when a process is running when it is not expected to be."""
+
+
+async def mongos_uri(ops_test: OpsTest, config_server_name=APP_NAME) -> str:
+    password = await get_password(ops_test, app_name=config_server_name)
+    hosts = [
+        f"{unit.public_address}:{MONGOS_PORT}"
+        for unit in ops_test.model.applications[config_server_name].units
+    ]
+    hosts = ",".join(hosts)
+    return f"mongodb://operator:{password}@{hosts}/admin"
+
+
+async def clear_db_writes(ops_test: OpsTest, config_server_name=APP_NAME) -> bool:
+    """Stop the DB process and remove any writes to the test collection."""
+    await stop_continous_writes(ops_test)
+
+    # remove collection from database
+    connection_string = await mongos_uri(ops_test, config_server_name)
+
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+
+    # collection for continuous writes
+    test_collection = db["test_collection"]
+    test_collection.drop()
+
+    client.close()
+
+
+async def start_continous_writes(
+    ops_test: OpsTest, starting_number: int, config_server_name=APP_NAME
+) -> None:
+    """Starts continuous writes to MongoDB with available replicas.
+
+    In the future this should be put in a dummy charm.
+    """
+    connection_string = await mongos_uri(ops_test, config_server_name)
+
+    # run continuous writes in the background.
+    subprocess.Popen(
+        [
+            "python3",
+            "tests/integration/ha_tests/continuous_writes.py",
+            connection_string,
+            str(starting_number),
+        ]
+    )
+
+
+async def stop_continous_writes(ops_test: OpsTest, config_server_name=APP_NAME) -> int:
+    """Stops continuous writes to MongoDB and returns the last written value.
+
+    In the future this should be put in a dummy charm.
+    """
+    # stop the process
+    proc = subprocess.Popen(["pkill", "-9", "-f", "continuous_writes.py"])
+
+    # wait for process to be killed
+    proc.communicate()
+
+    connection_string = await mongos_uri(ops_test, config_server_name)
+
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+
+    # last written value should be the highest number in the database.
+    last_written_value = test_collection.find_one(sort=[("number", -1)])
+    client.close()
+    return last_written_value
+
+
+async def count_writes(ops_test: OpsTest, config_server_name=APP_NAME) -> int:
+    """New versions of pymongo no longer support the count operation, instead find is used."""
+    connection_string = await mongos_uri(ops_test, config_server_name)
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    # TODO shard collection
+    # TODO return count on each shard
+    count = test_collection.count_documents({})
+    client.close()
+    return count
+
+
+async def verify_writes(ops_test: OpsTest, config_server_name=APP_NAME):
+    # verify that no writes to the db were missed
+    total_expected_writes = await stop_continous_writes(ops_test)
+    actual_writes = await count_writes(ops_test, config_server_name)
+
+    # todo rework this whole function
+    assert total_expected_writes["number"] == actual_writes, "writes to the db were missed."
+
+
+async def insert_unwanted_data(ops_test: OpsTest, config_server_name=APP_NAME) -> None:
+    """Inserts the data into the MongoDB cluster via primary replica."""
+    connection_string = await mongos_uri(ops_test, config_server_name)
+
+    client = MongoClient(connection_string)
+    db = client["new-db"]
+    test_collection = db["test_collection"]
+    test_collection.insert_one({"unwanted_data": "bad data 1"})
+    test_collection.insert_one({"unwanted_data": "bad data 2"})
+    test_collection.insert_one({"unwanted_data": "bad data 3"})
+    client.close()

--- a/tests/integration/sharding_tests/writes_helpers.py
+++ b/tests/integration/sharding_tests/writes_helpers.py
@@ -16,7 +16,7 @@ from ..helpers import get_password
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 MONGOS_PORT = 27018
 MONGOD_PORT = 27017
-APP_NAME = "config-server-one"  # todo change this back to config-server
+APP_NAME = "config-server"
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +30,7 @@ class ProcessRunningError(Exception):
 
 
 async def mongos_uri(ops_test: OpsTest, config_server_name=APP_NAME) -> str:
+    """Returns a uri for connecting to mongos."""
     password = await get_password(ops_test, app_name=config_server_name)
     hosts = [
         f"{unit.public_address}:{MONGOS_PORT}"
@@ -59,10 +60,7 @@ async def clear_db_writes(ops_test: OpsTest, config_server_name=APP_NAME) -> boo
 async def start_continous_writes(
     ops_test: OpsTest, starting_number: int, config_server_name=APP_NAME
 ) -> None:
-    """Starts continuous writes to MongoDB with available replicas.
-
-    In the future this should be put in a dummy charm.
-    """
+    """Starts continuous writes to MongoDB."""
     connection_string = await mongos_uri(ops_test, config_server_name)
 
     # run continuous writes in the background.
@@ -77,10 +75,7 @@ async def start_continous_writes(
 
 
 async def stop_continous_writes(ops_test: OpsTest, config_server_name=APP_NAME) -> int:
-    """Stops continuous writes to MongoDB and returns the last written value.
-
-    In the future this should be put in a dummy charm.
-    """
+    """Stops continuous writes to MongoDB and returns the last written value."""
     # stop the process
     proc = subprocess.Popen(["pkill", "-9", "-f", "continuous_writes.py"])
 


### PR DESCRIPTION
## Issue
Uncertain that restores are supported in current backup implemenation

## Solution
Verify their functionality via an integration test


1. write some data into a shared collection.
2. check the amount of data on each shard
3. make a backup
4. write more data.
5. check the amount of data grown on each shard.
6. stop writing. make a restore
7. check the amount of data on each shard; should be equal to step 2