### PR TITLE
[DPE-5235] add changes necessary for mongos-k8s ext connections

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -22,7 +22,6 @@ from ops.model import Relation
 from pymongo.errors import PyMongoError
 
 from config import Config
-from exceptions import FailedToGetHostsError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "4067879ef7dd4261bf6c164bc29d94b1"
@@ -48,6 +47,10 @@ A tuple for storing the diff between two data mappings.
 added — keys that were added
 changed — keys that still exist but have new values
 deleted — key that were deleted."""
+
+
+class FailedToGetHostsError(Exception):
+    """Raised when charm fails to retrieve hosts."""
 
 
 class MongoDBProvider(Object):

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -34,7 +34,3 @@ class SecretAlreadyExistsError(MongoSecretError):
 
 class NotConfigServerError(Exception):
     """Raised when an operation is performed on a component that is not a config server."""
-
-
-class FailedToGetHostsError(Exception):
-    """Raised when charm fails to retrieve hosts."""

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -34,3 +34,7 @@ class SecretAlreadyExistsError(MongoSecretError):
 
 class NotConfigServerError(Exception):
     """Raised when an operation is performed on a component that is not a config server."""
+
+
+class FailedToGetHostsError(Exception):
+    """Raised when charm fails to retrieve hosts."""


### PR DESCRIPTION
## Issue
mongos k8s charm can have errors while retrieving hosts, due to race conditions in units 

## Solution
library should be flexible to handle this scenario