### PR TITLE
[DPE-5500] Re enable sharding upgrade tests

### DIFF
--- a/tests/integration/upgrade/test_sharding_rollback.py
+++ b/tests/integration/upgrade/test_sharding_rollback.py
@@ -30,7 +30,6 @@ TIMEOUT = 15 * 60
 MEDIAN_REELECTION_TIME = 12
 
 
-@pytest.mark.skip(reason="Disable until sharded upgrades are working again")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -52,7 +51,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
 
 
-@pytest.mark.skip(reason="Disable until sharded upgrades are working again")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -111,7 +109,6 @@ async def test_rollback_on_config_server(
     # TODO implement this check once we have implemented the post-cluster-upgrade code DPE-4143
 
 
-@pytest.mark.skip(reason="Disable until sharded upgrades are working again")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail

--- a/tests/integration/upgrade/test_sharding_upgrade.py
+++ b/tests/integration/upgrade/test_sharding_upgrade.py
@@ -38,7 +38,6 @@ TIMEOUT = 15 * 60
 MEDIAN_REELECTION_TIME = 12
 
 
-@pytest.mark.skip(reason="Disable until sharded upgrades are working again")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -60,7 +59,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     )
 
 
-@pytest.mark.skip(reason="Disable until sharded upgrades are working again")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail
@@ -116,7 +114,6 @@ async def test_upgrade(
     assert balancer_state["mode"] != "off", "balancer not turned back on from config server"
 
 
-@pytest.mark.skip(reason="Disable until sharded upgrades are working again")
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
 @pytest.mark.group(1)
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
## Issue

 * Some tests were disabled during #486 

## Solution

 * Enable it again
