### PR TITLE
Fix incorrect Adding shard to config-server status

### DIFF
--- a/lib/charms/mongodb/v1/shards_interface.py
+++ b/lib/charms/mongodb/v1/shards_interface.py
@@ -58,7 +58,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 KEYFILE_KEY = "key-file"
 HOSTS_KEY = "host"
@@ -557,7 +557,7 @@ class ConfigServerRequirer(Object):
         super().__init__(charm, self.relation_name)
 
         self.framework.observe(
-            charm.on[self.relation_name].relation_joined, self._on_relation_joined
+            charm.on[self.relation_name].relation_created, self.relation_created
         )
         self.framework.observe(
             charm.on[self.relation_name].relation_changed, self._on_relation_changed
@@ -687,7 +687,7 @@ class ConfigServerRequirer(Object):
         # after updating the password of the backup user, restart pbm with correct password
         self.charm._connect_pbm_agent()
 
-    def _on_relation_joined(self, event: RelationJoinedEvent):
+    def relation_created(self, event: RelationJoinedEvent):
         """Sets status and flags in relation data relevant to sharding."""
         # if re-using an old shard, re-set flags.
         self.charm.unit_peer_data["drained"] = json.dumps(False)


### PR DESCRIPTION
## Issue
show relation-created relevant status for relation created , the "Adding shard to config-server" status shows when config-server application scales.

## Solution
This event is meant to be listened to on relation created