### PR TITLE
[DPE-3388] Write logs to files

### DIFF
--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -67,6 +67,7 @@ def _get_audit_log_settings(snap_install: bool) -> List[str]:
         f"--auditFormat={Config.AuditLog.FORMAT}",
     ]
 
+
 # noinspection GrazieInspection
 def get_create_user_cmd(config: MongoDBConfiguration, mongo_path=MONGO_SHELL) -> List[str]:
     """Creates initial admin user for MongoDB.
@@ -189,7 +190,7 @@ def get_mongod_args(
         # for simplicity we run the mongod daemon on shards, configsvrs, and replicas on the same
         # port
         f"--port={Config.MONGODB_PORT}",
-        "--setParameter processUmask=037", # required for log files perminission (g+r)
+        "--setParameter processUmask=037",  # required for log files perminission (g+r)
         logging_options,
     ]
     cmd.extend(audit_log_settings)

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -52,6 +52,11 @@ logger = logging.getLogger(__name__)
 
 
 def _get_logging_options(snap_install: bool) -> str:
+    """Returns config option for log path.
+
+    :param snap_install: indicate that charmed-mongodb was installed from snap (VM charms)
+    :return: a path to log file to be used
+    """
     log_path = f"{LOG_DIR}/{MONGODB_LOG_FILENAME}"
     if snap_install:
         log_path = f"{MONGODB_COMMON_DIR}{log_path}"
@@ -59,6 +64,11 @@ def _get_logging_options(snap_install: bool) -> str:
 
 
 def _get_audit_log_settings(snap_install: bool) -> List[str]:
+    """Return config options for audit log.
+
+    :param snap_install: indicate that charmed-mongodb was installed from snap (VM charms)
+    :return: a list of audit log settings for charmed MongoDB
+    """
     audit_log_path = f"{LOG_DIR}/{Config.AuditLog.FILE_NAME}"
     if snap_install:
         audit_log_path = f"{MONGODB_COMMON_DIR}{audit_log_path}"

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -59,12 +59,13 @@ def _get_logging_options(snap_install: bool) -> str:
 
 
 def _get_audit_log_settings(snap_install: bool) -> List[str]:
-    log_path = f"{LOG_DIR}/{Config.AuditLog.FILE_NAME}"
+    audit_log_path = f"{LOG_DIR}/{Config.AuditLog.FILE_NAME}"
     if snap_install:
-        log_path = f"{MONGODB_COMMON_DIR}{log_path}"
+        audit_log_path = f"{MONGODB_COMMON_DIR}{audit_log_path}"
     return [
         f"--auditDestination={Config.AuditLog.DESTINATION}",
         f"--auditFormat={Config.AuditLog.FORMAT}",
+        f"--auditPath={audit_log_path}"
     ]
 
 

--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -65,7 +65,7 @@ def _get_audit_log_settings(snap_install: bool) -> List[str]:
     return [
         f"--auditDestination={Config.AuditLog.DESTINATION}",
         f"--auditFormat={Config.AuditLog.FORMAT}",
-        f"--auditPath={audit_log_path}"
+        f"--auditPath={audit_log_path}",
     ]
 
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,6 +34,9 @@ storage:
   mongodb:
     type: filesystem
     location: /var/snap/charmed-mongodb/common
+  logs:
+    type: filesystem
+    location: /var/snap/charmed-mongodb/common/var/log/mongodb
 
 peers:
   database-peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -34,9 +34,6 @@ storage:
   mongodb:
     type: filesystem
     location: /var/snap/charmed-mongodb/common
-  logs:
-    type: filesystem
-    location: /var/snap/charmed-mongodb/common/var/log/mongodb
 
 peers:
   database-peers:

--- a/src/config.py
+++ b/src/config.py
@@ -44,6 +44,7 @@ class Config:
         """Audit log related configuration."""
 
         FORMAT = "JSON"
+        DESTINATION = "file"
         FILE_NAME = "audit.log"
 
     class Backup:

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -37,7 +37,7 @@ DB_PROCESS = "/usr/bin/mongod"
 MONGODB_LOG_PATH = f"{MONGO_COMMON_DIR}/var/log/mongodb/mongodb.log"
 MONGOD_SERVICE_DEFAULT_PATH = "/etc/systemd/system/snap.charmed-mongodb.mongod.service"
 TMP_SERVICE_PATH = "tests/integration/ha_tests/tmp.service"
-LOGGING_OPTIONS = f"--logpath={MONGO_COMMON_DIR}/var/log/mongodb/mongodb.log --logappend"
+LOGGING_OPTIONS = "--logappend"
 EXPORTER_PROC = "/usr/bin/mongodb_exporter"
 GREP_PROC = "grep"
 

--- a/tests/integration/sharding_tests/test_sharding_tls.py
+++ b/tests/integration/sharding_tests/test_sharding_tls.py
@@ -107,7 +107,6 @@ async def test_tls_then_build_cluster(ops_test: OpsTest) -> None:
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_tls_inconsistent_rels(ops_test: OpsTest) -> None:
-
     await ops_test.model.deploy(
         CERTS_APP_NAME, application_name=DIFFERENT_CERTS_APP_NAME, channel="stable"
     )

--- a/tests/unit/test_mongodb_helpers.py
+++ b/tests/unit/test_mongodb_helpers.py
@@ -14,7 +14,10 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--replSet=my_repl_set",
             "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
             "--port=27017",
-            "--auditDestination=syslog",
+            "--setParameter",
+            "processUmask=037",
+            "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
+            "--auditDestination=file",
             "--auditFormat=JSON",
             "--auth",
             "--clusterAuthMode=keyFile",
@@ -38,7 +41,10 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--replSet=my_repl_set",
             "--dbpath=/var/snap/charmed-mongodb/common/var/lib/mongodb",
             "--port=27017",
-            "--auditDestination=syslog",
+            "--setParameter",
+            "processUmask=037",
+            "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
+            "--auditDestination=file",
             "--auditFormat=JSON",
         ]
 
@@ -54,7 +60,10 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--replSet=my_repl_set",
             "--dbpath=/var/lib/mongodb",
             "--port=27017",
-            "--auditDestination=syslog",
+            "--setParameter",
+            "processUmask=037",
+            "--logpath=/var/log/mongodb/mongodb.log",
+            "--auditDestination=file",
             "--auditFormat=JSON",
         ]
 

--- a/tests/unit/test_mongodb_helpers.py
+++ b/tests/unit/test_mongodb_helpers.py
@@ -19,6 +19,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
             "--auditDestination=file",
             "--auditFormat=JSON",
+            "--auditPath=/var/snap/charmed-mongodb/common/var/log/mongodb/audit.log",
             "--auth",
             "--clusterAuthMode=keyFile",
             "--keyFile=/var/snap/charmed-mongodb/current/etc/mongod/keyFile",
@@ -46,6 +47,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--logpath=/var/snap/charmed-mongodb/common/var/log/mongodb/mongodb.log",
             "--auditDestination=file",
             "--auditFormat=JSON",
+            "--auditPath=/var/snap/charmed-mongodb/common/var/log/mongodb/audit.log",
         ]
 
         self.assertEqual(
@@ -65,6 +67,7 @@ class TestMongoDBHelpers(unittest.TestCase):
             "--logpath=/var/log/mongodb/mongodb.log",
             "--auditDestination=file",
             "--auditFormat=JSON",
+            "--auditPath=/var/log/mongodb/audit.log",
         ]
 
         self.assertEqual(

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ all_path = {[vars]src_path} {[vars]tests_path} {[vars]mongodb_lib_path}
 set_env =
     PYTHONPATH = {[vars]src_path}:{tox_root}/lib
     PY_COLORS=1
+    PYTHONDONTWRITEBYTECODE=1
 pass_env =
     PYTHONPATH
     CHARM_BUILD_DIR


### PR DESCRIPTION
## Issue
We need to write mongod logs and audit logs into files instead of syslog.

## Solution
Write logs to files located on a separate mount point
<img width="1142" alt="Screenshot 2024-04-05 at 10 47 21" src="https://github.com/canonical/mongodb-operator/assets/132273757/ab47d0a2-a760-4d03-a858-1aaf0dcbc35e">
