### PR TITLE
[DPE-3609] Fix rotate cluster + replicaset password

### DIFF
--- a/tests/integration/sharding_tests/test_sharding.py
+++ b/tests/integration/sharding_tests/test_sharding.py
@@ -6,6 +6,7 @@ import asyncio
 import pytest
 from pytest_operator.plugin import OpsTest
 
+from ..helpers import get_leader_id, get_password, set_password
 from .helpers import (
     generate_mongodb_client,
     has_correct_shards,
@@ -19,8 +20,11 @@ SHARD_TWO_APP_NAME = "shard-two"
 SHARD_THREE_APP_NAME = "shard-three"
 SHARD_APPS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME]
 CONFIG_SERVER_APP_NAME = "config-server-one"
+CLUSTER_APPS = [CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME]
 SHARD_REL_NAME = "sharding"
 CONFIG_SERVER_REL_NAME = "config-server"
+OPERATOR_USERNAME = "operator"
+OPERATOR_PASSWORD = "operator-password"
 MONGODB_KEYFILE_PATH = "/var/snap/charmed-mongodb/current/etc/mongod/keyFile"
 # for now we have a large timeout due to the slow drainage of the `config.system.sessions`
 # collection. More info here:
@@ -342,3 +346,51 @@ async def test_unconventual_shard_removal(ops_test: OpsTest):
         shard_name=SHARD_ONE_APP_NAME,
         expected_databases_on_shard=["animals_database_1", "animals_database_2"],
     ), "Not all databases on final shard"
+
+
+@pytest.mark.group(1)
+async def test_set_operator_password(ops_test: OpsTest):
+    """Tests that the cluster can safely set the operator password."""
+    shard_backup_password = await get_password(
+        ops_test, username=OPERATOR_USERNAME, app_name=SHARD_ONE_APP_NAME
+    )
+    assert (
+        shard_backup_password != OPERATOR_PASSWORD
+    ), "shard-one is incorrectly already set to the new password."
+
+    shard_backup_password = await get_password(
+        ops_test, username=OPERATOR_USERNAME, app_name=SHARD_TWO_APP_NAME
+    )
+    assert (
+        shard_backup_password != OPERATOR_PASSWORD
+    ), "shard-two is incorrectly already set to the new password."
+
+    # rotate password and verify that no unit goes into error as a result of password rotation
+    config_leader_id = await get_leader_id(ops_test, app_name=CONFIG_SERVER_APP_NAME)
+    await set_password(
+        ops_test, unit_id=config_leader_id, username=OPERATOR_USERNAME, password=OPERATOR_PASSWORD
+    )
+    await ops_test.model.wait_for_idle(
+        apps=CLUSTER_APPS,
+        status="active",
+        idle_period=20,
+    ),
+
+    config_svr_backup_password = await get_password(
+        ops_test, username=OPERATOR_USERNAME, app_name=CONFIG_SERVER_APP_NAME
+    )
+    assert (
+        config_svr_backup_password == OPERATOR_PASSWORD
+    ), "Application config-srver did not rotate password"
+    shard_backup_password = await get_password(
+        ops_test, username=OPERATOR_USERNAME, app_name=SHARD_ONE_APP_NAME
+    )
+    assert (
+        shard_backup_password == OPERATOR_PASSWORD
+    ), "Application shard-one did not rotate password"
+    shard_backup_password = await get_password(
+        ops_test, username=OPERATOR_USERNAME, app_name=SHARD_TWO_APP_NAME
+    )
+    assert (
+        shard_backup_password == OPERATOR_PASSWORD
+    ), "Application shard-two did not rotate password"

--- a/tests/integration/sharding_tests/test_sharding_backups.py
+++ b/tests/integration/sharding_tests/test_sharding_backups.py
@@ -274,14 +274,10 @@ async def test_restore_backup(ops_test: OpsTest, add_writes_to_shards) -> None:
 async def test_migrate_restore_backup(ops_test: OpsTest, add_writes_to_shards) -> None:
     """Tests that sharded Charmed MongoDB cluster supports restores."""
     config_leader_id = await get_leader_id(ops_test, app_name=CONFIG_SERVER_APP_NAME)
-    # TODO Future Work - determine the source of the temporary error state that occurs during the
-    # rotation of the operator user.
     await set_password(
         ops_test, unit_id=config_leader_id, username="operator", password=OPERATOR_PASSWORD
     )
-    await ops_test.model.wait_for_idle(
-        apps=CLUSTER_APPS, status="active", idle_period=20, raise_on_error=False
-    ),
+    await ops_test.model.wait_for_idle(apps=CLUSTER_APPS, status="active", idle_period=20)
 
     # count total writes
     cluster_writes = await writes_helpers.get_cluster_writes_count(
@@ -326,14 +322,12 @@ async def test_migrate_restore_backup(ops_test: OpsTest, add_writes_to_shards) -
     await deploy_cluster_backup_test(ops_test, deploy_s3_integrator=False)
     await setup_cluster_and_s3(ops_test)
     config_leader_id = await get_leader_id(ops_test, app_name=CONFIG_SERVER_APP_NAME)
-    # TODO Future Work - determine the source of the temporary error state that occurs during the
-    # rotation of the operator user.
     await set_password(
         ops_test, unit_id=config_leader_id, username="operator", password=OPERATOR_PASSWORD
     )
     await ops_test.model.wait_for_idle(
-        apps=CLUSTER_APPS, status="active", idle_period=20, timeout=TIMEOUT, raise_on_error=False
-    ),
+        apps=CLUSTER_APPS, status="active", idle_period=20, timeout=TIMEOUT
+    )
 
     # find most recent backup id and restore
     leader_unit = await backup_helpers.get_leader_unit(


### PR DESCRIPTION
## Issue
Rotating operator password for on MongoDB cluster or replica set results in “flickering” errors on update_status

## Solution
Fix this by adding extra processing that checks if passwords + tls settings are consistent across the cluster / replica set.
