### PR TITLE
[DPE-4263] fix errors for statuses in TLS sharding tests

### DIFF
--- a/tests/integration/sharding_tests/test_sharding_tls.py
+++ b/tests/integration/sharding_tests/test_sharding_tls.py
@@ -124,6 +124,11 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest) -> None:
         raise_on_blocked=False,
     )
 
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME], status="blocked", timeout=1000
+        )
+
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (
         shard_unit.workload_status_message == "Shard requires TLS to be enabled."
@@ -155,6 +160,11 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest) -> None:
         timeout=TIMEOUT,
         raise_on_blocked=False,
     )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME], status="blocked", timeout=1000
+        )
+
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (
         shard_unit.workload_status_message == "Shard has TLS enabled, but config-server does not."
@@ -174,6 +184,11 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest) -> None:
         timeout=TIMEOUT,
         raise_on_blocked=False,
     )
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(
+            apps=[SHARD_ONE_APP_NAME], status="blocked", timeout=1000
+        )
+
     shard_unit = ops_test.model.applications[SHARD_ONE_APP_NAME].units[0]
     assert (
         shard_unit.workload_status_message == "Shard CA and Config-Server CA don't match."


### PR DESCRIPTION
## Issue
tests for TLS tests are consistently failing due to status checks failing [see this release run](https://github.com/canonical/mongodb-operator/actions/runs/8896004004)

## Solution
as it turns out the tests do not wait for the application to go into the blocked state which is why the tests fail. By waiting for blocked we wait for t he status hook to get called and update the messages in the units 