### PR TITLE
[DPE-5227][DPE-5228]: Enable Storage reuse test

### DIFF
--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -8,7 +8,7 @@ import os
 import secrets
 import string
 import subprocess
-from typing import List
+from typing import List, Mapping
 
 from charms.mongodb.v1.mongodb import MongoConfiguration
 from ops.model import ActiveStatus, MaintenanceStatus, StatusBase, WaitingStatus
@@ -23,7 +23,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -320,3 +320,25 @@ def add_args_to_env(var: str, args: str):
 
     with open(Config.ENV_VAR_PATH, "w") as service_file:
         service_file.writelines(env_vars)
+
+
+def safe_exec(
+    command: list[str] | str,
+    env: Mapping[str, str] | None = None,
+    working_dir: str | None = None,
+) -> str:
+    """Execs a command on the workload in a safe way."""
+    try:
+        output = subprocess.check_output(
+            command,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            shell=isinstance(command, str),
+            env=env,
+            cwd=working_dir,
+        )
+        logger.debug(f"{output=}")
+        return output
+    except subprocess.CalledProcessError as err:
+        logger.error(f"cmd failed - {err.cmd = }, {err.stdout = }, {err.stderr = }")
+        raise

--- a/src/charm.py
+++ b/src/charm.py
@@ -1092,7 +1092,7 @@ class MongodbOperatorCharm(CharmBase):
                 logger.error(
                     "An exception occurred when installing %s. Reason: %s", snap_name, str(e)
                 )
-            raise
+                raise
 
     def _instatiate_keyfile(self, event: StartEvent) -> None:
         # wait for keyFile to be created by leader unit

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from pathlib import Path
 from typing import Literal, TypeAlias
 
 from ops.model import BlockedStatus
@@ -21,7 +22,13 @@ class Config:
     MONGOD_CONF_DIR = f"{MONGODB_SNAP_DATA_DIR}/etc/mongod"
     MONGOD_CONF_FILE_PATH = f"{MONGOD_CONF_DIR}/mongod.conf"
     CHARM_INTERNAL_VERSION_FILE = "charm_internal_version"
-    SNAP_PACKAGES = [("charmed-mongodb", "6/edge", 118)]
+    SNAP_PACKAGES = [("charmed-mongodb", "6/edge", 121)]
+
+    MONGODB_COMMON_PATH = Path("/var/snap/charmed-mongodb/common")
+
+    # This is the snap_daemon user, which does not exist on the VM before the
+    # snap install so creating it by UID
+    SNAP_USER = 584788
 
     # Keep these alphabetically sorted
     class Actions:

--- a/src/upgrades/upgrade.py
+++ b/src/upgrades/upgrade.py
@@ -178,7 +178,7 @@ class Upgrade(AbstractUpgrade):
             resume_string = ""
             if len(self._sorted_units) > 1:
                 resume_string = (
-                    "Verify highest unit is healthy & run `{RESUME_ACTION_NAME}` action. "
+                    f"Verify highest unit is healthy & run `{RESUME_ACTION_NAME}` action. "
                 )
             return ops.BlockedStatus(
                 f"Upgrading. {resume_string}To rollback, `juju refresh` to last revision"

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -423,10 +423,6 @@ async def reused_storage(ops_test: OpsTest, unit_name: str, removal_time: float)
 
         item = json.loads(line)
 
-        # We need a msg
-        if "msg" not in item:
-            continue
-
         # "attr" is needed and stores the state information and changes of mongodb
         if "attr" not in item:
             continue

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -427,7 +427,7 @@ async def reused_storage(ops_test: OpsTest, unit_name: str, removal_time: float)
         if "msg" not in item:
             continue
 
-        # We need the attrs
+        # "attr" is needed and stores the state information and changes of mongodb
         if "attr" not in item:
             continue
 

--- a/tests/integration/ha_tests/helpers.py
+++ b/tests/integration/ha_tests/helpers.py
@@ -1,10 +1,10 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import calendar
 import json
 import logging
 import subprocess
-import time
 from datetime import datetime
 from pathlib import Path
 from subprocess import PIPE, check_output
@@ -641,10 +641,10 @@ async def verify_replica_set_configuration(ops_test: OpsTest, app_name=None) -> 
 
 
 def convert_time(time_as_str: str) -> int:
-    """Converts a string time representation to an integer time representation."""
+    """Converts a string time representation to an integer time representation, in UTC."""
     # parse time representation, provided in this format: 'YYYY-MM-DDTHH:MM:SS.MMM+00:00'
     d = datetime.strptime(time_as_str, "%Y-%m-%dT%H:%M:%S.%f%z")
-    return time.mktime(d.timetuple())
+    return calendar.timegm(d.timetuple())
 
 
 def cut_network_from_unit(machine_name: str) -> None:

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -7,6 +7,7 @@ import os
 import time
 
 import pytest
+from juju import tag
 from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
@@ -20,7 +21,6 @@ from ..helpers import (
     unit_uri,
 )
 from .helpers import (
-    add_unit_with_storage,
     all_db_processes_down,
     clear_db_writes,
     count_primaries,
@@ -114,7 +114,11 @@ async def test_storage_re_use(ops_test, continuous_writes):
     await ops_test.model.wait_for_idle(
         apps=[app_name], status="active", timeout=1000, wait_for_exact_units=expected_units
     )
-    new_unit = await add_unit_with_storage(ops_test, app_name, unit_storage_id)
+    new_unit = await ops_test.model.applications[app_name].add_unit(
+        count=1, attach_storage=[tag.storage(unit_storage_id)]
+    )
+
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 
     assert await reused_storage(
         ops_test, new_unit.name, removal_time
@@ -128,6 +132,7 @@ async def test_storage_re_use(ops_test, continuous_writes):
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.skip("This is currently unsupported on MongoDB charm.")
 @pytest.mark.abort_on_fail
 async def test_storage_re_use_different_cluster(ops_test: OpsTest, continuous_writes):
     """Tests that we can reuse storage from a different cluster.
@@ -143,11 +148,11 @@ async def test_storage_re_use_different_cluster(ops_test: OpsTest, continuous_wr
         )
 
     writes_results = await stop_continous_writes(ops_test, app_name=app_name)
-    unit_ids = (unit.name for unit in ops_test.models.applications[app_name].units)
+    unit_ids = [unit.name for unit in ops_test.model.applications[app_name].units]
     storage_ids = {}
     for unit_id in unit_ids:
-        storage_ids[unit_id] = storage_id(ops_test, app_name, unit_id)
-        await ops_test.model.applications[app_name].destroy_unit(f"{app_name}/{unit_id}")
+        storage_ids[unit_id] = storage_id(ops_test, unit_id)
+        await ops_test.model.applications[app_name].destroy_unit(unit_id)
         # Give some time to remove the unit. We don't use asyncio.sleep here to
         # leave time for each unit to be removed before removing the next one.
         time.sleep(60)
@@ -156,8 +161,10 @@ async def test_storage_re_use_different_cluster(ops_test: OpsTest, continuous_wr
     await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, wait_for_exact_units=0)
 
     for unit_id in unit_ids:
-        await add_unit_with_storage(ops_test, app_name, storage_ids[unit_id])
-        await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000)
+        await ops_test.model.applications[app_name].add_unit(
+            count=1, attach_storage=[tag.storage(storage_ids[unit_id])]
+        )
+        time.sleep(10)
 
     await ops_test.model.wait_for_idle(
         apps=[app_name],

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -114,9 +114,11 @@ async def test_storage_re_use(ops_test, continuous_writes):
     await ops_test.model.wait_for_idle(
         apps=[app_name], status="active", timeout=1000, wait_for_exact_units=expected_units
     )
-    new_unit = await ops_test.model.applications[app_name].add_unit(
-        count=1, attach_storage=[tag.storage(unit_storage_id)]
-    )
+    new_unit = (
+        await ops_test.model.applications[app_name].add_unit(
+            count=1, attach_storage=[tag.storage(unit_storage_id)]
+        )
+    )[0]
 
     await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=1000)
 

--- a/tests/integration/ha_tests/test_ha.py
+++ b/tests/integration/ha_tests/test_ha.py
@@ -86,6 +86,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_storage_re_use(ops_test, continuous_writes):
     """Verifies that database units with attached storage correctly repurpose storage.
 
@@ -116,7 +117,7 @@ async def test_storage_re_use(ops_test, continuous_writes):
     new_unit = await add_unit_with_storage(ops_test, app_name, unit_storage_id)
 
     assert await reused_storage(
-        ops_test, new_unit.public_address, removal_time
+        ops_test, new_unit.name, removal_time
     ), "attached storage not properly reused by MongoDB."
 
     # verify that the no writes were skipped
@@ -127,6 +128,7 @@ async def test_storage_re_use(ops_test, continuous_writes):
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_storage_re_use_different_cluster(ops_test: OpsTest, continuous_writes):
     """Tests that we can reuse storage from a different cluster.
 
@@ -282,6 +284,7 @@ async def test_scale_down_capablities(ops_test: OpsTest, continuous_writes) -> N
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_replication_across_members(ops_test: OpsTest, continuous_writes) -> None:
     """Check consistency, ie write to primary, read data from secondaries."""
     # first find primary, write to primary, then read from each unit
@@ -310,6 +313,7 @@ async def test_replication_across_members(ops_test: OpsTest, continuous_writes) 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes) -> None:
     """Verify unique clusters do not share DBs."""
     # first find primary, write to primary,
@@ -360,6 +364,7 @@ async def test_unique_cluster_dbs(ops_test: OpsTest, continuous_writes) -> None:
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_replication_member_scaling(ops_test: OpsTest, continuous_writes) -> None:
     """Verify newly added and newly removed members properly replica data.
 
@@ -407,6 +412,7 @@ async def test_replication_member_scaling(ops_test: OpsTest, continuous_writes) 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_kill_db_process(ops_test, continuous_writes):
     # locate primary unit
     app_name = await get_app_name(ops_test)
@@ -445,6 +451,7 @@ async def test_kill_db_process(ops_test, continuous_writes):
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_freeze_db_process(ops_test, continuous_writes):
     # locate primary unit
     app_name = await get_app_name(ops_test)
@@ -500,6 +507,7 @@ async def test_freeze_db_process(ops_test, continuous_writes):
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_restart_db_process(ops_test, continuous_writes):
     # locate primary unit
     app_name = await get_app_name(ops_test)
@@ -548,6 +556,7 @@ async def test_restart_db_process(ops_test, continuous_writes):
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes, reset_restart_delay):
     app_name = await get_app_name(ops_test)
 
@@ -600,6 +609,7 @@ async def test_full_cluster_crash(ops_test: OpsTest, continuous_writes, reset_re
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_full_cluster_restart(ops_test: OpsTest, continuous_writes, reset_restart_delay):
     app_name = await get_app_name(ops_test)
 
@@ -650,6 +660,7 @@ async def test_full_cluster_restart(ops_test: OpsTest, continuous_writes, reset_
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
+@pytest.mark.abort_on_fail
 async def test_network_cut(ops_test, continuous_writes):
     # locate primary unit
     app_name = await get_app_name(ops_test)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -75,11 +75,13 @@ class Unit:
         return result
 
 
-async def destroy_cluster(ops_test: OpsTest, applications: list[str]) -> None:
+async def destroy_cluster(
+    ops_test: OpsTest, applications: list[str], destroy_storage: bool = False
+) -> None:
     """Destroy cluster in a forceful way."""
     for app in applications:
         await ops_test.model.applications[app].destroy(
-            destroy_storage=True, force=True, no_wait=False
+            destroy_storage=destroy_storage, force=True, no_wait=False
         )
 
     # destroy does not wait for applications to be removed, perform this check manually

--- a/tests/integration/upgrade/test_sharding_upgrade.py
+++ b/tests/integration/upgrade/test_sharding_upgrade.py
@@ -2,9 +2,9 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import logging
 import time
 
-import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/upgrade/test_sharding_upgrade.py
+++ b/tests/integration/upgrade/test_sharding_upgrade.py
@@ -4,6 +4,7 @@
 
 import time
 
+import logging
 import pytest
 from pytest_operator.plugin import OpsTest
 
@@ -20,6 +21,8 @@ from ..sharding_tests.writes_helpers import (
     count_shard_writes,
     stop_continous_writes,
 )
+
+logger = logging.getLogger(__name__)
 
 MONGOD_SERVICE = "snap.charmed-mongodb.mongod.service"
 MONGOS_SERVICE = "snap.charmed-mongodb.mongos.service"
@@ -75,7 +78,7 @@ async def test_upgrade(
 
     # We want to be sure that everything is settled down
     await ops_test.model.wait_for_idle(
-        CLUSTER_COMPONENTS, status="active", idle_period=20, timeout=TIMEOUT
+        CLUSTER_COMPONENTS, status="active", idle_period=20, timeout=20 * 60
     )
     # verify no writes were skipped during upgrade process
     shard_one_expected_writes = await stop_continous_writes(
@@ -153,19 +156,22 @@ async def run_upgrade_sequence(ops_test: OpsTest, app_name: str, new_charm) -> N
     assert action.status == "completed", "pre-upgrade-check failed, expected to succeed."
 
     await ops_test.model.applications[app_name].refresh(path=new_charm)
-    await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, idle_period=30)
+    await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, idle_period=120)
 
     # resume upgrade only needs to be ran when:
     # 1. there are more than one units in the application
     # 2. AND the underlying workload was updated
-    if not len(ops_test.model.applications[app_name].units) > 1:
+    if len(ops_test.model.applications[app_name].units) < 2:
         return
 
     if "resume-upgrade" not in ops_test.model.applications[app_name].status_message:
         return
 
+    logger.info(f"Calling resume-upgrade for {app_name}")
     action = await leader_unit.run_action("resume-upgrade")
     await action.wait()
     assert action.status == "completed", "resume-upgrade failed, expected to succeed."
 
-    await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, idle_period=30)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=1000, idle_period=30
+    )

--- a/tests/integration/upgrade/test_sharding_upgrade.py
+++ b/tests/integration/upgrade/test_sharding_upgrade.py
@@ -4,6 +4,7 @@
 
 import logging
 import time
+from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
@@ -148,7 +149,7 @@ async def test_pre_upgrade_check_failure(ops_test: OpsTest) -> None:
     # TODO Future PR: Add more cases for failing pre-upgrade-check
 
 
-async def run_upgrade_sequence(ops_test: OpsTest, app_name: str, new_charm) -> None:
+async def run_upgrade_sequence(ops_test: OpsTest, app_name: str, new_charm: Path) -> None:
     """Runs the upgrade sequence on a given app."""
     leader_unit = await find_unit(ops_test, leader=True, app_name=app_name)
     action = await leader_unit.run_action("pre-upgrade-check")
@@ -172,6 +173,4 @@ async def run_upgrade_sequence(ops_test: OpsTest, app_name: str, new_charm) -> N
     await action.wait()
     assert action.status == "completed", "resume-upgrade failed, expected to succeed."
 
-    await ops_test.model.wait_for_idle(
-        apps=[app_name], status="active", timeout=1000, idle_period=30
-    )
+    await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, idle_period=30)


### PR DESCRIPTION
## Issue

 * This test is disabled and also needs some fixes
 * There is no test for storage reuse on a new cluster

## Solution

 * Enable the test and fix the small bugs
 * Develop the `Storage reuse on different cluster` test, and skip it as it's not a supported feature for now.