### PR TITLE
[DPE-5318] charm manges only created users

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -31,7 +31,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"

--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -466,13 +466,13 @@ class MongoDBProvider(Object):
 
         self.charm.app_peer_data[MANAGED_USERS_KEY] = json.dumps(list(new_users))
 
-    def _remove_from_relational_users_to_manage(self, user_to_remove) -> None:
+    def _remove_from_relational_users_to_manage(self, user_to_remove: str) -> None:
         """Removes the provided user from the set of the users to manage."""
         current_users = self._get_relational_users_to_manage()
         updated_users = current_users - {user_to_remove}
         self._update_relational_users_to_manage(updated_users)
 
-    def _add_to_relational_users_to_manage(self, user_to_add) -> None:
+    def _add_to_relational_users_to_manage(self, user_to_add: str) -> None:
         """Adds the provided user to the set of the users to manage."""
         current_users = self._get_relational_users_to_manage()
         current_users.add(user_to_add)

--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -80,10 +80,6 @@ class MongoDBProvider(Object):
 
     def pass_hook_checks(self, event: EventBase) -> bool:
         """Runs the pre-hooks checks for MongoDBProvider, returns True if all pass."""
-        # Quirk of data platform libs we should only set credentials on the database requested
-        # event
-        # TODO
-
         # We shouldn't try to create or update users if the database is not
         # initialised. We will create users as part of initialisation.
         if not self.charm.db_initialised:

--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -38,6 +38,7 @@ REL_NAME = "database"
 MONGOS_RELATIONS = "cluster"
 MONGOS_CLIENT_RELATIONS = "mongos_proxy"
 EXTERNAL_CONNECTIVITY_TAG = "external-node-connectivity"
+MANAGED_USERS_KEY = "managed-users-key"
 
 # We expect the MongoDB container to use the default ports
 
@@ -79,6 +80,10 @@ class MongoDBProvider(Object):
 
     def pass_hook_checks(self, event: EventBase) -> bool:
         """Runs the pre-hooks checks for MongoDBProvider, returns True if all pass."""
+        # Quirk of data platform libs we should only set credentials on the database requested
+        # event
+        # TODO
+
         # We shouldn't try to create or update users if the database is not
         # initialised. We will create users as part of initialisation.
         if not self.charm.db_initialised:
@@ -158,12 +163,36 @@ class MongoDBProvider(Object):
         When the function is executed in relation departed event, the departed
         relation is still on the list of all relations. Therefore, for proper
         work of the function, we need to exclude departed relation from the list.
+
+        Raises:
+            PyMongoError
         """
         with MongoConnection(self.charm.mongo_config) as mongo:
             database_users = mongo.get_users()
-            relation_users = self._get_users_from_relations(departed_relation_id)
 
-            for username in database_users - relation_users:
+        users_being_managed = database_users.intersection(self._get_relational_users_to_manage())
+        expected_current_users = self._get_users_from_relations(departed_relation_id)
+
+        self.remove_users(users_being_managed, expected_current_users)
+        self.add_users(users_being_managed, expected_current_users)
+        self.update_users(event, users_being_managed, expected_current_users)
+        self.auto_delete_dbs(departed_relation_id)
+
+    def remove_users(
+        self, users_being_managed: Set[str], expected_current_users: Set[str]
+    ) -> None:
+        """Removes users from Charmed MongoDB.
+
+        Note this only removes users that this application of Charmed MongoDB is responsible for
+        managing. It won't remove:
+        1. users created from other applications
+        2. users created from other mongos routers.
+
+        Raises:
+            PyMongoError
+        """
+        with MongoConnection(self.charm.mongo_config) as mongo:
+            for username in users_being_managed - expected_current_users:
                 logger.info("Remove relation user: %s", username)
                 if (
                     self.charm.is_role(Config.Role.MONGOS)
@@ -172,8 +201,16 @@ class MongoDBProvider(Object):
                     continue
 
                 mongo.drop_user(username)
+                self._remove_from_relational_users_to_manage(username)
 
-            for username in relation_users - database_users:
+    def add_users(self, users_being_managed: Set[str], expected_current_users: Set[str]) -> None:
+        """Adds users to Charmed MongoDB.
+
+        Raises:
+            PyMongoError
+        """
+        with MongoConnection(self.charm.mongo_config) as mongo:
+            for username in expected_current_users - users_being_managed:
                 config = self._get_config(username, None)
                 if config.database is None:
                     # We need to wait for the moment when the provider library
@@ -182,14 +219,32 @@ class MongoDBProvider(Object):
                 logger.info("Create relation user: %s on %s", config.username, config.database)
 
                 mongo.create_user(config)
+                self._add_to_relational_users_to_manage(username)
                 self._set_relation(config)
 
-            for username in relation_users.intersection(database_users):
+    def update_users(
+        self, event: EventBase, users_being_managed: Set[str], expected_current_users: Set[str]
+    ) -> None:
+        """Updates existing users in Charmed MongoDB.
+
+        Raises:
+            PyMongoError
+        """
+        with MongoConnection(self.charm.mongo_config) as mongo:
+            for username in expected_current_users.intersection(users_being_managed):
                 config = self._get_config(username, None)
                 logger.info("Update relation user: %s on %s", config.username, config.database)
                 mongo.update_user(config)
                 logger.info("Updating relation data according to diff")
                 self._diff(event)
+
+    def auto_delete_dbs(self, departed_relation_id):
+        """Delete's unused dbs if configured to do so.
+
+        Raises:
+            PyMongoError
+        """
+        with MongoConnection(self.charm.mongo_config) as mongo:
 
             if not self.charm.model.config["auto-delete"]:
                 return
@@ -407,6 +462,35 @@ class MongoDBProvider(Object):
             self.database_provides.fetch_relation_field(rel_id, EXTERNAL_CONNECTIVITY_TAG)
             == "true"
         )
+
+    def _get_relational_users_to_manage(self) -> Set[str]:
+        """Returns a set of the users to manage.
+
+        Note json cannot serialise sets. Convert from list.
+        """
+        return set(json.loads(self.charm.app_peer_data.get(MANAGED_USERS_KEY, "[]")))
+
+    def _update_relational_users_to_manage(self, new_users: Set[str]) -> None:
+        """Updates the set of the users to manage.
+
+        Note json cannot serialise sets. Convert from list.
+        """
+        if not self.charm.unit.is_leader():
+            raise Exception("Cannot update relational data on non-leader unit")
+
+        self.charm.app_peer_data[MANAGED_USERS_KEY] = json.dumps(list(new_users))
+
+    def _remove_from_relational_users_to_manage(self, user_to_remove) -> None:
+        """Removes the provided user from the set of the users to manage."""
+        current_users = self._get_relational_users_to_manage()
+        updated_users = current_users - {user_to_remove}
+        self._update_relational_users_to_manage(updated_users)
+
+    def _add_to_relational_users_to_manage(self, user_to_add) -> None:
+        """Adds the provided user to the set of the users to manage."""
+        current_users = self._get_relational_users_to_manage()
+        current_users.add(user_to_add)
+        self._update_relational_users_to_manage(current_users)
 
     @staticmethod
     def _get_database_from_relation(relation: Relation) -> Optional[str]:

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import json
 import unittest
 from unittest import mock
 from unittest.mock import patch
@@ -147,6 +148,9 @@ class TestMongoProvider(unittest.TestCase):
     def test_oversee_users_drop_user_failure(self, connection, relation_users):
         """Verifies that when unable to drop users from mongod an exception is raised."""
         # presets, such that there is a need to drop users.
+        self.harness.charm.app_peer_data["managed-users-key"] = json.dumps(
+            ["relation-user1", "relation-user2"]
+        )
         relation_users.return_value = {"relation-user1"}
         connection.return_value.__enter__.return_value.get_users.return_value = {
             "relation-user1",
@@ -267,6 +271,7 @@ class TestMongoProvider(unittest.TestCase):
     def test_oversee_users_update_user_failure(self, connection, relation_users, get_config):
         """Verifies that when updating users fails an exception is raised."""
         # presets, such that the need to update user relations is triggered
+        self.harness.charm.app_peer_data["managed-users-key"] = json.dumps(["relation-user1"])
         relation_users.return_value = {"relation-user1"}
         connection.return_value.__enter__.return_value.get_users.return_value = {"relation-user1"}
 


### PR DESCRIPTION
## Issue:

1. Users created by clients get automatically deleted by MongoDB charm
2. Users for mongos K8s charm get automatically deleted by MongoDB charm

## Solution:

Keep track of which users the charm should manage and only remove/update those users

## Testing

Lib tested for all charms that use it i.e. MongoDB VM+K8s and Mongos K8s