### PR TITLE
[DPE-3832] Fix incorrect statuses for Adding shards

### DIFF
--- a/lib/charms/mongodb/v1/shards_interface.py
+++ b/lib/charms/mongodb/v1/shards_interface.py
@@ -328,10 +328,10 @@ class ShardingProvider(Object):
             return BlockedStatus("sharding interface cannot be used by replicas")
 
         if self.model.relations[LEGACY_REL_NAME]:
-            return BlockedStatus(f"relation {LEGACY_REL_NAME} to shard not supported.")
+            return BlockedStatus(f"Sharding roles do not support {LEGACY_REL_NAME} interface.")
 
         if self.model.relations[REL_NAME]:
-            return BlockedStatus(f"relation {REL_NAME} to shard not supported.")
+            return BlockedStatus(f"Sharding roles do not support {REL_NAME} interface.")
 
         if not self.is_mongos_running():
             return BlockedStatus("Internal mongos is not running.")
@@ -805,10 +805,10 @@ class ConfigServerRequirer(Object):
             return BlockedStatus("sharding interface cannot be used by replicas")
 
         if self.model.get_relation(LEGACY_REL_NAME):
-            return BlockedStatus(f"relation {LEGACY_REL_NAME} to shard not supported.")
+            return BlockedStatus(f"Sharding roles do not support {LEGACY_REL_NAME} interface.")
 
         if self.model.get_relation(REL_NAME):
-            return BlockedStatus(f"relation {REL_NAME} to shard not supported.")
+            return BlockedStatus(f"Sharding roles do not support {REL_NAME} interface.")
 
         if not self.model.get_relation(self.relation_name) and not self.charm.drained:
             return BlockedStatus("missing relation to config server")

--- a/tests/integration/sharding_tests/test_sharding_relations.py
+++ b/tests/integration/sharding_tests/test_sharding_relations.py
@@ -69,31 +69,29 @@ async def test_build_and_deploy(
     await ops_test.model.deploy(application_charm, application_name=APP_CHARM_NAME)
     await ops_test.model.deploy(legacy_charm, application_name=LEGACY_APP_CHARM_NAME)
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[
-                CONFIG_SERVER_ONE_APP_NAME,
-                CONFIG_SERVER_TWO_APP_NAME,
-                SHARD_ONE_APP_NAME,
-            ],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[
+            CONFIG_SERVER_ONE_APP_NAME,
+            CONFIG_SERVER_TWO_APP_NAME,
+            SHARD_ONE_APP_NAME,
+        ],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     await ops_test.model.integrate(
         f"{MONGOS_APP_NAME}",
         f"{MONGOS_HOST_APP_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[MONGOS_HOST_APP_NAME, MONGOS_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-            raise_on_error=False,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[MONGOS_HOST_APP_NAME, MONGOS_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
 
 
 @pytest.mark.group(1)
@@ -121,13 +119,12 @@ async def test_only_one_config_server_relation(ops_test: OpsTest) -> None:
         f"{CONFIG_SERVER_ONE_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[REPLICATION_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[REPLICATION_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
 
 @pytest.mark.group(1)
@@ -137,13 +134,12 @@ async def test_cannot_use_db_relation(ops_test: OpsTest) -> None:
     for sharded_component in SHARDING_COMPONENTS:
         await ops_test.model.integrate(f"{APP_CHARM_NAME}:{DATABASE_REL_NAME}", sharded_component)
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=SHARDING_COMPONENTS,
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=SHARDING_COMPONENTS,
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     for sharded_component in SHARDING_COMPONENTS:
         sharded_component_unit = ops_test.model.applications[sharded_component].units[0]
@@ -159,13 +155,12 @@ async def test_cannot_use_db_relation(ops_test: OpsTest) -> None:
             sharded_component,
         )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=SHARDING_COMPONENTS,
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=SHARDING_COMPONENTS,
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
 
 @pytest.mark.group(1)
@@ -175,13 +170,12 @@ async def test_cannot_use_legacy_db_relation(ops_test: OpsTest) -> None:
     for sharded_component in SHARDING_COMPONENTS:
         await ops_test.model.integrate(LEGACY_APP_CHARM_NAME, sharded_component)
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=SHARDING_COMPONENTS,
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=SHARDING_COMPONENTS,
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     for sharded_component in SHARDING_COMPONENTS:
         sharded_component_unit = ops_test.model.applications[sharded_component].units[0]
@@ -197,13 +191,12 @@ async def test_cannot_use_legacy_db_relation(ops_test: OpsTest) -> None:
             f"{LEGACY_APP_CHARM_NAME}:{LEGACY_RELATION_NAME}",
         )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=SHARDING_COMPONENTS,
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=SHARDING_COMPONENTS,
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
 
 @pytest.mark.group(1)
@@ -216,13 +209,12 @@ async def test_replication_config_server_relation(ops_test: OpsTest):
         f"{CONFIG_SERVER_ONE_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[REPLICATION_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[REPLICATION_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     replication_unit = ops_test.model.applications[REPLICATION_APP_NAME].units[0]
     assert (
@@ -246,13 +238,12 @@ async def test_replication_shard_relation(ops_test: OpsTest):
         f"{REPLICATION_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[REPLICATION_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[REPLICATION_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     replication_unit = ops_test.model.applications[REPLICATION_APP_NAME].units[0]
     assert (
@@ -265,13 +256,12 @@ async def test_replication_shard_relation(ops_test: OpsTest):
         f"{REPLICATION_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[REPLICATION_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[REPLICATION_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
 
 @pytest.mark.group(1)
@@ -284,13 +274,12 @@ async def test_replication_mongos_relation(ops_test: OpsTest) -> None:
         f"{MONGOS_APP_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[REPLICATION_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[REPLICATION_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     replication_unit = ops_test.model.applications[REPLICATION_APP_NAME].units[0]
     assert (
@@ -304,13 +293,12 @@ async def test_replication_mongos_relation(ops_test: OpsTest) -> None:
         f"{MONGOS_APP_NAME}:cluster",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[SHARD_ONE_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[SHARD_ONE_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
 
 @pytest.mark.group(1)
@@ -323,13 +311,12 @@ async def test_shard_mongos_relation(ops_test: OpsTest) -> None:
         f"{MONGOS_APP_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[SHARD_ONE_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[SHARD_ONE_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (
@@ -343,13 +330,12 @@ async def test_shard_mongos_relation(ops_test: OpsTest) -> None:
         f"{SHARD_ONE_APP_NAME}:cluster",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[SHARD_ONE_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[SHARD_ONE_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
 
 @pytest.mark.group(1)
@@ -362,13 +348,12 @@ async def test_shard_s3_relation(ops_test: OpsTest) -> None:
         f"{S3_APP_NAME}",
     )
 
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(
-            apps=[SHARD_ONE_APP_NAME],
-            idle_period=20,
-            raise_on_blocked=False,
-            timeout=TIMEOUT,
-        )
+    await ops_test.model.wait_for_idle(
+        apps=[SHARD_ONE_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+    )
 
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (

--- a/tests/integration/sharding_tests/test_sharding_relations.py
+++ b/tests/integration/sharding_tests/test_sharding_relations.py
@@ -69,29 +69,31 @@ async def test_build_and_deploy(
     await ops_test.model.deploy(application_charm, application_name=APP_CHARM_NAME)
     await ops_test.model.deploy(legacy_charm, application_name=LEGACY_APP_CHARM_NAME)
 
-    await ops_test.model.wait_for_idle(
-        apps=[
-            CONFIG_SERVER_ONE_APP_NAME,
-            CONFIG_SERVER_TWO_APP_NAME,
-            SHARD_ONE_APP_NAME,
-        ],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[
+                CONFIG_SERVER_ONE_APP_NAME,
+                CONFIG_SERVER_TWO_APP_NAME,
+                SHARD_ONE_APP_NAME,
+            ],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     await ops_test.model.integrate(
         f"{MONGOS_APP_NAME}",
         f"{MONGOS_HOST_APP_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[MONGOS_HOST_APP_NAME, MONGOS_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-        raise_on_error=False,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[MONGOS_HOST_APP_NAME, MONGOS_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+            raise_on_error=False,
+        )
 
 
 @pytest.mark.group(1)
@@ -119,12 +121,13 @@ async def test_only_one_config_server_relation(ops_test: OpsTest) -> None:
         f"{CONFIG_SERVER_ONE_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[REPLICATION_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[REPLICATION_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
 
 @pytest.mark.group(1)
@@ -134,12 +137,13 @@ async def test_cannot_use_db_relation(ops_test: OpsTest) -> None:
     for sharded_component in SHARDING_COMPONENTS:
         await ops_test.model.integrate(f"{APP_CHARM_NAME}:{DATABASE_REL_NAME}", sharded_component)
 
-    await ops_test.model.wait_for_idle(
-        apps=SHARDING_COMPONENTS,
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=SHARDING_COMPONENTS,
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     for sharded_component in SHARDING_COMPONENTS:
         sharded_component_unit = ops_test.model.applications[sharded_component].units[0]
@@ -155,12 +159,13 @@ async def test_cannot_use_db_relation(ops_test: OpsTest) -> None:
             sharded_component,
         )
 
-    await ops_test.model.wait_for_idle(
-        apps=SHARDING_COMPONENTS,
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=SHARDING_COMPONENTS,
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
 
 @pytest.mark.group(1)
@@ -170,12 +175,13 @@ async def test_cannot_use_legacy_db_relation(ops_test: OpsTest) -> None:
     for sharded_component in SHARDING_COMPONENTS:
         await ops_test.model.integrate(LEGACY_APP_CHARM_NAME, sharded_component)
 
-    await ops_test.model.wait_for_idle(
-        apps=SHARDING_COMPONENTS,
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=SHARDING_COMPONENTS,
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     for sharded_component in SHARDING_COMPONENTS:
         sharded_component_unit = ops_test.model.applications[sharded_component].units[0]
@@ -191,12 +197,13 @@ async def test_cannot_use_legacy_db_relation(ops_test: OpsTest) -> None:
             f"{LEGACY_APP_CHARM_NAME}:{LEGACY_RELATION_NAME}",
         )
 
-    await ops_test.model.wait_for_idle(
-        apps=SHARDING_COMPONENTS,
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=SHARDING_COMPONENTS,
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
 
 @pytest.mark.group(1)
@@ -209,12 +216,13 @@ async def test_replication_config_server_relation(ops_test: OpsTest):
         f"{CONFIG_SERVER_ONE_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[REPLICATION_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[REPLICATION_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     replication_unit = ops_test.model.applications[REPLICATION_APP_NAME].units[0]
     assert (
@@ -238,12 +246,13 @@ async def test_replication_shard_relation(ops_test: OpsTest):
         f"{REPLICATION_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[REPLICATION_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[REPLICATION_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     replication_unit = ops_test.model.applications[REPLICATION_APP_NAME].units[0]
     assert (
@@ -256,12 +265,13 @@ async def test_replication_shard_relation(ops_test: OpsTest):
         f"{REPLICATION_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[REPLICATION_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[REPLICATION_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
 
 @pytest.mark.group(1)
@@ -274,12 +284,13 @@ async def test_replication_mongos_relation(ops_test: OpsTest) -> None:
         f"{MONGOS_APP_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[REPLICATION_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[REPLICATION_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     replication_unit = ops_test.model.applications[REPLICATION_APP_NAME].units[0]
     assert (
@@ -293,12 +304,13 @@ async def test_replication_mongos_relation(ops_test: OpsTest) -> None:
         f"{MONGOS_APP_NAME}:cluster",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[SHARD_ONE_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
 
 @pytest.mark.group(1)
@@ -311,12 +323,13 @@ async def test_shard_mongos_relation(ops_test: OpsTest) -> None:
         f"{MONGOS_APP_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[SHARD_ONE_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (
@@ -330,12 +343,13 @@ async def test_shard_mongos_relation(ops_test: OpsTest) -> None:
         f"{SHARD_ONE_APP_NAME}:cluster",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[SHARD_ONE_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
 
 @pytest.mark.group(1)
@@ -348,12 +362,13 @@ async def test_shard_s3_relation(ops_test: OpsTest) -> None:
         f"{S3_APP_NAME}",
     )
 
-    await ops_test.model.wait_for_idle(
-        apps=[SHARD_ONE_APP_NAME],
-        idle_period=20,
-        raise_on_blocked=False,
-        timeout=TIMEOUT,
-    )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME],
+            idle_period=20,
+            raise_on_blocked=False,
+            timeout=TIMEOUT,
+        )
 
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (


### PR DESCRIPTION
## Issue
#380 - Shards incorrectly report `Adding shard to config-server` when they cannot reach the config-server. This may occur for three reasons:
1. The shard is truly getting added to the config-server and it does not have access to the config-server
2. The shard is getting its cluster password updated
3. The shard is getting updating TLS

In cases 2&3, the shard is not getting added to the cluster and so this status is wrong

## Solution
Report that the shard is getting added to the cluster only when it is truly getting added for the first time.

Reporting this status in `relation-changed` does not make sense since this hook is used to manage changes in the sharding interface. Therefore it makes the most sense to report this when the shard is actually getting added to the cluster (i.e. relation-joined) 