### PR TITLE
Create sync_docs.yaml

### DIFF
--- a/.github/workflows/sync_docs.yaml
+++ b/.github/workflows/sync_docs.yaml
@@ -1,0 +1,18 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Sync docs from Discourse
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '53 0 * * *'    # Daily at 00:53 UTC
+
+jobs:
+  sync-docs:
+    name: Sync docs from Discourse
+    uses: canonical/data-platform-workflows/.github/workflows/sync_docs.yaml@v21.0.0
+    with:
+      reviewers: a-velasco
+    permissions:
+      contents: write  # Needed to push branch & tag
+      pull-requests: write  # Needed to create PR


### PR DESCRIPTION
Adds the [new `sync_docs.yaml` workflow](https://github.com/canonical/data-platform-workflows/pull/220) released in data-platform-workflows `v19.2.0`.

This workflow pulls all documentation on [charmhub.io/mongodb](https://charmhub.io/mongodb) into the repository once a day. For more details about its behavior, see the [`sync_docs.yaml` readme file](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/sync_docs.md#behavior)