### PR TITLE
[URGENT] bump lib for helpers to enable access to sock

### DIFF
--- a/lib/charms/mongodb/v1/helpers.py
+++ b/lib/charms/mongodb/v1/helpers.py
@@ -23,7 +23,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 # path to store mongodb ketFile
 KEY_FILE = "keyFile"
@@ -118,7 +118,7 @@ def get_mongos_args(
     binding_ips = (
         "--bind_ip_all"
         if external_connectivity
-        else f"--bind_ip {MONGODB_COMMON_DIR}/var/mongodb-27018.sock"
+        else f"--bind_ip {MONGODB_COMMON_DIR}/var/mongodb-27018.sock  --filePermissions 755"
     )
 
     # mongos running on the config server communicates through localhost


### PR DESCRIPTION
## Issue
only the snap_daemon can access mongodb via the unix socket, this prevents clients integrated to mongos from accesses the db

## Solution
allow users to access it

Kudos to @Gu1nness for the help here
