### PR TITLE
[DPE-6543] add workflow for TIOBE

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    - self-hosted
+    - linux
+    - amd64
+    - tiobe
+    - jammy

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -18,7 +18,7 @@ jobs:
         run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
 
       - name: Add pipx to PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
 
       - name: Install tox and poetry using pipx
         run: |

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -12,6 +12,23 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3.10-venv
+
+      - name: Install pipx
+        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
+
+      - name: Add pipx to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tox and poetry using pipx
+        run: |
+          pipx install tox
+          pipx install poetry
+
+      - name: Run tox tests to create coverage.xml
+        run: tox run -e unit
+
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@v3
         with:

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -15,7 +15,7 @@ jobs:
         uses: tiobe/tics-github-action@v3
         with:
           mode: qserver
-          project: testimage
+          project: mongodb-operator
           branchdir: .
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -2,7 +2,6 @@ name: TICS run self-hosted test (github-action)
 
 on:
   workflow_dispatch: # Allows manual triggering
-  push:
 
 jobs:
   build:
@@ -12,18 +11,25 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3.10-venv
+
+      - name: Install pipx
+        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
+
+      - name: Add pipx to PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install tox and poetry using pipx
         run: |
-          sudo apt-get update && sudo apt-get install -y python3.10-venv
-          python3 -m pip install --user pipx && python3 -m pipx ensurepath
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           pipx install tox
           pipx install poetry
 
-      - name: Generate coverage.xml for TICS
+      - name: Run tox tests to create coverage.xml
+        run: tox run -e unit
+
+      - name: move results to necessary folder for TICS
         run: |
-          tox run -e unit
-          # move results to folder for TICS
           mkdir .cover
           mv coverage.xml .cover/coverage.xml
 

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Run tox tests to create coverage.xml
         run: tox run -e unit
 
+      - name: move results to necessary folder for TICS
+        run: |
+          mkdir .cover
+          mv coverage.xml .cover/coverage.xml
+
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@v3
         with:

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -2,6 +2,7 @@ name: TICS run self-hosted test (github-action)
 
 on:
   workflow_dispatch: # Allows manual triggering
+  push:
 
 jobs:
   build:

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -12,25 +12,18 @@ jobs:
       - name: Checkout the project
         uses: actions/checkout@v4
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y python3.10-venv
-
-      - name: Install pipx
-        run: python3 -m pip install --user pipx && python3 -m pipx ensurepath
-
-      - name: Add pipx to PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install tox and poetry using pipx
+      - name: Install dependencies
         run: |
+          sudo apt-get update && sudo apt-get install -y python3.10-venv
+          python3 -m pip install --user pipx && python3 -m pipx ensurepath
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           pipx install tox
           pipx install poetry
 
-      - name: Run tox tests to create coverage.xml
-        run: tox run -e unit
-
-      - name: move results to necessary folder for TICS
+      - name: Generate coverage.xml for TICS
         run: |
+          tox run -e unit
+          # move results to folder for TICS
           mkdir .cover
           mv coverage.xml .cover/coverage.xml
 

--- a/.github/workflows/tics_run_sh_ghaction_test.yml
+++ b/.github/workflows/tics_run_sh_ghaction_test.yml
@@ -1,0 +1,22 @@
+name: TICS run self-hosted test (github-action)
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: testimage
+          branchdir: .
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true


### PR DESCRIPTION
## Issue
We need the ability to run TIOBE workflow on the charm

## Solution
Add the workflow to our charm. [Based on the example provided by TIOBE](https://github.com/canonical/ticsimg/blob/main/.github/workflows/tics_run_sh_ghaction_test.yml_)

We leverage the Canonical org level secret for TICSAUTHTOKEN for this workflow as specified by the TIOBE instructions. 