### PR TITLE
[DPE-4434] fix lint in ci

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,9 @@ deps =
     pyproject-flake8
     pep8-naming
     isort
-    codespell
+    codespell==2.2.5 # current version reports incorrectly reports issues in string names and function names
 commands =
-    codespell {[vars]all_path}
-    codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache 
+    codespell {[vars]all_path} --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache --skip {tox_root}/src/grafana_dashboards
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]all_path}  --exclude tests/integration/*/lib/* 
     isort --check-only --diff {[vars]all_path}


### PR DESCRIPTION
## Issue
linter is failing on all workflow runs. Linter complains about function names and string values (i.e. things it should not be) 

## Solution
Revert linter to an earlier revision (i.e. the one MySQLRouter uses) 