### PR TITLE
[DPE-3911] Update lib so that correct mongos port is used in k8s

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -31,7 +31,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
@@ -372,6 +372,7 @@ class MongoDBProvider(Object):
             mongo_args["port"] = Config.MONGOS_PORT
             if self.substrate == Config.Substrate.K8S:
                 mongo_args["hosts"] = self.charm.get_mongos_hosts_for_client()
+                mongo_args["port"] = self.charm.get_mongos_port()
         else:
             mongo_args["replset"] = self.charm.app.name
 


### PR DESCRIPTION
## Issue
port in mongos k8s is incorrect - since we don't query the actual charm for its port 

## Solution
add the port in mongos clients 