### PR TITLE
chore: update single-kernel to v1.8.16

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1550,14 +1550,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.15"
+version = "1.8.16"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.15-py3-none-any.whl", hash = "sha256:15eb8389c79c215ef1229f8048508339810d6ab0d467675a2a9cbb47fb2ba3e7"},
-    {file = "mongo_charms_single_kernel-1.8.15.tar.gz", hash = "sha256:ad0be0ea257de0cc45ea07b1ea060430c3a810847d7272bff90f025794ad6b14"},
+    {file = "mongo_charms_single_kernel-1.8.16-py3-none-any.whl", hash = "sha256:38f9bee829e71481191cb5b92f0cc96fe0fa0ceb449b40ab2f04a4cd0bd31068"},
+    {file = "mongo_charms_single_kernel-1.8.16.tar.gz", hash = "sha256:01c1f3d4ba60588e56370416370b029b7208cb7965836af72a942a1e3cf03610"},
 ]
 
 [package.dependencies]
@@ -3217,4 +3217,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12.0"
-content-hash = "655d967e42f13175b77359b561fb2a6564f8cb7ee041c8ea451366ea92148c9b"
+content-hash = "e87d49689b520c091911f9dc855df3450b525510a1a434ae000f4284f89458d0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-poetry = ">=2.0.0"
 
 [tool.poetry.dependencies]
 python = "^3.12.0"
-mongo-charms-single-kernel = "1.8.15"
+mongo-charms-single-kernel = "1.8.16"
 ops = ">=2.21.0"
 overrides = "^7.7.0"
 pymongo = "^4.7.3"
@@ -52,7 +52,7 @@ black = "^24.4.2"
 isort = "^5.13.2"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.8.15"
+mongo-charms-single-kernel = "1.8.16"
 allure-pytest = "^2.13.5"
 ops = ">=2.21"
 pymongo = "^4.7.3"


### PR DESCRIPTION
## Issue
addresses https://github.com/canonical/mongodb-operator/issues/595

## Solution
update `mongo-charms-single-kernel` to v1.8.16