### PR TITLE
[DPE-4075] Migrate upgrade code out of lib

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,6 @@ from charms.mongodb.v0.mongodb import (
 )
 from charms.mongodb.v0.mongodb_secrets import SecretCache, generate_secret_label
 from charms.mongodb.v0.mongodb_tls import MongoDBTLS
-from charms.mongodb.v0.upgrade import MongoDBDependencyModel, MongoDBUpgrade
 from charms.mongodb.v1.helpers import (
     KEY_FILE,
     TLS_EXT_CA_FILE,
@@ -77,6 +76,7 @@ from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
 from tenacity import Retrying, before_log, retry, stop_after_attempt, wait_fixed
 
 from config import Config, Package
+from events.upgrade import MongoDBDependencyModel, MongoDBUpgrade
 from exceptions import AdminUserCreationError, ApplicationHostNotFoundError
 from machine_helpers import MONGO_USER, ROOT_USER_GID, update_mongod_service
 

--- a/src/events/upgrade.py
+++ b/src/events/upgrade.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 """Manager for handling MongoDB in-place upgrades."""
@@ -29,15 +29,6 @@ logger = logging.getLogger(__name__)
 WRITE_KEY = "write_value"
 MONGOD_SERVICE = "mongod"
 
-# The unique Charmhub library identifier, never change it
-LIBID = "aad46b9f0ddb4cb392982a52a596ec9b"
-
-# Increment this major API version when introducing breaking changes
-LIBAPI = 0
-
-# Increment this PATCH version before using `charmcraft publish-lib` or reset
-# to 0 if you are raising the major API version
-LIBPATCH = 3
 
 ROLLBACK_INSTRUCTIONS = """Unit failed to upgrade and requires manual rollback to previous stable version.
     1. Re-run `pre-upgrade-check` action on the leader unit to enter 'recovery' state

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -81,11 +81,11 @@ class TestCharm(unittest.TestCase):
         assert self.harness.charm.upgrade.build_upgrade_stack() == [0, 1]
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charms.mongodb.v0.upgrade.Retrying")
+    @patch("events.upgrade.Retrying")
     @patch("charm.MongoDBUpgrade.is_excepted_write_on_replica")
     @patch("charm.MongodbOperatorCharm.restart_charm_services")
     @patch("charm.MongoDBConnection")
-    @patch("charms.mongodb.v0.upgrade.MongoDBConnection")
+    @patch("events.upgrade.MongoDBConnection")
     @patch("charm.MongodbOperatorCharm.install_snap_packages")
     @patch("charm.MongodbOperatorCharm.stop_charm_services")
     @patch("charm.MongoDBUpgrade.post_upgrade_check")

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -20,7 +20,7 @@ class TestCharm(unittest.TestCase):
         self.peer_rel_id = self.harness.add_relation("database-peers", "database-peers")
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charms.mongodb.v0.upgrade.MongoDBConnection")
+    @patch("events.upgrade.MongoDBConnection")
     def test_is_cluster_healthy(self, connection):
         """Test is_cluster_healthy function."""
 
@@ -56,7 +56,7 @@ class TestCharm(unittest.TestCase):
         assert self.harness.charm.upgrade.is_cluster_healthy()
 
     @patch_network_get(private_address="1.1.1.1")
-    @patch("charms.mongodb.v0.upgrade.MongoDBConnection")
+    @patch("events.upgrade.MongoDBConnection")
     @patch("charm.MongoDBUpgrade.is_excepted_write_on_replica")
     def test_is_replica_set_able_read_write(self, is_excepted_write_on_replica, connection):
         """Test test_is_replica_set_able_read_write function."""


### PR DESCRIPTION
## Issue
upgrade code was written to shared lib code, but on further thought this code cannot be shared with the K8s charm since upgrades are handled differently in K8s

## Solution
Migrate the upgrade code out of lib

## Future Work
After this PR has merged I will request the snap/charm store team to remove this lib
