### PR TITLE
revert recent lib changes 

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -31,7 +31,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
@@ -303,9 +303,7 @@ class MongoDBProvider(Object):
         if self.charm.is_role(Config.Role.MONGOS):
             mongo_args["port"] = Config.MONGOS_PORT
             if self.substrate == Config.Substrate.K8S:
-                external = self.is_external_client(relation.id)
-                mongo_args["port"] = self.charm.get_mongos_port(external)
-                mongo_args["hosts"] = self.charm.get_mongos_hosts(external)
+                mongo_args["port"] = self.charm.get_mongos_port()
         else:
             mongo_args["replset"] = self.charm.app.name
 
@@ -400,13 +398,6 @@ class MongoDBProvider(Object):
             return MONGOS_CLIENT_RELATIONS
         else:
             return REL_NAME
-
-    def is_external_client(self, rel_id) -> bool:
-        """Returns true if the integrated client requests external connectivity."""
-        return (
-            self.database_provides.fetch_relation_field(rel_id, EXTERNAL_CONNECTIVITY_TAG)
-            == "true"
-        )
 
     @staticmethod
     def _get_database_from_relation(relation: Relation) -> Optional[str]:


### PR DESCRIPTION
## Issue
Previous changes made it so that on Mongos-K8s would return different endpoints to inside K8s apps and outside k8s apps if expose-external enabled.

However it was decided recently that this approach is incorrect.

## Solution

Revert this change and bump libpatch
