### PR TITLE
fix: lib version for publication

### DIFF
--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -23,7 +23,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"

--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -31,7 +31,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 14
+LIBPATCH = 12
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"


### PR DESCRIPTION
## Issue
 * With CI failing on `6/edge`, some lib versions were skipped

## Solution
 * Fix the version number wrt what is on charmhub + 1