### PR TITLE
[DPE-6191] - fix timeout on install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,8 @@ jobs:
           terraform fmt
           terraform validate
       - name: lint test charm module
-         working-directory: ./terraform/tests
-         run: |
+        working-directory: ./terraform/tests
+        run: |
           terraform init
           terraform fmt
           terraform validate

--- a/tests/integration/backup_tests/test_backups.py
+++ b/tests/integration/backup_tests/test_backups.py
@@ -13,6 +13,7 @@ from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from ..ha_tests import helpers as ha_helpers
 from ..helpers import (
+    DEPLOYMENT_TIMEOUT,
     destroy_cluster,
     get_app_name,
     is_relation_joined,
@@ -61,7 +62,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     # deploy the s3 integrator charm
     await ops_test.model.deploy(S3_APP_NAME, channel="edge")
 
-    await ops_test.model.wait_for_idle()
+    await ops_test.model.wait_for_idle(timeout=DEPLOYMENT_TIMEOUT)
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])
@@ -347,7 +348,12 @@ async def test_restore_new_cluster(
     db_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(db_charm, num_units=3, application_name=new_cluster_app_name)
     await asyncio.gather(
-        ops_test.model.wait_for_idle(apps=[new_cluster_app_name], status="active", idle_period=15),
+        ops_test.model.wait_for_idle(
+            apps=[new_cluster_app_name],
+            status="active",
+            idle_period=15,
+            timeout=DEPLOYMENT_TIMEOUT,
+        ),
     )
 
     db_unit = await helpers.get_leader_unit(ops_test, db_app_name=new_cluster_app_name)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -27,7 +27,7 @@ APP_NAME = METADATA["name"]
 PORT = 27017
 UNIT_IDS = [0, 1, 2]
 SERIES = "jammy"
-
+DEPLOYMENT_TIMEOUT = 2000
 logger = logging.getLogger(__name__)
 
 logger = logging.getLogger(__name__)

--- a/tests/integration/metrics_tests/test_metrics.py
+++ b/tests/integration/metrics_tests/test_metrics.py
@@ -11,6 +11,7 @@ from pytest_operator.plugin import OpsTest
 
 from ..ha_tests import helpers as ha_helpers
 from ..helpers import (
+    DEPLOYMENT_TIMEOUT,
     UNIT_IDS,
     check_or_scale_app,
     find_unit,
@@ -40,7 +41,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     my_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(my_charm, num_units=3)
-    await ops_test.model.wait_for_idle()
+    await ops_test.model.wait_for_idle(timeout=DEPLOYMENT_TIMEOUT)
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])

--- a/tests/integration/relation_tests/new_relations/test_charm_relations.py
+++ b/tests/integration/relation_tests/new_relations/test_charm_relations.py
@@ -13,7 +13,12 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError
 
 from ...ha_tests.helpers import replica_set_primary
-from ...helpers import check_or_scale_app, get_app_name, is_relation_joined
+from ...helpers import (
+    DEPLOYMENT_TIMEOUT,
+    check_or_scale_app,
+    get_app_name,
+    is_relation_joined,
+)
 from .helpers import (
     assert_created_user_can_connect,
     get_application_relation_data,
@@ -89,7 +94,10 @@ async def test_deploy_charms(ops_test: OpsTest, application_charm, database_char
     else:
         APP_NAMES.append(DATABASE_APP_NAME)
     await ops_test.model.wait_for_idle(
-        apps=APP_NAMES, status="active", wait_for_at_least_units=required_units
+        apps=APP_NAMES,
+        status="active",
+        wait_for_at_least_units=required_units,
+        timeout=DEPLOYMENT_TIMEOUT,
     )
 
 
@@ -316,7 +324,9 @@ async def test_two_applications_doesnt_share_the_same_relation_data(
         application_charm,
         application_name=ANOTHER_APPLICATION_NAME,
     )
-    await ops_test.model.wait_for_idle(apps=all_app_names, status="active")
+    await ops_test.model.wait_for_idle(
+        apps=all_app_names, status="active", timeout=DEPLOYMENT_TIMEOUT
+    )
 
     db_app_name = (
         await get_app_name(ops_test, test_deployments=[ANOTHER_DATABASE_APP_NAME])

--- a/tests/integration/sharding_tests/test_mongos.py
+++ b/tests/integration/sharding_tests/test_mongos.py
@@ -7,6 +7,7 @@ import pytest
 from pymongo.errors import OperationFailure
 from pytest_operator.plugin import OpsTest
 
+from ..helpers import DEPLOYMENT_TIMEOUT
 from .helpers import count_users, generate_mongodb_client, get_username_password
 
 MONGOS_HOST_APP_NAME = "application"
@@ -52,7 +53,7 @@ async def test_build_and_deploy(ops_test: OpsTest, mongos_host_application_charm
         apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, MONGOS_HOST_APP_NAME],
         idle_period=20,
         raise_on_blocked=False,  # cluster components are blocked waiting for integration.
-        timeout=TIMEOUT,
+        timeout=DEPLOYMENT_TIMEOUT,
         raise_on_error=False,
     )
 

--- a/tests/integration/sharding_tests/test_sharding.py
+++ b/tests/integration/sharding_tests/test_sharding.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
+    DEPLOYMENT_TIMEOUT,
     get_leader_id,
     get_password,
     set_password,
@@ -71,7 +72,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         ],
         idle_period=20,
         raise_on_blocked=False,
-        timeout=TIMEOUT,
+        timeout=DEPLOYMENT_TIMEOUT,
         raise_on_error=False,
     )
 

--- a/tests/integration/sharding_tests/test_sharding_backups.py
+++ b/tests/integration/sharding_tests/test_sharding_backups.py
@@ -12,7 +12,13 @@ from pytest_operator.plugin import OpsTest
 from tenacity import Retrying, stop_after_delay, wait_fixed
 
 from ..backup_tests import helpers as backup_helpers
-from ..helpers import destroy_cluster, get_leader_id, get_password, set_password
+from ..helpers import (
+    DEPLOYMENT_TIMEOUT,
+    destroy_cluster,
+    get_leader_id,
+    get_password,
+    set_password,
+)
 from . import writes_helpers
 from .helpers import generate_mongodb_client, write_data_to_mongodb
 
@@ -406,7 +412,7 @@ async def deploy_cluster_backup_test(
         apps=[S3_APP_NAME, config_server_name, shard_one_name, shard_two_name],
         idle_period=20,
         raise_on_blocked=False,
-        timeout=TIMEOUT,
+        timeout=DEPLOYMENT_TIMEOUT,
         raise_on_error=False,
     )
 

--- a/tests/integration/sharding_tests/test_sharding_relations.py
+++ b/tests/integration/sharding_tests/test_sharding_relations.py
@@ -5,7 +5,7 @@ import pytest
 from juju.errors import JujuAPIError
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import wait_for_mongodb_units_blocked
+from ..helpers import DEPLOYMENT_TIMEOUT, wait_for_mongodb_units_blocked
 
 S3_APP_NAME = "s3-integrator"
 SHARD_ONE_APP_NAME = "shard"
@@ -75,7 +75,7 @@ async def test_build_and_deploy(
         ],
         idle_period=20,
         raise_on_blocked=False,
-        timeout=TIMEOUT,
+        timeout=DEPLOYMENT_TIMEOUT,
     )
 
     await ops_test.model.integrate(

--- a/tests/integration/sharding_tests/test_sharding_tls.py
+++ b/tests/integration/sharding_tests/test_sharding_tls.py
@@ -6,7 +6,11 @@
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import destroy_cluster, wait_for_mongodb_units_blocked
+from ..helpers import (
+    DEPLOYMENT_TIMEOUT,
+    destroy_cluster,
+    wait_for_mongodb_units_blocked,
+)
 from ..tls_tests import helpers as tls_helpers
 from .helpers import deploy_cluster_components, integrate_cluster
 
@@ -38,7 +42,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         apps=[CERTS_APP_NAME, CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME],
         idle_period=20,
         raise_on_blocked=False,
-        timeout=TIMEOUT,
+        timeout=DEPLOYMENT_TIMEOUT,
         raise_on_error=False,
     )
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,6 +25,7 @@ from .ha_tests.helpers import (
     stop_continous_writes,
 )
 from .helpers import (
+    DEPLOYMENT_TIMEOUT,
     PORT,
     UNIT_IDS,
     audit_log_line_sanity_check,
@@ -61,7 +62,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
 
     my_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(my_charm, num_units=len(UNIT_IDS))
-    await ops_test.model.wait_for_idle()
+    await ops_test.model.wait_for_idle(timeout=DEPLOYMENT_TIMEOUT)
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])

--- a/tests/integration/tls_tests/test_tls.py
+++ b/tests/integration/tls_tests/test_tls.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import UNIT_IDS, check_or_scale_app, get_app_name
+from ..helpers import DEPLOYMENT_TIMEOUT, UNIT_IDS, check_or_scale_app, get_app_name
 from .helpers import (
     EXTERNAL_CERT_PATH,
     INTERNAL_CERT_PATH,
@@ -47,12 +47,14 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
         async with ops_test.fast_forward():
             my_charm = await ops_test.build_charm(".")
             await ops_test.model.deploy(my_charm, num_units=3)
-            await ops_test.model.wait_for_idle(apps=[app_name], status="active")
+            await ops_test.model.wait_for_idle(
+                apps=[app_name], status="active", timeout=DEPLOYMENT_TIMEOUT
+            )
 
     config = {"ca-common-name": "Test CA"}
     await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config)
     await ops_test.model.wait_for_idle(
-        apps=[TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
+        apps=[TLS_CERTIFICATES_APP_NAME], status="active", timeout=DEPLOYMENT_TIMEOUT
     )
 
 

--- a/tests/integration/upgrade/test_sharding_rollback.py
+++ b/tests/integration/upgrade/test_sharding_rollback.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import find_unit, wait_for_mongodb_units_blocked
+from ..helpers import DEPLOYMENT_TIMEOUT, find_unit, wait_for_mongodb_units_blocked
 from ..sharding_tests.helpers import deploy_cluster_components, integrate_cluster
 from ..sharding_tests.writes_helpers import (
     SHARD_ONE_DB_NAME,
@@ -26,7 +26,6 @@ SHARD_COMPONENTS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME]
 CLUSTER_COMPONENTS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME, CONFIG_SERVER_APP_NAME]
 SHARD_REL_NAME = "sharding"
 CONFIG_SERVER_REL_NAME = "config-server"
-TIMEOUT = 15 * 60
 MEDIAN_REELECTION_TIME = 12
 
 
@@ -43,11 +42,17 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await deploy_cluster_components(ops_test, num_units_cluster_config, channel="6/edge")
 
     await ops_test.model.wait_for_idle(
-        apps=CLUSTER_COMPONENTS, idle_period=20, timeout=TIMEOUT, raise_on_blocked=False
+        apps=CLUSTER_COMPONENTS,
+        idle_period=20,
+        timeout=DEPLOYMENT_TIMEOUT,
+        raise_on_blocked=False,
     )
     await integrate_cluster(ops_test)
     await ops_test.model.wait_for_idle(
-        apps=CLUSTER_COMPONENTS, status="active", idle_period=20, timeout=TIMEOUT
+        apps=CLUSTER_COMPONENTS,
+        status="active",
+        idle_period=20,
+        timeout=DEPLOYMENT_TIMEOUT,
     )
 
 

--- a/tests/integration/upgrade/test_sharding_upgrade.py
+++ b/tests/integration/upgrade/test_sharding_upgrade.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from ..ha_tests import helpers as ha_helpers
-from ..helpers import find_unit, unit_hostname
+from ..helpers import DEPLOYMENT_TIMEOUT, find_unit, unit_hostname
 from ..sharding_tests.helpers import (
     deploy_cluster_components,
     generate_mongodb_client,
@@ -34,7 +34,6 @@ SHARD_COMPONENTS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME]
 CLUSTER_COMPONENTS = [SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME, CONFIG_SERVER_APP_NAME]
 SHARD_REL_NAME = "sharding"
 CONFIG_SERVER_REL_NAME = "config-server"
-TIMEOUT = 15 * 60
 MEDIAN_REELECTION_TIME = 12
 
 
@@ -51,11 +50,17 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await deploy_cluster_components(ops_test, num_units_cluster_config, channel="6/edge")
 
     await ops_test.model.wait_for_idle(
-        apps=CLUSTER_COMPONENTS, idle_period=20, timeout=TIMEOUT, raise_on_blocked=False
+        apps=CLUSTER_COMPONENTS,
+        idle_period=20,
+        timeout=DEPLOYMENT_TIMEOUT,
+        raise_on_blocked=False,
     )
     await integrate_cluster(ops_test)
     await ops_test.model.wait_for_idle(
-        apps=CLUSTER_COMPONENTS, status="active", idle_period=20, timeout=TIMEOUT
+        apps=CLUSTER_COMPONENTS,
+        status="active",
+        idle_period=20,
+        timeout=DEPLOYMENT_TIMEOUT,
     )
 
 
@@ -152,7 +157,6 @@ async def test_pre_upgrade_check_failure(ops_test: OpsTest) -> None:
             apps=CLUSTER_COMPONENTS,
             idle_period=20,
             status="active",
-            timeout=TIMEOUT,
             raise_on_blocked=False,
         )
 

--- a/tests/integration/upgrade/test_upgrade.py
+++ b/tests/integration/upgrade/test_upgrade.py
@@ -8,7 +8,13 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from ..ha_tests import helpers as ha_helpers
-from ..helpers import check_or_scale_app, find_unit, get_app_name, unit_hostname
+from ..helpers import (
+    DEPLOYMENT_TIMEOUT,
+    check_or_scale_app,
+    find_unit,
+    get_app_name,
+    unit_hostname,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +45,7 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await ops_test.model.deploy(MONGODB_CHARM_NAME, channel="6/edge", num_units=3)
 
     await ops_test.model.wait_for_idle(
-        apps=["mongodb"], status="active", timeout=1000, idle_period=120
+        apps=["mongodb"], status="active", timeout=DEPLOYMENT_TIMEOUT, idle_period=120
     )
 
 


### PR DESCRIPTION
## Issue
1. HA tests scaling by too many units puts consistent strain on the system:
> During my sabatical [this JIRA ticket](https://warthogs.atlassian.net/browse/DPE-2078) was completed, which involves scaling the replica set by 7/-7. [This consistently fails our tests timing out waiting for units to scale.](https://github.com/canonical/mongodb-operator/actions/runs/12325580784/job/34405404938).
It is necessary to scale the replica set for these tests I would keep with the original JIRA ticket which is "for more than 2 units" but not scale by more than 5 units at a time

2. Too short of a time out
3. 3.6 Juju has issues with secret retrieval in install



## Solution
1. update scaling to be no more than 5 units at a time
2. increase timeout to be higher as it is for other charms. There doesn't seem to be an agreed upon time limit here so 2000 was used
3. [currently being discussed](https://matrix.to/#/!xzmWHtGpPfVCXKivIh:ubuntu.com/$D8aw9mvEuuEOn4MfV5ZDllJVD-nnXppvCFAFmRDiFSg?via=ubuntu.com&via=matrix.org&via=canonical.com)