### PR TITLE
fix: export fallback out of get

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_backups.py
+++ b/lib/charms/mongodb/v1/mongodb_backups.py
@@ -41,7 +41,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 logger = logging.getLogger(__name__)
 
@@ -800,7 +800,7 @@ class MongoDBBackups(Object):
         """Get the error status for a provided backup."""
         pbm_status = self.charm.run_pbm_command(["status", "--out=json"])
         pbm_status = json.loads(pbm_status)
-        backups = pbm_status["backups"].get("snapshot", [])
+        backups = pbm_status["backups"].get("snapshot") or []
         for backup in backups:
             if backup_id == backup["name"]:
                 return backup.get("error", "")


### PR DESCRIPTION
## Issue

The dictionary can have a None value in case there's no snapshot: pbm status can contain a `null` value for pbm[backups][snapshot] which is parsed as None and then `pbm_status["backups"].get("snapshot", []) == None` which is not what is expected here since we want to iterate on the results

## Solution

Export the fallback out of the `get` in order to ensure that we can iterate on it later.