### PR TITLE
CHORE for [DPE-5095] move over code to be re-used by K8s into correct lib

### DIFF
--- a/lib/charms/mongodb/v0/set_status.py
+++ b/lib/charms/mongodb/v0/set_status.py
@@ -4,9 +4,9 @@
 # See LICENSE file for licensing details.
 import json
 import logging
-from typing import Tuple
+from typing import Optional, Tuple
 
-from charms.mongodb.v1.mongodb import MongoConfiguration, MongoDBConnection
+from charms.mongodb.v1.mongodb import MongoDBConfiguration, MongoDBConnection
 from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus
@@ -22,7 +22,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 AUTH_FAILED_CODE = 18
 UNAUTHORISED_CODE = 13
@@ -223,8 +223,22 @@ class MongoDBStatusHandler(Object):
         # if all statuses are active report mongodb status over sharding status
         return mongodb_status
 
+    def get_invalid_integration_status(self) -> Optional[StatusBase]:
+        """Returns a status if an invalid integration is present."""
+        if not self.charm.cluster.is_valid_mongos_integration():
+            return BlockedStatus(
+                "Relation to mongos not supported, config role must be config-server"
+            )
 
-def build_unit_status(mongodb_config: MongoConfiguration, unit_host: str) -> StatusBase:
+        if not self.charm.backups.is_valid_s3_integration():
+            return BlockedStatus(
+                "Relation to s3-integrator is not supported, config role must be config-server"
+            )
+
+        return self.charm.get_cluster_mismatched_revision_status()
+
+
+def build_unit_status(mongodb_config: MongoDBConfiguration, unit_host: str) -> StatusBase:
     """Generates the status of a unit based on its status reported by mongod."""
     try:
         with MongoDBConnection(mongodb_config) as mongo:

--- a/lib/charms/mongodb/v0/set_status.py
+++ b/lib/charms/mongodb/v0/set_status.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Optional, Tuple
 
-from charms.mongodb.v1.mongodb import MongoDBConfiguration, MongoDBConnection
+from charms.mongodb.v1.mongodb import MongoConfiguration, MongoDBConnection
 from ops.charm import CharmBase
 from ops.framework import Object
 from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus

--- a/lib/charms/mongodb/v0/set_status.py
+++ b/lib/charms/mongodb/v0/set_status.py
@@ -238,7 +238,7 @@ class MongoDBStatusHandler(Object):
         return self.charm.get_cluster_mismatched_revision_status()
 
 
-def build_unit_status(mongodb_config: MongoDBConfiguration, unit_host: str) -> StatusBase:
+def build_unit_status(mongodb_config: MongoConfiguration, unit_host: str) -> StatusBase:
     """Generates the status of a unit based on its status reported by mongod."""
     try:
         with MongoDBConnection(mongodb_config) as mongo:

--- a/src/charm.py
+++ b/src/charm.py
@@ -636,7 +636,7 @@ class MongodbOperatorCharm(CharmBase):
     def _on_update_status(self, event: UpdateStatusEvent):
         # user-made mistakes might result in other incorrect statues. Prioritise informing users of
         # their mistake.
-        invalid_integration_status = self.set_status.get_invalid_integration_status()
+        invalid_integration_status = self.status.get_invalid_integration_status()
         if invalid_integration_status:
             self.status.set_and_share_status(invalid_integration_status)
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -636,7 +636,7 @@ class MongodbOperatorCharm(CharmBase):
     def _on_update_status(self, event: UpdateStatusEvent):
         # user-made mistakes might result in other incorrect statues. Prioritise informing users of
         # their mistake.
-        invalid_integration_status = self.get_invalid_integration_status()
+        invalid_integration_status = self.set_status.get_invalid_integration_status()
         if invalid_integration_status:
             self.status.set_and_share_status(invalid_integration_status)
             return
@@ -1494,20 +1494,6 @@ class MongodbOperatorCharm(CharmBase):
     def _is_removing_last_replica(self) -> bool:
         """Returns True if the last replica (juju unit) is getting removed."""
         return self.app.planned_units() == 0 and len(self.peers_units) == 0
-
-    def get_invalid_integration_status(self) -> Optional[StatusBase]:
-        """Returns a status if an invalid integration is present."""
-        if not self.cluster.is_valid_mongos_integration():
-            return BlockedStatus(
-                "Relation to mongos not supported, config role must be config-server"
-            )
-
-        if not self.backups.is_valid_s3_integration():
-            return BlockedStatus(
-                "Relation to s3-integrator is not supported, config role must be config-server"
-            )
-
-        return self.get_cluster_mismatched_revision_status()
 
     def is_relation_feasible(self, rel_interface) -> bool:
         """Returns true if the proposed relation is feasible."""


### PR DESCRIPTION
## Issue
K8s charm needs to implement get_invalid_integration_status

## Solution
Add it to a lib so it can be easily re-used