### PR TITLE
Each unit manages its own internal cert for TLS 

### DIFF
--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -218,8 +218,8 @@ class MongoDBTLS(Object):
             return
 
         logger.debug("Generating a new Certificate Signing Request.")
-        key = self.charm.get_tls_secret(internal, Config.TLS.SECRET_KEY_LABEL).encode("utf-8")
-        old_csr = self.charm.get_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL).encode("utf-8")
+        key = self.get_tls_secret(internal, Config.TLS.SECRET_KEY_LABEL).encode("utf-8")
+        old_csr = self.get_tls_secret(internal, Config.TLS.SECRET_CSR_LABEL).encode("utf-8")
         new_csr = generate_csr(
             private_key=key,
             subject=self.get_host(self.charm.unit),

--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -39,7 +39,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 logger = logging.getLogger(__name__)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -771,8 +771,8 @@ class MongodbOperatorCharm(CharmBase):
     def _get_mongos_config_for_user(
         self, user: MongoDBUser, hosts: Set[str]
     ) -> MongosConfiguration:
-        external_ca, _ = self.tls.get_tls_files(UNIT_SCOPE)
-        internal_ca, _ = self.tls.get_tls_files(APP_SCOPE)
+        external_ca, _ = self.tls.get_tls_files(internal=False)
+        internal_ca, _ = self.tls.get_tls_files(internal=True)
 
         return MongosConfiguration(
             database=user.get_database_name(),
@@ -788,8 +788,8 @@ class MongodbOperatorCharm(CharmBase):
     def _get_mongodb_config_for_user(
         self, user: MongoDBUser, hosts: Set[str], standalone: bool = False
     ) -> MongoDBConfiguration:
-        external_ca, _ = self.tls.get_tls_files(UNIT_SCOPE)
-        internal_ca, _ = self.tls.get_tls_files(APP_SCOPE)
+        external_ca, _ = self.tls.get_tls_files(internal=False)
+        internal_ca, _ = self.tls.get_tls_files(internal=True)
 
         return MongoDBConfiguration(
             replset=self.app.name,
@@ -996,7 +996,7 @@ class MongodbOperatorCharm(CharmBase):
 
     def push_tls_certificate_to_workload(self) -> None:
         """Uploads certificate to the workload container."""
-        external_ca, external_pem = self.tls.get_tls_files(UNIT_SCOPE)
+        external_ca, external_pem = self.tls.get_tls_files(internal=False)
         if external_ca is not None:
             self.push_file_to_unit(
                 parent_dir=Config.MONGOD_CONF_DIR,
@@ -1011,7 +1011,7 @@ class MongodbOperatorCharm(CharmBase):
                 file_contents=external_pem,
             )
 
-        internal_ca, internal_pem = self.tls.get_tls_files(APP_SCOPE)
+        internal_ca, internal_pem = self.tls.get_tls_files(internal=True)
         if internal_ca is not None:
             self.push_file_to_unit(
                 parent_dir=Config.MONGOD_CONF_DIR,

--- a/src/config.py
+++ b/src/config.py
@@ -54,15 +54,15 @@ class Config:
     class TLS:
         """TLS related config for MongoDB Charm."""
 
+        KEY_FILE_NAME = "keyFile"
+        TLS_PEER_RELATION = "certificates"
+        SECRET_KEY_LABEL = "key-secret"
+
         EXT_PEM_FILE = "external-cert.pem"
         EXT_CA_FILE = "external-ca.crt"
         INT_PEM_FILE = "internal-cert.pem"
         INT_CA_FILE = "internal-ca.crt"
-        KEY_FILE_NAME = "keyFile"
-        TLS_PEER_RELATION = "certificates"
-
         SECRET_CA_LABEL = "ca-secret"
-        SECRET_KEY_LABEL = "key-secret"
         SECRET_CERT_LABEL = "cert-secret"
         SECRET_CSR_LABEL = "csr-secret"
         SECRET_CHAIN_LABEL = "chain-secret"

--- a/tests/unit/test_tls_lib.py
+++ b/tests/unit/test_tls_lib.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from ops.testing import Harness
+from parameterized import parameterized
 
 from charm import MongodbOperatorCharm
 
@@ -23,13 +24,15 @@ class TestMongoTLS(unittest.TestCase):
         self.charm = self.harness.charm
         self.addCleanup(self.harness.cleanup)
 
+    @parameterized.expand([True, False])
     @patch_network_get(private_address="1.1.1.1")
-    def test_set_internal_tls_private_key(self):
+    def test_set_tls_private_keys(self, leader):
         """Tests setting of TLS private key via the leader, ie both internal and external.
 
         Note: this implicitly tests: _request_certificate & _parse_tls_file
         """
         # Tests for leader unit (ie internal certificates and external certificates)
+        self.harness.set_leader(leader)
         action_event = mock.Mock()
         action_event.params = {}
 
@@ -50,91 +53,21 @@ class TestMongoTLS(unittest.TestCase):
         self.verify_internal_rsa_csr(specific_rsa=True, expected_rsa=parsed_app_rsa_key)
         self.verify_external_rsa_csr()
 
+    @parameterized.expand([True, False])
     @patch_network_get(private_address="1.1.1.1")
-    def test_set_external_tls_private_key(self):
-        """Tests setting of TLS private key in external certificate scenarios.
-
-        Note: this implicitly tests: _request_certificate & _parse_tls_file
-        """
-        #  Tests for non-leader unit (ie external certificates)
-        self.harness.set_leader(False)
-        action_event = mock.Mock()
-        action_event.params = {}
-
-        # generated rsa key test - non-leader
-        self.harness.charm.tls._on_set_tls_private_key(action_event)
-        self.verify_external_rsa_csr()
-        # non-leaders should not reset the app key and app csr
-        self.verify_internal_rsa_csr(
-            specific_rsa=True, expected_rsa=None, specific_csr=True, expected_csr=None
-        )
-
-        # provided rsa key test - non-leader
-
-        with open("tests/unit/data/key.pem") as f:
-            key_contents = f.readlines()
-            key_contents = "".join(key_contents)
-
-        set_unit_rsa_key = key_contents
-        # we expect the app rsa key to be parsed such that its trailing newline is removed.
-        parsed_unit_rsa_key = set_unit_rsa_key[:-1]
-
-        action_event.params = {"external-key": set_unit_rsa_key}
-        self.harness.charm.tls._on_set_tls_private_key(action_event)
-        self.verify_external_rsa_csr(specific_rsa=True, expected_rsa=parsed_unit_rsa_key)
-        # non-leaders should not reset the app key and app csr
-        self.verify_internal_rsa_csr(
-            specific_rsa=True, expected_rsa=None, specific_csr=True, expected_csr=None
-        )
-
-    @patch_network_get(private_address="1.1.1.1")
-    def test_tls_relation_joined_non_leader(self):
-        """Test that non-leader units set only external certificates."""
-        self.harness.set_leader(False)
-        self.relate_to_tls_certificates_operator()
-        # non leaders should not be allowed to set internal certificates
-        self.verify_internal_rsa_csr(
-            specific_rsa=True, expected_rsa=None, specific_csr=True, expected_csr=None
-        )
-        self.verify_external_rsa_csr()
-
-    @patch_network_get(private_address="1.1.1.1")
-    def test_tls_relation_joined_leader(self):
+    def test_tls_relation_joined(self, leader):
         """Test that leader units set both external and internal certificates."""
+        self.harness.set_leader(leader)
         self.relate_to_tls_certificates_operator()
         self.verify_internal_rsa_csr()
         self.verify_external_rsa_csr()
 
+    @parameterized.expand([True, False])
     @patch("charm.MongodbOperatorCharm.restart_mongod_service")
     @patch_network_get(private_address="1.1.1.1")
-    def test_tls_relation_broken_non_leader(self, restart_mongod_service):
-        """Test non-leader removes only external cert & chain."""
-        # set initial certificate values
-        rel_id = self.relate_to_tls_certificates_operator()
-        app_rsa_key = self.harness.charm.get_secret("app", "key-secret")
-        app_csr = self.harness.charm.get_secret("app", "csr-secret")
-
-        self.harness.set_leader(False)
-        self.harness.remove_relation(rel_id)
-        ca_secret = self.harness.charm.get_secret("unit", "ca-secret")
-        cert_secret = self.harness.charm.get_secret("unit", "cert-secret")
-        chain_secret = self.harness.charm.get_secret("unit", "chain-secret")
-        self.assertIsNone(ca_secret)
-        self.assertIsNone(cert_secret)
-        self.assertIsNone(chain_secret)
-
-        #  internal certificate should be maintained
-        self.verify_internal_rsa_csr(
-            specific_rsa=True, expected_rsa=app_rsa_key, specific_csr=True, expected_csr=app_csr
-        )
-
-        # units should be restarted after updating TLS settings
-        restart_mongod_service.assert_called()
-
-    @patch("charm.MongodbOperatorCharm.restart_mongod_service")
-    @patch_network_get(private_address="1.1.1.1")
-    def test_tls_relation_broken_leader(self, restart_mongod_service):
-        """Test leader removes both external and internal certificates."""
+    def test_tls_relation_broken(self, leader, restart_mongod_service):
+        """Test removes both external and internal certificates."""
+        self.harness.set_leader(leader)
         # set initial certificate values
         rel_id = self.relate_to_tls_certificates_operator()
 
@@ -157,17 +90,17 @@ class TestMongoTLS(unittest.TestCase):
         """Verifies that when an external certificate expires a csr is made."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
-
-        self.harness.charm.set_secret("unit", "cert-secret", "unit-cert")
+        self.harness.charm.set_secret("unit", "int-cert-secret", "int-cert")
+        self.harness.charm.set_secret("unit", "ext-cert-secret", "ext-cert")
 
         # simulate current certificate expiring
-        old_csr = self.harness.charm.get_secret("unit", "csr-secret")
+        old_csr = self.harness.charm.get_secret("unit", "ext-csr-secret")
 
-        self.charm.tls.certs.on.certificate_expiring.emit(certificate="unit-cert", expiry=None)
+        self.charm.tls.certs.on.certificate_expiring.emit(certificate="ext-cert", expiry=None)
 
         # verify a new csr was generated
 
-        new_csr = self.harness.charm.get_secret("unit", "csr-secret")
+        new_csr = self.harness.charm.get_secret("unit", "ext-csr-secret")
         self.assertNotEqual(old_csr, new_csr)
 
     @patch_network_get(private_address="1.1.1.1")
@@ -175,23 +108,13 @@ class TestMongoTLS(unittest.TestCase):
         """Verifies that when an internal certificate expires a csr is made."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
-        self.harness.charm.set_secret("app", "cert-secret", "app-cert")
-        self.harness.charm.set_secret("unit", "cert-secret", "unit-cert")
+        self.harness.charm.set_secret("unit", "int-cert-secret", "int-cert")
+        self.harness.charm.set_secret("unit", "ext-cert-secret", "ext-cert")
 
-        # simulate current certificate expiring on non-leader
-        self.harness.set_leader(False)
-
-        old_csr = self.harness.charm.get_secret("app", "csr-secret")
-        self.charm.tls.certs.on.certificate_expiring.emit(certificate="app-cert", expiry=None)
-
-        # the csr should not be changed by non-leader units
-        new_csr = self.harness.charm.get_secret("app", "csr-secret")
-        self.assertEqual(old_csr, new_csr)
-
-        # verify a new csr was generated when leader receives expiry
-        self.harness.set_leader(True)
-        self.charm.tls.certs.on.certificate_expiring.emit(certificate="app-cert", expiry=None)
-        new_csr = self.harness.charm.get_secret("app", "csr-secret")
+        # verify a new csr was generated when unit receives expiry
+        old_csr = self.harness.charm.get_secret("unit", "int-csr-secret")
+        self.charm.tls.certs.on.certificate_expiring.emit(certificate="int-cert", expiry=None)
+        new_csr = self.harness.charm.get_secret("unit", "int-csr-secret")
         self.assertNotEqual(old_csr, new_csr)
 
     @patch_network_get(private_address="1.1.1.1")
@@ -199,17 +122,17 @@ class TestMongoTLS(unittest.TestCase):
         """Verifies that when an unknown certificate expires nothing happens."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
-        self.harness.charm.set_secret("app", "cert-secret", "app-cert")
-        self.harness.charm.set_secret("unit", "cert-secret", "unit-cert")
+        self.harness.charm.set_secret("unit", "int-cert-secret", "ext-cert")
+        self.harness.charm.set_secret("unit", "ext-cert-secret", "int-cert")
 
         # simulate unknown certificate expiring on leader
-        old_app_csr = self.harness.charm.get_secret("app", "csr-secret")
-        old_unit_csr = self.harness.charm.get_secret("unit", "csr-secret")
+        old_app_csr = self.harness.charm.get_secret("unit", "int-csr-secret")
+        old_unit_csr = self.harness.charm.get_secret("unit", "ext-csr-secret")
 
-        self.charm.tls.certs.on.certificate_expiring.emit(certificate="unknown-cert", expiry=None)
+        self.charm.tls.certs.on.certificate_expiring.emit(certificate="unknown-cert", expiry="")
 
-        new_app_csr = self.harness.charm.get_secret("app", "csr-secret")
-        new_unit_csr = self.harness.charm.get_secret("unit", "csr-secret")
+        new_app_csr = self.harness.charm.get_secret("unit", "int-csr-secret")
+        new_unit_csr = self.harness.charm.get_secret("unit", "ext-csr-secret")
 
         self.assertEqual(old_app_csr, new_app_csr)
         self.assertEqual(old_unit_csr, new_unit_csr)
@@ -221,9 +144,9 @@ class TestMongoTLS(unittest.TestCase):
         """Tests behavior when external certificate is made available."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
-        self.harness.charm.set_secret("unit", "csr-secret", "csr-secret")
-        self.harness.charm.set_secret("unit", "cert-secret", "unit-cert-old")
-        self.harness.charm.set_secret("app", "cert-secret", "app-cert")
+        self.harness.charm.set_secret("unit", "ext-csr-secret", "csr-secret")
+        self.harness.charm.set_secret("unit", "ext-cert-secret", "unit-cert-old")
+        self.harness.charm.set_secret("unit", "int-cert-secret", "app-cert")
 
         self.charm.tls.certs.on.certificate_available.emit(
             certificate_signing_request="csr-secret",
@@ -232,9 +155,9 @@ class TestMongoTLS(unittest.TestCase):
             ca="unit-ca",
         )
 
-        chain_secret = self.harness.charm.get_secret("unit", "chain-secret")
-        unit_secret = self.harness.charm.get_secret("unit", "cert-secret")
-        ca_secret = self.harness.charm.get_secret("unit", "ca-secret")
+        chain_secret = self.harness.charm.get_secret("unit", "ext-chain-secret")
+        unit_secret = self.harness.charm.get_secret("unit", "ext-cert-secret")
+        ca_secret = self.harness.charm.get_secret("unit", "ext-ca-secret")
 
         self.assertEqual(chain_secret, "unit-chain")
         self.assertEqual(unit_secret, "unit-cert")
@@ -249,24 +172,24 @@ class TestMongoTLS(unittest.TestCase):
         """Tests behavior when internal certificate is made available."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
-        self.harness.charm.set_secret("app", "csr-secret", "app-crs")
-        self.harness.charm.set_secret("app", "cert-secret", "app-cert-old")
-        self.harness.charm.set_secret("unit", "cert-secret", "unit-cert")
+        self.harness.charm.set_secret("unit", "int-csr-secret", "int-crs")
+        self.harness.charm.set_secret("unit", "int-cert-secret", "int-cert-old")
+        self.harness.charm.set_secret("unit", "ext-cert-secret", "ext-cert")
 
         self.charm.tls.certs.on.certificate_available.emit(
-            certificate_signing_request="app-crs",
-            chain=["app-chain"],
-            certificate="app-cert",
-            ca="app-ca",
+            certificate_signing_request="int-crs",
+            chain=["int-chain"],
+            certificate="int-cert",
+            ca="int-ca",
         )
 
-        chain_secret = self.harness.charm.get_secret("app", "chain-secret")
-        unit_secret = self.harness.charm.get_secret("app", "cert-secret")
-        ca_secret = self.harness.charm.get_secret("app", "ca-secret")
+        chain_secret = self.harness.charm.get_secret("unit", "int-chain-secret")
+        unit_secret = self.harness.charm.get_secret("unit", "int-cert-secret")
+        ca_secret = self.harness.charm.get_secret("unit", "int-ca-secret")
 
-        self.assertEqual(chain_secret, "app-chain")
-        self.assertEqual(unit_secret, "app-cert")
-        self.assertEqual(ca_secret, "app-ca")
+        self.assertEqual(chain_secret, "int-chain")
+        self.assertEqual(unit_secret, "int-cert")
+        self.assertEqual(ca_secret, "int-ca")
 
         restart_mongod_service.assert_called()
 
@@ -277,11 +200,11 @@ class TestMongoTLS(unittest.TestCase):
         """Tests that when an unknown certificate is available, nothing is updated."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
-        self.harness.charm.set_secret("app", "chain-secret", "app-chain-old")
-        self.harness.charm.set_secret("app", "cert-secret", "app-cert-old")
-        self.harness.charm.set_secret("app", "csr-secret", "app-crs-old")
-        self.harness.charm.set_secret("app", "ca-secret", "app-ca-old")
-        self.harness.charm.set_secret("unit", "cert-secret", "unit-cert")
+        self.harness.charm.set_secret("unit", "int-chain-secret", "app-chain-old")
+        self.harness.charm.set_secret("unit", "int-cert-secret", "app-cert-old")
+        self.harness.charm.set_secret("unit", "int-csr-secret", "app-crs-old")
+        self.harness.charm.set_secret("unit", "int-ca-secret", "app-ca-old")
+        self.harness.charm.set_secret("unit", "ext-cert-secret", "unit-cert")
 
         self.charm.tls.certs.on.certificate_available.emit(
             certificate_signing_request="app-crs",
@@ -290,9 +213,9 @@ class TestMongoTLS(unittest.TestCase):
             ca="app-ca",
         )
 
-        chain_secret = self.harness.charm.get_secret("app", "chain-secret")
-        unit_secret = self.harness.charm.get_secret("app", "cert-secret")
-        ca_secret = self.harness.charm.get_secret("app", "ca-secret")
+        chain_secret = self.harness.charm.get_secret("unit", "int-chain-secret")
+        unit_secret = self.harness.charm.get_secret("unit", "int-cert-secret")
+        ca_secret = self.harness.charm.get_secret("unit", "int-ca-secret")
 
         self.assertEqual(chain_secret, "app-chain-old")
         self.assertEqual(unit_secret, "app-cert-old")
@@ -314,8 +237,8 @@ class TestMongoTLS(unittest.TestCase):
 
         Checks if rsa/csr were randomly generated or if they are a provided value.
         """
-        unit_rsa_key = self.harness.charm.get_secret("unit", "key-secret")
-        unit_csr = self.harness.charm.get_secret("unit", "csr-secret")
+        unit_rsa_key = self.harness.charm.get_secret("unit", "ext-key-secret")
+        unit_csr = self.harness.charm.get_secret("unit", "ext-csr-secret")
 
         if specific_rsa:
             self.assertEqual(unit_rsa_key, expected_rsa)
@@ -334,14 +257,14 @@ class TestMongoTLS(unittest.TestCase):
 
         Checks if rsa/csr were randomly generated or if they are a provided value.
         """
-        app_rsa_key = self.harness.charm.get_secret("app", "key-secret")
-        app_csr = self.harness.charm.get_secret("app", "csr-secret")
+        int_rsa_key = self.harness.charm.get_secret("unit", "int-key-secret")
+        int_csr = self.harness.charm.get_secret("unit", "int-csr-secret")
         if specific_rsa:
-            self.assertEqual(app_rsa_key, expected_rsa)
+            self.assertEqual(int_rsa_key, expected_rsa)
         else:
-            self.assertEqual(app_rsa_key.split("\n")[0], "-----BEGIN RSA PRIVATE KEY-----")
+            self.assertEqual(int_rsa_key.split("\n")[0], "-----BEGIN RSA PRIVATE KEY-----")
 
         if specific_csr:
-            self.assertEqual(app_csr, expected_csr)
+            self.assertEqual(int_csr, expected_csr)
         else:
-            self.assertEqual(app_csr.split("\n")[0], "-----BEGIN CERTIFICATE REQUEST-----")
+            self.assertEqual(int_csr.split("\n")[0], "-----BEGIN CERTIFICATE REQUEST-----")


### PR DESCRIPTION
## Issue
Right now the leader manages the internal cert whereas each unit should manage their own internal cert.

## Solution
Have each unit manage their own internal cert i.e.
1. Generate
2. Rotate
3. Remove
