### PR TITLE
[DPE-5215] feat(libs): Correct use of data_interfaces

### DIFF
--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -11,10 +11,11 @@ from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import (
     DatabaseProvides,
+    DatabaseRequestedEvent,
     DatabaseRequires,
 )
 from charms.mongodb.v1.mongos import MongosConnection
-from ops.charm import CharmBase, EventBase, RelationBrokenEvent
+from ops.charm import CharmBase, EventBase, RelationBrokenEvent, RelationChangedEvent
 from ops.framework import Object
 from ops.model import (
     ActiveStatus,
@@ -42,7 +43,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 
 class ClusterProvider(Object):
@@ -57,6 +58,9 @@ class ClusterProvider(Object):
         self.database_provides = DatabaseProvides(self.charm, relation_name=self.relation_name)
 
         super().__init__(charm, self.relation_name)
+        self.framework.observe(
+            self.database_provides.on.database_requested, self._on_database_requested
+        )
         self.framework.observe(
             charm.on[self.relation_name].relation_changed, self._on_relation_changed
         )
@@ -105,8 +109,8 @@ class ClusterProvider(Object):
 
         return True
 
-    def _on_relation_changed(self, event) -> None:
-        """Handles providing mongos with KeyFile and hosts."""
+    def _on_database_requested(self, event: DatabaseRequestedEvent | RelationChangedEvent) -> None:
+        """Handles the database requested event, which is the first time we can write data."""
         if not self.pass_hook_checks(event):
             if not self.is_valid_mongos_integration():
                 self.charm.status.set_and_share_status(
@@ -116,12 +120,9 @@ class ClusterProvider(Object):
                 )
             logger.info("Skipping relation joined event: hook checks did not pass")
             return
-
         config_server_db = self.generate_config_server_db()
-
         # create user and set secrets for mongos relation
         self.charm.client_relations.oversee_users(None, None)
-
         relation_data = {
             KEYFILE_KEY: self.charm.get_secret(
                 Config.Relations.APP_SCOPE, Config.Secrets.SECRET_KEYFILE_NAME
@@ -135,8 +136,18 @@ class ClusterProvider(Object):
         )
         if int_tls_ca:
             relation_data[INT_TLS_CA_KEY] = int_tls_ca
-
         self.database_provides.update_relation_data(event.relation.id, relation_data)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handles providing mongos with KeyFile and hosts."""
+        # First we need to ensure that the database requested event has run
+        # otherwise we would write secrets in plain sight.
+        if not self.database_provides.fetch_relation_field(event.relation.id, "database"):
+            logger.info("Database Requested has not run yet, skipping.")
+            event.defer()
+            return
+
+        self._on_database_requested(event)
 
     def _on_relation_broken(self, event) -> None:
         if self.charm.upgrade_in_progress:

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -110,7 +110,10 @@ class ClusterProvider(Object):
         return True
 
     def _on_database_requested(self, event: DatabaseRequestedEvent | RelationChangedEvent) -> None:
-        """Handles the database requested event, which is the first time we can write data."""
+        """Handles the database requested event, the first time secrets are written to relations should be on this event.
+        
+        Note: If secrets are written for the first time on other events we risk the chance of writing secrets in plain sight
+        """
         if not self.pass_hook_checks(event):
             if not self.is_valid_mongos_integration():
                 self.charm.status.set_and_share_status(

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -110,9 +110,12 @@ class ClusterProvider(Object):
         return True
 
     def _on_database_requested(self, event: DatabaseRequestedEvent | RelationChangedEvent) -> None:
-        """Handles the database requested event, the first time secrets are written to relations should be on this event.
-        
-        Note: If secrets are written for the first time on other events we risk the chance of writing secrets in plain sight
+        """Handles the database requested event.
+
+        The first time secrets are written to relations should be on this event.
+
+        Note: If secrets are written for the first time on other events we risk
+        the chance of writing secrets in plain sight.
         """
         if not self.pass_hook_checks(event):
             if not self.is_valid_mongos_integration():

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -141,7 +141,7 @@ class ClusterProvider(Object):
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handles providing mongos with KeyFile and hosts."""
         # First we need to ensure that the database requested event has run
-        # otherwise we would write secrets in plain sight.
+        # otherwise we risk the chance of writing secrets in plain sight.
         if not self.database_provides.fetch_relation_field(event.relation.id, "database"):
             logger.info("Database Requested has not run yet, skipping.")
             event.defer()

--- a/lib/charms/mongodb/v0/config_server_interface.py
+++ b/lib/charms/mongodb/v0/config_server_interface.py
@@ -147,6 +147,7 @@ class ClusterProvider(Object):
             event.defer()
             return
 
+        # TODO : This workflow is a fix until we have time for a better and complete fix (DPE-5513)
         self._on_database_requested(event)
 
     def _on_relation_broken(self, event) -> None:


### PR DESCRIPTION
## Issue
 * In the Mongos k8s charm, we saw that the data which is expected to be stored as secrets are shown in plain sight.
 * A thorough investigation and the help of @juditnovak lead us to see that we were not using the data_interfaces library the correct way, breaking the expected flow, which lead to this issue.

## Solution

This library was not using the data interface library the right way. The provider should not write in the databag before the `database_requested` event which is fired when the requirer asks for the DB and write its name + the `requested-secrets` list in the databag.

This commit hence:
 * Defines a handler for the `database_requested` event
 * Protects the call to `relation_changed` events by checking first if the `database` field is in the relation databag, which can happen only after the `database_requested` event has run.
