### PR TITLE
patch: migrate from action-based password management to config-option-based passwords

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -4,28 +4,6 @@
 get-primary:
   description: Report primary replica
 
-get-password:
-  description:
-    Fetch the password of the provided internal user of the charm, used for internal charm operations.
-    It is for internal charm users only, and SHOULD NOT be used by applications.
-  params:
-    username:
-      type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, backup, monitor.
-
-set-password:
-  description: Change the admin user's password, which is used by charm.
-    It is for internal charm users and SHOULD NOT be used by applications.
-  params:
-    username:
-      type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, backup, monitor.
-    password:
-      type: string
-      description: The password will be auto-generated if this option is not specified.
-
 create-backup:
   description: Create a database backup.
     S3 credentials are retrieved from a relation with the S3 integrator charm.

--- a/config.yaml
+++ b/config.yaml
@@ -26,3 +26,12 @@ options:
       `{PROVIDED_USER}` should be used only if no ldapUserToDNMapping is provided.
       If this configuration is not provided, a default string will be computed based on the base_dn returned by the GLAuth k8s charm.
       Example: dc=example,dc=com??sub?(&(objectClass=groupOfNames)(member={USER}))
+  system-users:
+    type: secret
+    description: |
+      Configure the internal system users and their passwords. The passwords will
+      be auto-generated if this option is not set. It is for internal use only
+      and SHOULD NOT be used by applications. This must be a Juju Secret URI pointing
+      to a secret that contains a map with the following content: `<username>: <password>`.
+      Possible users: `backup`, `logrorate`, `monitor`, `operator`.
+      This option is only compatible with `replication` and `config-server` roles.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1531,14 +1531,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.7.2"
+version = "1.7.3"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-1.7.2-py3-none-any.whl", hash = "sha256:f1ae5de40afbba43a3caa1ed26c616672b5f81be974eb3f8d9da5eae6e6c5b33"},
-    {file = "mongo_charms_single_kernel-1.7.2.tar.gz", hash = "sha256:ddf7dddc0d8e33794dcbe199e4dab1d710b765ba852343e80e464896308cf94b"},
+    {file = "mongo_charms_single_kernel-1.7.3-py3-none-any.whl", hash = "sha256:f246201cafd185de73612ecbd624b0bb8a983c905236f05237dc4889270dc49e"},
+    {file = "mongo_charms_single_kernel-1.7.3.tar.gz", hash = "sha256:208ac2180ec78f746b04253890a0da89e58944d4e0ed0d14c19272b77d76e0be"},
 ]
 
 [package.dependencies]
@@ -3128,4 +3128,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.12"
-content-hash = "61d1903e2dbf2bbba0e6adc892bcecc028839164c32767d3b75ba4684b2dd976"
+content-hash = "0a5477091d2b21449163a9def522f66c6d81eb61eb54f2342a3e32a848e07dd7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.10.12"
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 ops = ">=2.21.0"
 overrides = "^7.7.0"
 pymongo = "^4.7.3"
@@ -48,7 +48,7 @@ black = "^24.4.2"
 isort = "^5.13.2"
 
 [tool.poetry.group.unit.dependencies]
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 pytest-mock = "*"
@@ -57,7 +57,7 @@ pymongo = "^4.7.3"
 juju = "~3.6.0"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -261,7 +261,7 @@ async def mongodb_uri(
     hosts = [f"{host}:{port}" for host in addresses]
     hosts = ",".join(hosts)
 
-    password = await get_password(ops_test, 0, username=username, app_name=app_name)
+    password = await get_password(ops_test, username=username, app_name=app_name)
 
     return f"mongodb://{username}:{password}@{hosts}/admin"
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -17,6 +17,10 @@ APP_NAME = "mongodb"
 logger = logging.getLogger(__name__)
 
 
+class SecretNotFoundError(Exception):
+    """Raised when a secret is not found."""
+
+
 class Status:
     """Model class for status."""
 
@@ -219,22 +223,28 @@ async def get_direct_mongo_client(
     assert False, "No fitting unit could be found"
 
 
-async def get_password(
-    ops_test: OpsTest,
-    unit_id: int = 0,
-    username: str = "operator",
-    app_name: str = APP_NAME,
-) -> str:
-    """Use the charm action to retrieve the password from provided unit.
+async def get_password(ops_test: OpsTest, username: str, app_name: str) -> str:
+    """Retrieve the password for a given user from the application's Juju secret."""
+    secret = await get_secret_by_label(ops_test, label=f"{app_name}.app")
+    return secret.get(f"{username}-password")
 
-    Returns:
-        String with the password stored on the peer relation databag.
-    """
-    action = await ops_test.model.units.get(f"{app_name}/{unit_id}").run_action(
-        "get-password", **{"username": username}
-    )
-    action = await action.wait()
-    return action.results["password"]
+
+async def get_secret_by_label(ops_test: OpsTest, label: str) -> dict[str, str]:
+    secrets_raw = await ops_test.juju("list-secrets")
+    secret_ids = [
+        secret_line.split()[0] for secret_line in secrets_raw[1].split("\n")[1:] if secret_line
+    ]
+
+    for secret_id in secret_ids:
+        secret_data_raw = await ops_test.juju(
+            "show-secret", "--format", "json", "--reveal", secret_id
+        )
+        secret_data = json.loads(secret_data_raw[1])
+
+        if label == secret_data[secret_id].get("label"):
+            return secret_data[secret_id]["content"]["Data"]
+
+    raise SecretNotFoundError(f"Secret with label {label} not found.")
 
 
 async def mongodb_uri(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
-from ops.testing import ActionFailed, Harness
+from ops.testing import Harness
 from parameterized import parameterized
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
 from single_kernel_mongo.config.literals import OS_REQUIREMENTS, Scope
@@ -18,11 +18,7 @@ from single_kernel_mongo.exceptions import (
     WorkloadServiceError,
 )
 from single_kernel_mongo.utils.mongo_connection import NotReadyError
-from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
-    MonitorUser,
-    OperatorUser,
-)
+from single_kernel_mongo.utils.mongodb_users import MonitorUser
 
 from charm import MongoDBVMCharm
 
@@ -447,12 +443,12 @@ class TestCharm(unittest.TestCase):
     @pytest.mark.usefixtures("mock_fs_interactions")
     @parameterized.expand(
         [
-            ({}, WaitingStatus("Member being added...")),
-            ({"10.0.0.10": "REMOVED"}, WaitingStatus("Member is removing...")),
-            ({"10.0.0.10": "STARTUP"}, WaitingStatus("Member is syncing...")),
-            ({"10.0.0.10": "STARTUP2"}, WaitingStatus("Member is syncing...")),
-            ({"10.0.0.10": "ROLLBACK"}, WaitingStatus("Member is syncing...")),
-            ({"10.0.0.10": "RECOVERING"}, WaitingStatus("Member is syncing...")),
+            ({}, MaintenanceStatus("Adding member...")),
+            ({"10.0.0.10": "REMOVED"}, MaintenanceStatus("Removing member...")),
+            ({"10.0.0.10": "STARTUP"}, MaintenanceStatus("Syncing member...")),
+            ({"10.0.0.10": "STARTUP2"}, MaintenanceStatus("Syncing member...")),
+            ({"10.0.0.10": "ROLLBACK"}, MaintenanceStatus("Syncing member...")),
+            ({"10.0.0.10": "RECOVERING"}, MaintenanceStatus("Syncing member...")),
             ({"10.0.0.10": "unknown"}, BlockedStatus("unknown")),
         ]
     )
@@ -577,36 +573,23 @@ class TestCharm(unittest.TestCase):
         """Tests that a new admin password is generated and is returned to the user."""
         self.harness.set_leader(True)
         pbm_status.return_value = [StatusObject(status="active", message="pbm")]
-        original_password = self.harness.charm.operator.state.secrets.get_for_key(
-            Scope.APP, "operator-password"
+        system_users = {"operator": "canonical123"}
+        secret_id = self.harness.add_model_secret("mongodb", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
         )
-        self.harness.run_action("set-password")
         new_password = self.harness.charm.operator.state.secrets.get_for_key(
             Scope.APP, "operator-password"
         )
 
-        # verify app data is updated and results are reported to user
-        self.assertNotEqual(original_password, new_password)
-
-    @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
-    @patch("single_kernel_mongo.managers.backups.BackupManager.get_statuses")
-    def test_set_password_provided(self, pbm_status, *unused):
-        """Tests that a given password is set as the new mongodb password."""
-        self.harness.set_leader(True)
-        pbm_status.return_value = [StatusObject(status="active", message="pbm")]
-        output = self.harness.run_action("set-password", {"password": "canonical123"})
-        new_password = self.harness.charm.operator.state.secrets.get_for_key(
-            Scope.APP, "operator-password"
-        )
-
-        # verify app data is updated and results are reported to user
         self.assertEqual("canonical123", new_password)
-        assert output.results["password"] == "canonical123"
-        assert output.results["secret-id"]
 
+    @patch("ops.framework.EventBase.defer")
     @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
     @patch("single_kernel_mongo.managers.backups.BackupManager.get_statuses")
-    def test_set_password_failure(self, pbm_status, set_user_password):
+    def test_set_password_failure(self, pbm_status, set_user_password, event_defer):
         """Tests failure to reset password does not update app data and failure is reported."""
         self.harness.set_leader(True)
         pbm_status.return_value = [StatusObject(status="active", message="pbm")]
@@ -614,10 +597,17 @@ class TestCharm(unittest.TestCase):
             Scope.APP, "operator-password"
         )
 
+        system_users = {"operator": "canonical123"}
+        secret_id = self.harness.add_model_secret("mongodb", system_users)
+
         for exception in [PYMONGO_EXCEPTIONS, NotReadyError]:
             set_user_password.side_effect = exception
-            with pytest.raises(ActionFailed):
-                self.harness.run_action("set-password")
+            self.harness.update_config(
+                {
+                    "system-users": f"{secret_id}",
+                }
+            )
+            event_defer.assert_called()
             current_password = self.harness.charm.operator.state.secrets.get_for_key(
                 Scope.APP, "operator-password"
             )
@@ -709,6 +699,7 @@ class TestCharm(unittest.TestCase):
         """NOTE: currently ops.testing seems to allow for non-leader to set secrets too!"""
         secret = self.harness.charm.operator.state.secrets.set("new-secret", "bla", scope)
         secret = self.harness.charm.model.get_secret(label=secret.label)
+        self.harness.set_leader(False)
 
         self.harness.charm.on.secret_changed.emit(label=secret.label, id=secret.id)
         connect_exporter.assert_called()
@@ -724,6 +715,7 @@ class TestCharm(unittest.TestCase):
         # "Hack": creating a secret outside of the normal MongodbOperatorCharm.set_secret workflow
         scope_obj = self.harness.charm.app if scope == Scope.APP else self.harness.charm.unit
         secret = scope_obj.add_secret({"key": "value"})
+        self.harness.set_leader(False)
 
         with self._caplog.at_level(logging.DEBUG):
             self.harness.charm.on.secret_changed.emit(label=secret.label, id=secret.id)
@@ -741,7 +733,15 @@ class TestCharm(unittest.TestCase):
         """Test _connect_mongodb_exporter is called when the password is set for 'monitor' user."""
         self.harness.set_leader(True)
 
-        self.harness.run_action("set-password", {"username": "monitor"})
+        system_users = {
+            "monitor": "abc",
+        }
+        secret_id = self.harness.add_model_secret("mongodb", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
         connect_exporter.assert_called()
 
     @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
@@ -757,47 +757,38 @@ class TestCharm(unittest.TestCase):
         """
         self.harness.set_leader(True)
 
-        # Getting current password
-        params = {"username": "monitor"}
-        output = self.harness.run_action("set-password", params)
-        assert output.results["password"]
-        pw1 = output.results["password"]
+        system_users = {
+            "monitor": "abc",
+        }
+        secret_id = self.harness.add_model_secret("mongodb", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
 
         connect_exporter.assert_called()
 
-        # New password was generated
-        params = {"username": "monitor"}
-        output = self.harness.run_action("set-password", params)
-        assert output.results["password"]
-        pw2 = output.results["password"]
-
-        # a new password was created
-        assert pw1 != pw2
-
-    @patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
-    @patch(
-        "single_kernel_mongo.managers.config.MongoDBExporterConfigManager.configure_and_restart"
-    )
-    def test_event_any_unit_can_get_password_secrets(self, connect_exporter, set_user_password):
-        """Test that a non leader unit can get the password."""
-        self._setup_secrets()
-
-        # Getting current password
-        output = self.harness.run_action("get-password", {"username": "monitor"})
-        assert output.results["password"]
-
+    @patch("ops.framework.EventBase.defer")
     @patch("single_kernel_mongo.managers.backups.BackupManager.get_statuses")
-    def test_set_backup_password_pbm_busy(self, pbm_status):
+    def test_set_backup_password_pbm_busy(self, pbm_status, event_defer):
         """Tests changes to passwords fail when pbm is restoring/backing up."""
         self.harness.set_leader(True)
 
         pbm_status.return_value = [StatusObject(status="maintenance", message="pbm")]
-        for user in [BackupUser, MonitorUser, OperatorUser]:
-            original_password = self.harness.charm.operator.state.get_user_password(user)
-            with pytest.raises(ActionFailed):
-                self.harness.run_action("set-password", {"username": user.username})
-            current_password = self.harness.charm.operator.state.get_user_password(user)
-            self.assertEqual(current_password, original_password)
+        system_users = {
+            "operator": "123",
+            "monitor": "abc",
+            "logrotate": "something",
+            "backup": "123abc",
+        }
+        secret_id = self.harness.add_model_secret("mongodb", system_users)
+        self.harness.update_config(
+            {
+                "system-users": f"{secret_id}",
+            }
+        )
+        event_defer.assert_called()
 
     def test_unit_host(self):
         """Tests that get hosts returns the current unit hosts."""

--- a/tests/unit/test_mongodb_backups.py
+++ b/tests/unit/test_mongodb_backups.py
@@ -55,7 +55,7 @@ class TestMongoBackups(unittest.TestCase):
             scope=Scope.UNIT, component="backup"
         ).root
 
-        assert MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value in statuses
+        assert MongoDBStatuses.INVALID_S3_REL.value in statuses
 
     def test_credentials_changed_to_blocked_if_shard(self):
         def is_shard_mock_call(role_name: str):
@@ -72,7 +72,7 @@ class TestMongoBackups(unittest.TestCase):
             scope=Scope.UNIT, component="backup"
         ).root
 
-        assert MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value in statuses
+        assert MongoDBStatuses.INVALID_S3_REL.value in statuses
 
     @patch("single_kernel_mongo.managers.backups.BackupManager.create_bucket")
     @patch(

--- a/tests/unit/test_mongodb_provider.py
+++ b/tests/unit/test_mongodb_provider.py
@@ -54,7 +54,7 @@ class TestMongoProvider(unittest.TestCase):
         statuses = self.harness.charm.operator.state.statuses.get(scope="unit", component="mongod")
         status = next(iter(statuses), None)
         assert as_status(status) == BlockedStatus(
-            "Sharding roles do not support database interface."
+            "The database relation cannot be used by sharding components (shards or config servers)."
         )
         oversee_users.assert_not_called()
 


### PR DESCRIPTION
This PR propagate the changes in https://github.com/canonical/mongo-single-kernel-library/pull/88 to the mongodb-operator.

Now the internal user passwords will be managed with a config option (system-users) instead of using actions.
