### PR TITLE
[DPE-3753] Support mongos tls

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -180,7 +180,7 @@ class ClusterProvider(Object):
             if new_ca is None:
                 self.database_provides.delete_relation_data(relation.id, {INT_TLS_CA_KEY: new_ca})
             else:
-                self._update_relation_data(relation.id, {INT_TLS_CA_KEY: new_ca})
+                self.database_provides.update_relation_data(relation.id, {INT_TLS_CA_KEY: new_ca})
 
 
 class ClusterRequirer(Object):

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -18,6 +18,7 @@ from ops.charm import CharmBase, EventBase, RelationBrokenEvent
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
+from typing import Optional
 from config import Config
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ KEY_FILE = "keyFile"
 HOSTS_KEY = "host"
 CONFIG_SERVER_DB_KEY = "config-server-db"
 MONGOS_SOCKET_URI_FMT = "%2Fvar%2Fsnap%2Fcharmed-mongodb%2Fcommon%2Fvar%2Fmongodb-27018.sock"
+INT_TLS_CA_KEY = f"int-{Config.TLS.SECRET_CA_LABEL}"
 
 # The unique Charmhub library identifier, never change it
 LIBID = "58ad1ccca4974932ba22b97781b9b2a0"
@@ -106,16 +108,22 @@ class ClusterProvider(Object):
         # create user and set secrets for mongos relation
         self.charm.client_relations.oversee_users(None, None)
 
+        relation_data = {
+            KEYFILE_KEY: self.charm.get_secret(
+                Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME
+            ),
+            CONFIG_SERVER_DB_KEY: config_server_db,
+        }
+
+        # if tls enabled
+        int_tls_ca = self.charm.tls.get_tls_secret(
+            internal=True, label_name=Config.TLS.SECRET_CA_LABEL
+        )
+        if int_tls_ca:
+            relation_data[INT_TLS_CA_KEY] = int_tls_ca
+
         if self.charm.unit.is_leader():
-            self.database_provides.update_relation_data(
-                event.relation.id,
-                {
-                    KEYFILE_KEY: self.charm.get_secret(
-                        Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME
-                    ),
-                    CONFIG_SERVER_DB_KEY: config_server_db,
-                },
-            )
+            self.database_provides.update_relation_data(event.relation.id, relation_data)
 
     def _on_relation_broken(self, event) -> None:
         # Only relation_deparated events can check if scaling down
@@ -166,6 +174,14 @@ class ClusterProvider(Object):
         hosts = ",".join(hosts)
         return f"{replica_set_name}/{hosts}"
 
+    def update_ca_secret(self, new_ca: str) -> None:
+        """Updates the new CA for all related shards."""
+        for relation in self.charm.model.relations[self.relation_name]:
+            if new_ca is None:
+                self.database_provides.delete_relation_data(relation.id, {INT_TLS_CA_KEY: new_ca})
+            else:
+                self._update_relation_data(relation.id, {INT_TLS_CA_KEY: new_ca})
+
 
 class ClusterRequirer(Object):
     """Manage relations between the config server and mongos router on the mongos side."""
@@ -182,7 +198,7 @@ class ClusterRequirer(Object):
             relations_aliases=[self.relation_name],
             database_name=self.charm.database,
             extra_user_roles=self.charm.extra_user_roles,
-            additional_secret_fields=[KEYFILE_KEY],
+            additional_secret_fields=[KEYFILE_KEY, INT_TLS_CA_KEY],
         )
 
         super().__init__(charm, self.relation_name)
@@ -318,5 +334,13 @@ class ClusterRequirer(Object):
             )
 
         return True
+
+    def get_config_server_name(self) -> Optional[str]:
+        """Returns the name of the Juju Application that mongos is using as a config server."""
+        if not self.model.get_relation(self.relation_name):
+            return None
+
+        # metadata.yaml prevents having multiple config servers
+        return self.charm.model.relations[self.relation_name][0].app.name
 
     # END: helper functions

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -122,8 +122,7 @@ class ClusterProvider(Object):
         if int_tls_ca:
             relation_data[INT_TLS_CA_KEY] = int_tls_ca
 
-        if self.charm.unit.is_leader():
-            self.database_provides.update_relation_data(event.relation.id, relation_data)
+        self.database_provides.update_relation_data(event.relation.id, relation_data)
 
     def _on_relation_broken(self, event) -> None:
         # Only relation_deparated events can check if scaling down

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -37,7 +37,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 class ClusterProvider(Object):

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -341,6 +341,6 @@ class ClusterRequirer(Object):
             return None
 
         # metadata.yaml prevents having multiple config servers
-        return self.charm.model.relations[self.relation_name][0].app.name
+        return self.model.get_relation(self.relation_name).app.name
 
     # END: helper functions

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -7,6 +7,7 @@ This class handles the sharing of secrets between sharded components, adding sha
 shards.
 """
 import logging
+from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
@@ -18,7 +19,6 @@ from ops.charm import CharmBase, EventBase, RelationBrokenEvent
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 
-from typing import Optional
 from config import Config
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -213,7 +213,8 @@ class MongoDBTLS(Object):
 
         if not self.charm.is_db_service_ready():
             self.charm.unit.status = WaitingStatus("Waiting for MongoDB to start")
-        else:
+        elif self.charm.unit.status == WaitingStatus("Waiting for MongoDB to start"):
+            # clear waiting status if db service is ready
             self.charm.unit.status = ActiveStatus()
 
     def waiting_for_certs(self):

--- a/lib/charms/mongodb/v0/mongodb_tls.py
+++ b/lib/charms/mongodb/v0/mongodb_tls.py
@@ -38,7 +38,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -124,7 +124,7 @@ class MongoDBProvider(Object):
         if self.substrate == "vm" and not self.charm.auth_enabled():
             logger.debug("Enabling authentication.")
             self.charm.unit.status = MaintenanceStatus("re-enabling authentication")
-            self.charm.restart_mongod_service(auth=True)
+            self.charm.restart_charm_services(auth=True)
             self.charm.unit.status = ActiveStatus()
 
         departed_relation_id = None

--- a/lib/charms/mongodb/v1/mongodb_vm_legacy_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_vm_legacy_provider.py
@@ -77,7 +77,7 @@ class MongoDBLegacyProvider(Object):
             try:
                 logger.debug("Disabling authentication.")
                 self.charm.unit.status = MaintenanceStatus("disabling authentication")
-                self.charm.restart_mongod_service(auth=False)
+                self.charm.restart_charm_services(auth=False)
                 self.charm.unit.status = ActiveStatus()
             except (systemd.SystemdError, snap.SnapError) as e:
                 logger.debug("Error disabling authentication %s", e)

--- a/lib/charms/mongodb/v1/mongos.py
+++ b/lib/charms/mongodb/v1/mongos.py
@@ -61,7 +61,7 @@ class MongosConfiguration:
         # Auth DB should be specified while user connects to application DB.
         auth_source = ""
         if self.database != "admin":
-            auth_source = "&authSource=admin"
+            auth_source = "authSource=admin"
         return (
             f"mongodb://{quote_plus(self.username)}:"
             f"{quote_plus(self.password)}@"

--- a/lib/charms/mongodb/v1/shards_interface.py
+++ b/lib/charms/mongodb/v1/shards_interface.py
@@ -950,7 +950,7 @@ class ConfigServerRequirer(Object):
         )
 
         # when the contents of the keyfile change, we must restart the service
-        self.charm.restart_mongod_service()
+        self.charm.restart_charm_services()
 
         if not self.charm.unit.is_leader():
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -1505,9 +1505,7 @@ class MongodbOperatorCharm(CharmBase):
             return mongod_ready
 
         with MongoDBConnection(self.mongos_config) as mongos:
-            mongos_ready = mongos.is_ready
-
-        return mongod_ready and mongos_ready
+            return mongod_ready and mongos.is_ready
 
     # END: helper functions
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1486,6 +1486,16 @@ class MongodbOperatorCharm(CharmBase):
         """Returns true if charm is running as a sharded component."""
         return self.is_role(Config.Role.SHARD) or self.is_role(Config.Role.CONFIG_SERVER)
 
+    def get_config_server_name(self) -> Optional[str]:
+        """Returns the name of the Juju Application that the shard is using as a config server."""
+        if not self.is_role(Config.Role.SHARD):
+            logger.info(
+                "Component %s is not a shard, cannot be integrated to a config-server.", self.role
+            )
+            return None
+
+        return self.shard.get_config_server_name()
+
     # END: helper functions
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1238,7 +1238,7 @@ class MongodbOperatorCharm(CharmBase):
         if self.is_role(Config.Role.CONFIG_SERVER):
             mongodb_snap.stop(services=["mongos"])
 
-    def restart_mongod_service(self, auth=None):
+    def restart_charm_services(self, auth=None):
         """Restarts the mongod service with its associated configuration."""
         if auth is None:
             auth = self.auth_enabled()
@@ -1495,6 +1495,19 @@ class MongodbOperatorCharm(CharmBase):
             return None
 
         return self.shard.get_config_server_name()
+
+    def is_db_service_ready(self) -> bool:
+        """Returns True if the underlying database service is ready."""
+        with MongoDBConnection(self.mongodb_config) as mongod:
+            mongod_ready = mongod.is_ready
+
+        if not self.is_role(Config.Role.CONFIG_SERVER):
+            return mongod_ready
+
+        with MongoDBConnection(self.mongos_config) as mongos:
+            mongos_ready = mongos.is_ready
+
+        return mongod_ready and mongos_ready
 
     # END: helper functions
 

--- a/src/config.py
+++ b/src/config.py
@@ -87,6 +87,7 @@ class Config:
         CONFIG_SERVER = "config-server"
         REPLICATION = "replication"
         SHARD = "shard"
+        MONGOS = "mongos"
 
     class Secrets:
         """Secrets related constants."""

--- a/tests/unit/test_tls_lib.py
+++ b/tests/unit/test_tls_lib.py
@@ -63,9 +63,9 @@ class TestMongoTLS(unittest.TestCase):
         self.verify_external_rsa_csr()
 
     @parameterized.expand([True, False])
-    @patch("charm.MongodbOperatorCharm.restart_mongod_service")
+    @patch("charm.MongodbOperatorCharm.restart_charm_services")
     @patch_network_get(private_address="1.1.1.1")
-    def test_tls_relation_broken(self, leader, restart_mongod_service):
+    def test_tls_relation_broken(self, leader, restart_charm_services):
         """Test removes both external and internal certificates."""
         self.harness.set_leader(leader)
         # set initial certificate values
@@ -83,7 +83,7 @@ class TestMongoTLS(unittest.TestCase):
             self.assertIsNone(chain_secret)
 
         # units should be restarted after updating TLS settings
-        restart_mongod_service.assert_called()
+        restart_charm_services.assert_called()
 
     @patch_network_get(private_address="1.1.1.1")
     def test_external_certificate_expiring(self):
@@ -139,8 +139,8 @@ class TestMongoTLS(unittest.TestCase):
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongodbOperatorCharm.push_tls_certificate_to_workload")
-    @patch("charm.MongodbOperatorCharm.restart_mongod_service")
-    def test_external_certificate_available(self, restart_mongod_service, _):
+    @patch("charm.MongodbOperatorCharm.restart_charm_services")
+    def test_external_certificate_available(self, restart_charm_services, _):
         """Tests behavior when external certificate is made available."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
@@ -163,12 +163,12 @@ class TestMongoTLS(unittest.TestCase):
         self.assertEqual(unit_secret, "unit-cert")
         self.assertEqual(ca_secret, "unit-ca")
 
-        restart_mongod_service.assert_called()
+        restart_charm_services.assert_called()
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongodbOperatorCharm.push_tls_certificate_to_workload")
-    @patch("charm.MongodbOperatorCharm.restart_mongod_service")
-    def test_internal_certificate_available(self, restart_mongod_service, _):
+    @patch("charm.MongodbOperatorCharm.restart_charm_services")
+    def test_internal_certificate_available(self, restart_charm_services, _):
         """Tests behavior when internal certificate is made available."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
@@ -191,12 +191,12 @@ class TestMongoTLS(unittest.TestCase):
         self.assertEqual(unit_secret, "int-cert")
         self.assertEqual(ca_secret, "int-ca")
 
-        restart_mongod_service.assert_called()
+        restart_charm_services.assert_called()
 
     @patch_network_get(private_address="1.1.1.1")
     @patch("charm.MongodbOperatorCharm.push_tls_certificate_to_workload")
-    @patch("charm.MongodbOperatorCharm.restart_mongod_service")
-    def test_unknown_certificate_available(self, restart_mongod_service, _):
+    @patch("charm.MongodbOperatorCharm.restart_charm_services")
+    def test_unknown_certificate_available(self, restart_charm_services, _):
         """Tests that when an unknown certificate is available, nothing is updated."""
         # assume relation exists with a current certificate
         self.relate_to_tls_certificates_operator()
@@ -221,7 +221,7 @@ class TestMongoTLS(unittest.TestCase):
         self.assertEqual(unit_secret, "app-cert-old")
         self.assertEqual(ca_secret, "app-ca-old")
 
-        restart_mongod_service.assert_not_called()
+        restart_charm_services.assert_not_called()
 
     # Helper functions
     def relate_to_tls_certificates_operator(self) -> int:


### PR DESCRIPTION
## Issue
mongos charm does not support TLS and we want to re-use some of the shared libs owned by the mongodb chamr

## Solution
update the shared lib owned by the mongodb charm so that mongos charm can easily support TLS 

## Future PRs:
1. add libs to mongos + add necessary changes to mongos src/charm
2. add sanity checks for mongos checking valid TLS configuration
3. Int tests