### PR TITLE
[DPE-5371]: Storage reuse on a different cluster

### DIFF
--- a/lib/charms/mongodb/v0/mongo.py
+++ b/lib/charms/mongodb/v0/mongo.py
@@ -31,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 ADMIN_AUTH_SOURCE = "authSource=admin"
 SYSTEM_DBS = ("admin", "local", "config")
@@ -270,6 +270,11 @@ class MongoConnection:
             ]
         )
 
+    def get_all_users(self) -> Set[str]:
+        """Get all users, including the three charmed managed users."""
+        users_info = self.client.admin.command("usersInfo")
+        return {user_obj["user"] for user_obj in users_info["users"]}
+
     def get_databases(self) -> Set[str]:
         """Return list of all non-default databases."""
         databases = self.client.list_database_names()
@@ -280,3 +285,7 @@ class MongoConnection:
         if database in SYSTEM_DBS:
             return
         self.client.drop_database(database)
+
+    def drop_local_database(self):
+        """DANGEROUS: Drops the local database."""
+        self.client.drop_database("local")

--- a/src/charm.py
+++ b/src/charm.py
@@ -788,6 +788,12 @@ class MongodbOperatorCharm(CharmBase):
                     return
 
         try:
+            self._reconfigure_replica_set()
+        except PyMongoError as e:
+            logger.info(f"Could not reconfigure replica set due to {e}")
+            return
+
+        try:
             self.perform_self_healing(event)
         except ServerSelectionTimeoutError:
             # health checks that are performed too early will fail if the hasn't elected a primary

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,6 +24,7 @@ from charms.mongodb.v1.helpers import (
     TLS_INT_PEM_FILE,
     copy_licenses_to_unit,
     generate_keyfile,
+    generate_lock_hash,
     generate_password,
     get_create_user_cmd,
     safe_exec,
@@ -81,6 +82,7 @@ from exceptions import (
     ApplicationHostNotFoundError,
     NotConfigServerError,
 )
+from lock_hash import HASH_KEY, UNDEFINED, LockHashHandler
 from machine_helpers import (
     MONGO_USER,
     ROOT_USER_GID,
@@ -98,6 +100,9 @@ Scopes = Config.Relations.Scopes
 
 class MongodbOperatorCharm(CharmBase):
     """Charm the service."""
+
+    # Lock Hash descriptor
+    lock_hash = LockHashHandler()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -258,14 +263,34 @@ class MongodbOperatorCharm(CharmBase):
         )
 
     @property
+    def _is_storage_from_different_cluster(self) -> bool:
+        """Checks if we are reusing storage from a different cluster."""
+        lock_hash = self.lock_hash  # Avoid duplicate read of the file
+        return lock_hash != UNDEFINED and lock_hash != self.databag_lock_hash
+
+    @property
     def mongo_config(self) -> MongoConfiguration:
         """Returns a MongoConfiguration object for shared libs with agnostic mongo commands."""
         return self.mongodb_config
 
     @property
+    def standalone_config(self) -> MongoConfiguration:
+        """Generates a MongoConfiguration object for local authenticated standalone connection."""
+        return self._get_mongodb_config_for_user(
+            OperatorUser, {self.unit_host(self.unit)}, standalone=True
+        )
+
+    @property
     def mongodb_config(self) -> MongoConfiguration:
         """Generates a MongoConfiguration object for this deployment of MongoDB."""
         return self._get_mongodb_config_for_user(OperatorUser, set(self.app_hosts))
+
+    @property
+    def single_host_config(self) -> MongoConfiguration:
+        """Generates a MongoConfiguration object for operator user on a single host."""
+        return self._get_mongodb_config_for_user(
+            OperatorUser, standalone=True, hosts={self.unit_host(self.unit)}
+        )
 
     @property
     def monitor_config(self) -> MongoConfiguration:
@@ -390,6 +415,10 @@ class MongodbOperatorCharm(CharmBase):
             self.status.set_and_share_status(BlockedStatus("Could not install MongoDB"))
             return
 
+        # If we are a replica and the lock hash doesn't match
+        if self.is_role(Config.Role.REPLICATION) and self._is_storage_from_different_cluster:
+            self._fix_mongodb_for_reuse()
+
         # Construct the mongod startup commandline args for systemd and reload the daemon.
         update_mongod_service(
             machine_ip=self.unit_host(self.unit),
@@ -423,6 +452,83 @@ class MongodbOperatorCharm(CharmBase):
             raise ShardingMigrationError(
                 f"Migration of sharding components not permitted, revert config role to {self.role}"
             )
+
+    def __fix_users_for_reuse(self, direct_mongo: MongoDBConnection) -> None:
+        """Fix the users in the DB for storage reuse."""
+        users = direct_mongo.get_all_users()
+        breakpoint()
+        # Update operator password since operator is present.
+        if self.unit.is_leader() and OperatorUser.get_username() in users:
+            logger.info("[Recovery] Update operator password (leader).")
+            direct_mongo.set_user_password(
+                OperatorUser.get_username(), direct_mongo.config.password
+            )
+        # Operator user not present in users, need to create it.
+        elif self.unit.is_leader():
+            logger.info("[Recovery] Create missing operator user (leader).")
+            direct_mongo.create_user(self.mongodb_config)
+        # Not leader and operator present, drop it.
+        elif OperatorUser.get_username() in users:
+            logger.info("[Recovering] Dropping operator user (not leader).")
+            direct_mongo.drop_user(OperatorUser.get_username())
+        # Drop backup and monitor user if present.
+        logger.info("[Recovering] Dropping users backup and monitor.")
+        if BackupUser.get_username() in users:
+            direct_mongo.drop_user(BackupUser.get_username())
+        if MonitorUser.get_username() in users:
+            direct_mongo.drop_user(MonitorUser.get_username())
+        pass
+
+    def _fix_mongodb_for_reuse(self) -> None:
+        """If we are reusing storage, we need to fix multiple things in the mongodb data.
+
+        This is done before starting (so with a downtime).
+        We need to:
+         * Start mongod in degraded mode (no auth validation, no replicaset
+         specified, bind only to local IP).
+         * Update operator password (on leader) and delete it on other units.
+         * Remove backup and monitor users on all units.
+         * Delete the local database (contains the replica set local information) on all units.
+        """
+        logger.debug("Fixing MongoDB for reuse.")
+        self.status.set_and_share_status(MaintenanceStatus("Updating MongoDB for storage reuse."))
+        try:
+            # Update with degraded configuration.
+            # Dangerous, this is only allowed here because we need to fix the DB configuration.
+            update_mongod_service(
+                machine_ip="127.0.0.1",
+                config=self.mongodb_config,
+                role=self.role,
+                degraded=True,
+            )
+            # Start the charm services in degraded mode.
+            self.start_charm_services()
+            # Perform data modification
+            if self.unit.is_leader():
+                # We can create only if we are the leader.
+                self._check_or_set_user_password(OperatorUser)
+            with MongoDBConnection(
+                self.mongodb_config, uri="localhost", direct=True
+            ) as direct_mongo:
+                for attempt in Retrying(
+                    stop=stop_after_attempt(10),
+                    wait=wait_fixed(5),
+                    reraise=True,
+                    before=before_log(logger, logging.DEBUG),
+                ):
+                    with attempt:
+                        if not direct_mongo.is_ready:
+                            raise NotReadyError
+                self.__fix_users_for_reuse(direct_mongo)
+                # Drop local database
+                logger.info("Dropping local database.")
+                direct_mongo.drop_local_database()
+        except Exception as err:
+            logger.error(f"Error encountered while updating database config: {err}")
+            raise
+        finally:
+            # Whatever happens here, we stop the charm services.
+            self.stop_charm_services()
 
     def _on_start(self, event: StartEvent) -> None:
         """Enables MongoDB service and initialises replica set.
@@ -519,46 +625,53 @@ class MongodbOperatorCharm(CharmBase):
         self._connect_mongodb_exporter()
         self._connect_pbm_agent()
 
+        if (
+            self.db_initialised
+            and self.is_role(Config.Role.REPLICATION)
+            and self.lock_hash != self.databag_lock_hash
+        ):
+            # We write the lock file if it wasn't written yet.
+            self.lock_hash = self.databag_lock_hash
+
         # only leader should configure replica set and app-changed-events can trigger the relation
         # changed hook resulting in no JUJU_REMOTE_UNIT if this is the case we should return
         # further reconfiguration can be successful only if a replica set is initialised.
         if not (self.unit.is_leader() and event.unit) or not self.db_initialised:
             return
 
-        with MongoDBConnection(self.mongodb_config) as mongo:
-            try:
-                replset_members = mongo.get_replset_members()
-                # compare set of mongod replica set members and juju hosts to avoid the unnecessary
-                # reconfiguration.
-                if replset_members == self.mongodb_config.hosts:
-                    return
+        # If needed, reconfigure replicaset (eg : network cut)
+        try:
+            self._reconfigure_replica_set()
+            self.__add_members_to_replicaset(event)
+        except NotReadyError:
+            self.status.set_and_share_status(WaitingStatus("waiting to reconfigure replica set"))
+            logger.error("Deferring reconfigure: another member doing sync right now")
+            event.defer()
+        except PyMongoError as e:
+            self.status.set_and_share_status(WaitingStatus("waiting to reconfigure replica set"))
+            logger.error("Deferring reconfigure: error=%r", e)
+            event.defer()
 
-                for member in self.mongodb_config.hosts - replset_members:
-                    logger.debug("Adding %s to replica set", member)
-                    with MongoDBConnection(
-                        self.mongodb_config, member, direct=True
-                    ) as direct_mongo:
-                        if not direct_mongo.is_ready:
-                            self.status.set_and_share_status(
-                                WaitingStatus("waiting to reconfigure replica set")
-                            )
-                            logger.debug("Deferring reconfigure: %s is not ready yet.", member)
-                            event.defer()
-                            return
-                    mongo.add_replset_member(member)
-                    self.status.set_and_share_status(ActiveStatus())
-            except NotReadyError:
-                self.status.set_and_share_status(
-                    WaitingStatus("waiting to reconfigure replica set")
-                )
-                logger.error("Deferring reconfigure: another member doing sync right now")
-                event.defer()
-            except PyMongoError as e:
-                self.status.set_and_share_status(
-                    WaitingStatus("waiting to reconfigure replica set")
-                )
-                logger.error("Deferring reconfigure: error=%r", e)
-                event.defer()
+    def __add_members_to_replicaset(self, event: RelationEvent):
+        with MongoDBConnection(self.mongodb_config) as mongo:
+            replset_members = mongo.get_replset_members()
+            # compare set of mongod replica set members and juju hosts to avoid the unnecessary
+            # reconfiguration.
+            if replset_members == self.mongodb_config.hosts:
+                return
+
+            for member in self.mongodb_config.hosts - replset_members:
+                logger.debug("Adding %s to replica set", member)
+                with MongoDBConnection(self.mongodb_config, member, direct=True) as direct_mongo:
+                    if not direct_mongo.is_ready:
+                        self.status.set_and_share_status(
+                            WaitingStatus("waiting to reconfigure replica set")
+                        )
+                        logger.debug("Deferring reconfigure: %s is not ready yet.", member)
+                        event.defer()
+                        return
+                mongo.add_replset_member(member)
+                self.status.set_and_share_status(ActiveStatus())
 
     def _on_leader_elected(self, event: LeaderElectedEvent) -> None:
         """Generates necessary keyfile and updates replica hosts."""
@@ -1234,6 +1347,25 @@ class MongodbOperatorCharm(CharmBase):
         except subprocess.CalledProcessError as e:
             logger.error(f"Exception occurred running '{cmd}'\n {e}")
 
+    def _reconfigure_replica_set(self) -> None:
+        """Optionally reconfigure replicaset if needed.
+
+        This should happen only when we are reusing storage from one cluster to another cluster,
+        because all IPs have changed and all configurations are broken.
+        """
+        if not self.db_initialised:
+            return
+
+        with MongoDBConnection(self.single_host_config, direct=True) as direct_mongo:
+
+            replset_members, version = direct_mongo.get_replset_members_and_version()
+            related_hosts = set(self.app_hosts)
+            if replset_members and all(member not in related_hosts for member in replset_members):
+                logger.info(f"Reconfiguring replica set to {related_hosts}")
+                direct_mongo.reconfigure_replset(
+                    hosts=related_hosts, version=version + 1, force=True
+                )
+
     def _initialise_replica_set(self, event: StartEvent) -> None:
         if self.db_initialised:
             # The replica set should be initialised only once. Check should be
@@ -1242,7 +1374,16 @@ class MongodbOperatorCharm(CharmBase):
             # can be corrupted.
             return
 
-        with MongoDBConnection(self.mongodb_config, "localhost", direct=True) as direct_mongo:
+        # If we are reusing storage, the user operator already exists
+        # hence the need to authenticate.
+        if self.is_role(Config.Role.REPLICATION) and self._is_storage_from_different_cluster:
+            config = self.standalone_config
+            uri = None
+        else:
+            config = self.mongodb_config
+            uri = "localhost"
+
+        with MongoDBConnection(config, uri, direct=True) as direct_mongo:
             try:
                 logger.info("Replica Set initialization")
                 direct_mongo.init_replset()
@@ -1266,20 +1407,26 @@ class MongodbOperatorCharm(CharmBase):
                 )
                 event.defer()
                 self.status.set_and_share_status(
-                    WaitingStatus("waiting to initialise replica set")
+                    WaitingStatus("[ERR1] waiting to initialise replica set")
                 )
                 return
             except PyMongoError as e:
                 logger.error("Deferring on_start since: error=%r", e)
                 event.defer()
                 self.status.set_and_share_status(
-                    WaitingStatus("waiting to initialise replica set")
+                    WaitingStatus("[ERR2] waiting to initialise replica set")
                 )
                 return
 
             # replica set initialised properly and ready to go
             self.db_initialised = True
+            self.lock_hash = generate_lock_hash()
             self.status.set_and_share_status(ActiveStatus())
+
+    @property
+    def databag_lock_hash(self) -> str:
+        """The data from the databag."""
+        return self.get_secret(APP_SCOPE, HASH_KEY) or UNDEFINED
 
     def unit_host(self, unit: Unit) -> str:
         """Returns the ip address of a given unit."""
@@ -1507,6 +1654,7 @@ class MongodbOperatorCharm(CharmBase):
     @property
     def _is_removing_last_replica(self) -> bool:
         """Returns True if the last replica (juju unit) is getting removed."""
+        logger.error(f"{self.app.planned_units() = } | {len(self.peers_units) = }")
         return self.app.planned_units() == 0 and len(self.peers_units) == 0
 
     def is_relation_feasible(self, rel_interface) -> bool:

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,7 @@
 # See LICENSE file for licensing details.
 
 from pathlib import Path
-from typing import Literal, TypeAlias
+from typing import List, Literal, TypeAlias
 
 from ops.model import BlockedStatus
 
@@ -22,9 +22,10 @@ class Config:
     MONGOD_CONF_DIR = f"{MONGODB_SNAP_DATA_DIR}/etc/mongod"
     MONGOD_CONF_FILE_PATH = f"{MONGOD_CONF_DIR}/mongod.conf"
     CHARM_INTERNAL_VERSION_FILE = "charm_internal_version"
-    SNAP_PACKAGES = [("charmed-mongodb", "6/edge", 121)]
+    SNAP_PACKAGES: List[Package] = [("charmed-mongodb", "6/edge", 121)]
 
     MONGODB_COMMON_PATH = Path("/var/snap/charmed-mongodb/common")
+    MONGODB_DATA_DIR = Path("/var/snap/charmed-mongodb/common/var/lib/mongodb")
 
     # This is the snap_daemon user, which does not exist on the VM before the
     # snap install so creating it by UID

--- a/src/lock_hash.py
+++ b/src/lock_hash.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Charm code for MongoDB service."""
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+"""A Data descriptor that is in charge of handling the filesystem lock hash value."""
 
 
 import os
@@ -20,7 +20,16 @@ UNDEFINED = "UNDEFINED"
 
 
 class LockHashHandler:
-    """Descriptor class for the lock hash stored in the file."""
+    """Descriptor class for the lock hash stored in the file.
+
+    In order to safely reuse storage, we need to be able to detect if we are reusing storage.
+    This is done by maintaining two things: A file in the filesystem of the
+    unit which stores a string, shared in the cluster, and the exact same
+    string in the application secrets.
+    If they have the same value, we're reusing storage in the same application/replicaset.
+    If there's no file but a value in the secret, we're adding a new unit.
+    If there's a file but no value in the secret, we're reusing in a new application context.
+    """
 
     def __set__(self, obj: ops.CharmBase, value: str):
         """Sets the key in the dedicated file and in the storage."""

--- a/src/lock_hash.py
+++ b/src/lock_hash.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Charm code for MongoDB service."""
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import os
+from logging import getLogger
+
+import ops
+
+from config import Config
+from machine_helpers import ROOT_USER_GID
+
+logger = getLogger(__name__)
+
+HASH_KEY = "lockhash"
+LOCK_PATH = Config.MONGODB_DATA_DIR / f".{HASH_KEY}"
+UNDEFINED = "UNDEFINED"
+
+
+class LockHashHandler:
+    """Descriptor class for the lock hash stored in the file."""
+
+    def __set__(self, obj: ops.CharmBase, value: str):
+        """Sets the key in the dedicated file and in the storage."""
+        logger.debug(f"Writing {value} in file for unit {obj.unit.name}")
+        with open(LOCK_PATH, "w") as write_file:
+            write_file.write(value)
+        os.chmod(LOCK_PATH, 0o644)
+        os.chown(LOCK_PATH, Config.SNAP_USER, ROOT_USER_GID)
+        if obj.unit.is_leader():
+            obj.set_secret(Config.Relations.APP_SCOPE, HASH_KEY, value)
+
+    def __get__(self, *unused) -> str:
+        """Optionally gets the key from the file."""
+        try:
+            return LOCK_PATH.read_text()
+        except OSError as err:
+            logger.info(f"Unable to read file because of {err}")
+            return UNDEFINED

--- a/src/machine_helpers.py
+++ b/src/machine_helpers.py
@@ -9,6 +9,7 @@ from charms.mongodb.v1.helpers import (
     LOG_DIR,
     MONGODB_COMMON_DIR,
     add_args_to_env,
+    get_degraded_mongod_args,
     get_mongod_args,
     get_mongos_args,
 )
@@ -33,9 +34,15 @@ def update_mongod_service(
     """
     # write our arguments and write them to /etc/environment - the environment variable here is
     # read in in the charmed-mongob.mongod.service file.
-    mongod_start_args = get_mongod_args(
-        config, auth=True, role=role, snap_install=True, machine_ip=machine_ip, degraded=degraded
-    )
+    if degraded:
+        mongod_start_args = get_degraded_mongod_args(snap_install=True)
+    else:
+        mongod_start_args = get_mongod_args(
+            config,
+            auth=True,
+            role=role,
+            snap_install=True,
+        )
     add_args_to_env("MONGOD_ARGS", mongod_start_args)
 
     if role == Config.Role.CONFIG_SERVER:

--- a/src/machine_helpers.py
+++ b/src/machine_helpers.py
@@ -24,12 +24,18 @@ MONGO_USER = "snap_daemon"
 
 
 def update_mongod_service(
-    machine_ip: str, config: MongoConfiguration, role: str = "replication"
+    machine_ip: str, config: MongoConfiguration, role: str = "replication", degraded: bool = False
 ) -> None:
-    """Updates the mongod service file with the new options for starting."""
+    """Updates the mongod service file with the new options for starting.
+
+    `degraded` argument should be used only for maintenance situation, it
+    induces a downtime and a disconnection from the replicaset.
+    """
     # write our arguments and write them to /etc/environment - the environment variable here is
     # read in in the charmed-mongob.mongod.service file.
-    mongod_start_args = get_mongod_args(config, auth=True, role=role, snap_install=True)
+    mongod_start_args = get_mongod_args(
+        config, auth=True, role=role, snap_install=True, machine_ip=machine_ip, degraded=degraded
+    )
     add_args_to_env("MONGOD_ARGS", mongod_start_args)
 
     if role == Config.Role.CONFIG_SERVER:

--- a/tests/integration/ha_tests/conftest.py
+++ b/tests/integration/ha_tests/conftest.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import get_app_name
+from .helpers import clear_db_writes, start_continous_writes, update_restart_delay
+
+ORIGINAL_RESTART_DELAY = 5
+
+
+@pytest.fixture
+async def continuous_writes(ops_test: OpsTest):
+    """Starts continuous write operations to MongoDB for test and clears writes at end of test."""
+    await start_continous_writes(ops_test, 1)
+    yield
+    await clear_db_writes(ops_test)
+
+
+@pytest.fixture
+async def reset_restart_delay(ops_test: OpsTest):
+    """Resets service file delay on all units."""
+    yield
+    app_name = await get_app_name(ops_test)
+    for unit in ops_test.model.applications[app_name].units:
+        await update_restart_delay(ops_test, unit, ORIGINAL_RESTART_DELAY)
+
+
+@pytest.fixture(scope="module")
+async def database_charm(ops_test: OpsTest):
+    """Build the database charm."""
+    charm = await ops_test.build_charm(".")
+    return charm

--- a/tests/integration/ha_tests/test_storage.py
+++ b/tests/integration/ha_tests/test_storage.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+import os
+import time
+
+import pytest
+from juju import tag
+from pytest_operator.plugin import OpsTest
+
+from ..helpers import check_or_scale_app, get_app_name
+from .helpers import (
+    APP_NAME,
+    count_writes,
+    reused_storage,
+    stop_continous_writes,
+    storage_id,
+    storage_type,
+)
+
+OTHER_APP_NAME = "mongodb-new"
+TIMEOUT = 1000
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.skipif(
+    os.environ.get("PYTEST_SKIP_DEPLOY", False),
+    reason="skipping deploy, model expected to be provided.",
+)
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, database_charm) -> None:
+    """Build and deploy one unit of MongoDB."""
+    # it is possible for users to provide their own cluster for HA testing. Hence check if there
+    # is a pre-existing cluster.
+    required_units = 3
+    user_app_name = await get_app_name(ops_test)
+    if user_app_name:
+        await check_or_scale_app(ops_test, user_app_name, required_units)
+        return
+
+    storage = {"mongodb": {"pool": "lxd", "size": 2048}}
+
+    await ops_test.model.deploy(
+        database_charm, application_name=APP_NAME, num_units=required_units, storage=storage
+    )
+    await ops_test.model.wait_for_idle()
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_storage_re_use(ops_test, continuous_writes):
+    """Verifies that database units with attached storage correctly repurpose storage.
+
+    It is not enough to verify that Juju attaches the storage. Hence test checks that the mongod
+    properly uses the storage that was provided. (ie. doesn't just re-sync everything from
+    primary, but instead computes a diff between current storage and primary storage.)
+    """
+    app_name = await get_app_name(ops_test)
+    if storage_type(ops_test, app_name) == "rootfs":
+        pytest.skip(
+            "reuse of storage can only be used on deployments with persistent storage not on rootfs deployments"
+        )
+
+    # removing the only replica can be disastrous
+    if len(ops_test.model.applications[app_name].units) < 2:
+        await ops_test.model.applications[app_name].add_unit(count=1)
+        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=TIMEOUT)
+
+    # remove a unit and attach it's storage to a new unit
+    unit = ops_test.model.applications[app_name].units[0]
+    unit_storage_id = storage_id(ops_test, unit.name)
+    expected_units = len(ops_test.model.applications[app_name].units) - 1
+    removal_time = time.time()
+    await ops_test.model.destroy_unit(unit.name)
+    await ops_test.model.wait_for_idle(
+        apps=[app_name], status="active", timeout=TIMEOUT, wait_for_exact_units=expected_units
+    )
+    new_unit = (
+        await ops_test.model.applications[app_name].add_unit(
+            count=1, attach_storage=[tag.storage(unit_storage_id)]
+        )
+    )[0]
+
+    await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=TIMEOUT)
+
+    assert await reused_storage(
+        ops_test, new_unit.name, removal_time
+    ), "attached storage not properly reused by MongoDB."
+
+    # verify that the no writes were skipped
+    total_expected_writes = await stop_continous_writes(ops_test, app_name=app_name)
+    actual_writes = await count_writes(ops_test, app_name=app_name)
+    assert total_expected_writes["number"] == actual_writes
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_storage_re_use_after_scale_down_to_zero(ops_test: OpsTest, continuous_writes):
+    """Tests that we can reuse storage after a scale down to zero.
+
+    For that, we completely scale down to zero while keeping the storages,
+    and then we add units back with storage reuse and check that the
+    storage has been reused.
+    """
+    app_name = await get_app_name(ops_test)
+    if storage_type(ops_test, app_name) == "rootfs":
+        pytest.skip(
+            "reuse of storage can only be used on deployments with persistent storage not on rootfs deployments"
+        )
+
+    writes_results = await stop_continous_writes(ops_test, app_name=app_name)
+    unit_ids = [unit.name for unit in ops_test.model.applications[app_name].units]
+    storage_ids = {}
+
+    remaining_units = len(unit_ids)
+    for unit_id in unit_ids:
+        storage_ids[unit_id] = storage_id(ops_test, unit_id)
+        await ops_test.model.applications[app_name].destroy_unit(unit_id)
+        # Give some time to remove the unit. We don't use asyncio.sleep here to
+        # leave time for each unit to be removed before removing the next one.
+        # time.sleep(60)
+        remaining_units -= 1
+        await ops_test.model.wait_for_idle(
+            apps=[app_name],
+            status="active",
+            timeout=TIMEOUT,
+            idle_period=20,
+            wait_for_exact_units=remaining_units,
+        )
+
+    # Wait until all apps are cleaned up
+    await ops_test.model.wait_for_idle(apps=[app_name], timeout=TIMEOUT, wait_for_exact_units=0)
+
+    for unit_id in unit_ids:
+        n_units = len(ops_test.model.applications[app_name].units)
+        await ops_test.model.applications[app_name].add_unit(
+            count=1, attach_storage=[tag.storage(storage_ids[unit_id])]
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[app_name],
+            status="active",
+            timeout=TIMEOUT,
+            idle_period=20,
+            wait_for_exact_units=n_units + 1,
+        )
+
+    await ops_test.model.wait_for_idle(
+        apps=[app_name],
+        status="active",
+        timeout=TIMEOUT,
+        idle_period=20,
+        wait_for_exact_units=len(unit_ids),
+    )
+
+    actual_writes = await count_writes(ops_test, app_name=app_name)
+    assert writes_results["number"] == actual_writes
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_storage_reuse_new_app_same_name(
+    ops_test: OpsTest, database_charm, continuous_writes
+):
+    """Tests that we can reuse storage from a different cluster, with the same app name.
+
+    For that, we completely remove the application while keeping the storages,
+    and then we deploy a new application with storage reuse and check that the
+    storage has been reused.
+    """
+    app_name = await get_app_name(ops_test)
+    if storage_type(ops_test, app_name) == "rootfs":
+        pytest.skip(
+            "reuse of storage can only be used on deployments with persistent storage not on rootfs deployments"
+        )
+
+    writes_results = await stop_continous_writes(ops_test, app_name=app_name)
+
+    time.sleep(70)  # Leave some time to write the oplog + lock (60s + a few more)
+    unit_ids = [unit.name for unit in ops_test.model.applications[app_name].units]
+    storage_ids = {}
+
+    remaining_units = len(unit_ids)
+    for unit_id in unit_ids:
+        storage_ids[unit_id] = storage_id(ops_test, unit_id)
+        await ops_test.model.applications[app_name].destroy_unit(unit_id)
+
+        remaining_units -= 1
+        await ops_test.model.wait_for_idle(
+            apps=[app_name],
+            status="active",
+            timeout=TIMEOUT,
+            idle_period=20,
+            wait_for_exact_units=remaining_units,
+        )
+
+    # Wait until all apps are cleaned up
+    await ops_test.model.wait_for_idle(apps=[app_name], timeout=TIMEOUT, wait_for_exact_units=0)
+
+    await ops_test.model.remove_application(
+        app_name,
+        block_until_done=True,
+        destroy_storage=False,
+    )
+
+    await ops_test.model.deploy(
+        database_charm,
+        application_name=app_name,
+        num_units=1,
+        attach_storage=[tag.storage(storage_ids[unit_ids[0]])],
+    )
+
+    deployed_units = 1
+    await ops_test.model.wait_for_idle(
+        apps=[app_name],
+        status="active",
+        timeout=TIMEOUT,
+        idle_period=60,
+        wait_for_exact_units=deployed_units,
+    )
+
+    for unit_id in unit_ids[1:]:
+        deployed_units += 1
+        await ops_test.model.applications[app_name].add_unit(
+            count=1, attach_storage=[tag.storage(storage_ids[unit_id])]
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[app_name],
+            status="active",
+            timeout=TIMEOUT,
+            idle_period=60,
+            wait_for_exact_units=deployed_units,
+        )
+
+    await ops_test.model.wait_for_idle(
+        apps=[app_name],
+        status="active",
+        timeout=TIMEOUT,
+        idle_period=120,
+        wait_for_exact_units=deployed_units,
+    )
+
+    assert len(ops_test.model.applications[app_name].units) == len(storage_ids)
+
+    # check if previous volumes are attached to the units of the new cluster
+    new_storage_ids = []
+    for unit in ops_test.model.applications[app_name].units:
+        new_storage_ids.append(storage_id(ops_test, unit.name))
+
+    assert sorted(storage_ids.values()) == sorted(new_storage_ids), "Storage IDs mismatch"
+
+    actual_writes = await count_writes(ops_test, app_name=app_name)
+    assert writes_results["number"] == actual_writes
+
+
+@pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
+@pytest.mark.group(1)
+@pytest.mark.abort_on_fail
+async def test_storage_reuse_new_app_different_name(
+    ops_test: OpsTest, database_charm, continuous_writes
+):
+    """Tests that we can reuse storage from a different cluster, with the same app name.
+
+    For that, we completely remove the application while keeping the storages,
+    and then we deploy a new application with storage reuse and check that the
+    storage has been reused.
+    """
+    app_name = await get_app_name(ops_test)
+    if storage_type(ops_test, app_name) == "rootfs":
+        pytest.skip(
+            "reuse of storage can only be used on deployments with persistent storage not on rootfs deployments"
+        )
+
+    writes_results = await stop_continous_writes(ops_test, app_name=app_name)
+    time.sleep(70)  # Leave some time to write the oplog + lock (60s + a few more)
+    unit_ids = [unit.name for unit in ops_test.model.applications[app_name].units]
+    storage_ids = {}
+
+    remaining_units = len(unit_ids)
+    for unit_id in unit_ids:
+        storage_ids[unit_id] = storage_id(ops_test, unit_id)
+        await ops_test.model.applications[app_name].destroy_unit(unit_id)
+        # Give some time to remove the unit. We don't use asyncio.sleep here to
+        # leave time for each unit to be removed before removing the next one.
+        # time.sleep(60)
+        remaining_units -= 1
+        await ops_test.model.wait_for_idle(
+            apps=[app_name],
+            status="active",
+            timeout=TIMEOUT,
+            idle_period=20,
+            wait_for_exact_units=remaining_units,
+        )
+
+    # Wait until all apps are cleaned up
+    await ops_test.model.wait_for_idle(apps=[app_name], timeout=TIMEOUT, wait_for_exact_units=0)
+
+    await ops_test.model.remove_application(app_name, block_until_done=True, destroy_storage=False)
+
+    new_app_name = OTHER_APP_NAME
+
+    await ops_test.model.deploy(
+        database_charm,
+        application_name=new_app_name,
+        num_units=1,
+        attach_storage=[tag.storage(storage_ids[unit_ids[0]])],
+    )
+    deployed_units = 1
+    await ops_test.model.wait_for_idle(
+        apps=[new_app_name],
+        status="active",
+        timeout=TIMEOUT,
+        idle_period=60,
+        wait_for_exact_units=deployed_units,
+    )
+
+    for unit_id in unit_ids[1:]:
+        deployed_units += 1
+        await ops_test.model.applications[new_app_name].add_unit(
+            count=1, attach_storage=[tag.storage(storage_ids[unit_id])]
+        )
+        await ops_test.model.wait_for_idle(
+            apps=[new_app_name],
+            status="active",
+            timeout=TIMEOUT,
+            idle_period=60,
+            wait_for_exact_units=deployed_units,
+        )
+
+    assert len(ops_test.model.applications[new_app_name].units) == len(storage_ids)
+
+    # check if previous volumes are attached to the units of the new cluster
+    new_storage_ids = []
+    for unit in ops_test.model.applications[new_app_name].units:
+        new_storage_ids.append(storage_id(ops_test, unit.name))
+
+    assert sorted(storage_ids.values()) == sorted(new_storage_ids), "Storage IDs mismatch"
+
+    actual_writes = await count_writes(ops_test, app_name=new_app_name)
+    assert writes_results["number"] == actual_writes

--- a/tests/integration/ha_tests/test_storage.py
+++ b/tests/integration/ha_tests/test_storage.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-import os
 import time
 
 import pytest
@@ -18,16 +17,12 @@ from .helpers import (
     storage_type,
 )
 
-OTHER_APP_NAME = "mongodb-new"
+OTHER_MONGODB_APP_NAME = "mongodb-new"
 TIMEOUT = 1000
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
-@pytest.mark.skipif(
-    os.environ.get("PYTEST_SKIP_DEPLOY", False),
-    reason="skipping deploy, model expected to be provided.",
-)
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, database_charm) -> None:
     """Build and deploy one unit of MongoDB."""
@@ -62,11 +57,6 @@ async def test_storage_re_use(ops_test, continuous_writes):
         pytest.skip(
             "reuse of storage can only be used on deployments with persistent storage not on rootfs deployments"
         )
-
-    # removing the only replica can be disastrous
-    if len(ops_test.model.applications[app_name].units) < 2:
-        await ops_test.model.applications[app_name].add_unit(count=1)
-        await ops_test.model.wait_for_idle(apps=[app_name], status="active", timeout=TIMEOUT)
 
     # remove a unit and attach it's storage to a new unit
     unit = ops_test.model.applications[app_name].units[0]
@@ -300,7 +290,7 @@ async def test_storage_reuse_new_app_different_name(
 
     await ops_test.model.remove_application(app_name, block_until_done=True, destroy_storage=False)
 
-    new_app_name = OTHER_APP_NAME
+    new_app_name = OTHER_MONGODB_APP_NAME
 
     await ops_test.model.deploy(
         database_charm,


### PR DESCRIPTION
## Issue
 * Storage reuse doesn't work if we use a new application

## Solution

There are multiple problems to face when reusing storage in a new application:
* We need to be able to detect that we are using a new application and not adding back to the same replica set.
* We cannot suppose we have kept all users passwords so we need to change it.
* We might have to change the replica set name.
* We need in any case to reconfigure the replicaset.

The solution chosen here is the following:
 * We store on the storage volume a file containing a random string
 * This string is also stored as a secret (because we have access to app secrets in `install` event, which is not the case for the app peer databag)
 * If we detect that, after installing charmed mongodb, we'll start mongodb in a degraded mode: no replicaset, no auth validation. This allows us to patch the deployment
 * Then we init the replica set, but we need to use authentication here in order to ensure that it works, because we already have the users in this case.
 * We add one more optional reconfigure : for at least two situations, it can happen that all IP changes. This leads to the replica set being fully broken, no host being able to find the other members of the replica set. In order to fix this, a new method to forcefully reconfigure the replica set is added in a specific case : None of the IPs in the mongoDB replica set config is matching the IPs in the replica set config in the Databag. This is achieved by opening a standalone connection to the node (which doesn't require any server selection in the replicaset) and getting the `config` (not the `status` which does requires to be connected to other nodes).

The (not so big) drawback:
 * Some of the most recent data might be lost (sic). WiredTiger writes the snapshots to disk every 60 seconds, which means some of the last data might be lost.
 * I tried to go to different solutions (update users and rename replica set only) in order to avoid that, which ended up in: Core dump of mongodb (yes…), MongoDB restarting in loop because of some config collections being broken. I haven't been able to figure out what the issue was, so I decided to go with this in-between solution.
 * I find this is an acceptable solution granted that:
  * If we're reusing storage in a new application willingly, we can leave time for snapshot to be written on disk
  * If we reusing storage after a crash, it's an acceptable loss to lose the very latest data.

## Implements
 * Storage reuse on the same cluster (scale down, scale to zero).
 * Storage reuse on a different cluster with same app name.
 * Storage reuse on a different cluster with different app name.
 * Restore after a full cluster crash.

## Suggestions for the future

* A big part of the issues we have come from the fact that we use IPs and no DNS inside the cluster.
Having a DNS in the cluster would help as network crash or machines restarting wouldn't change the name of each unit, and the cluster would be able to survive IP changes.
* An integration to external secrets could help make this easier: deploying a new application connected to external secrets would help not losing the secrets in the first application and just restarting as before, with "only" big reconfigurations of hosts.
