### PR TITLE
send correct hosts for mongos k8s

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -31,13 +31,12 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
 MONGOS_RELATIONS = "cluster"
 MONGOS_CLIENT_RELATIONS = "mongos_proxy"
-EXTERNAL_CONNECTIVITY_TAG = "external-node-connectivity"
 
 # We expect the MongoDB container to use the default ports
 
@@ -303,7 +302,7 @@ class MongoDBProvider(Object):
         if self.charm.is_role(Config.Role.MONGOS):
             mongo_args["port"] = Config.MONGOS_PORT
             if self.substrate == Config.Substrate.K8S:
-                mongo_args["port"] = self.charm.get_mongos_port()
+                mongo_args["hosts"] = self.charm.get_mongos_hosts_for_client()
         else:
             mongo_args["replset"] = self.charm.app.name
 


### PR DESCRIPTION
## Issue
1. Mongos K8s handles hosts in a very unique way compared to other charms since it supports external connections
2. port information is not shared directly to clients (it is shared instead in the URI)

## Solution
Update the way mongos k8s handles hosts for client relations
Remove port update