### PR TITLE
patch: Bump mongo-charms-single-kernel to version v1.8.19

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -77,7 +77,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/poetry.lock
+++ b/poetry.lock
@@ -1549,14 +1549,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.18"
+version = "1.8.19"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.18-py3-none-any.whl", hash = "sha256:54187acd4fe2b2d9402a0f26fb89f7a0455396590285a2e7151fc79d43530c0e"},
-    {file = "mongo_charms_single_kernel-1.8.18.tar.gz", hash = "sha256:2ace3e23ce8bc559b10e5db11d7d60bba952ddc686221c2d89772384c5e6795a"},
+    {file = "mongo_charms_single_kernel-1.8.19-py3-none-any.whl", hash = "sha256:6930c0efc6032aef107f0c61031f2b5670e37f270187be54749af389cdf0553f"},
+    {file = "mongo_charms_single_kernel-1.8.19.tar.gz", hash = "sha256:ed67da0d7ebfb69c90a0d815ef08fd0f67b3d9a3a29a376e39ae115a0de2ad2e"},
 ]
 
 [package.dependencies]
@@ -3201,4 +3201,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12.0"
-content-hash = "1c7e2091e2ade0102686be3696556e89ff12af63128c6144c8a5c77c217bd96f"
+content-hash = "512284fc921e1f1c837d40edc89bf4d649a191bd5bcc028c10b604436bcb9a35"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ rpds-py = "0.18.0"
 pyOpenSSL = "^24.2.1"
 charm-refresh = "^3.1.0.3"
 lightkube = "^0.15.3"
-mongo-charms-single-kernel = "v1.8.18"
+mongo-charms-single-kernel = "v1.8.19"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -66,7 +66,7 @@ pytest-operator = "^0.36.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/github_secrets"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
-mongo-charms-single-kernel = "v1.8.18"
+mongo-charms-single-kernel = "v1.8.19"
 
 [tool.poetry.group.build-refresh-version]
 optional = true


### PR DESCRIPTION
Includes:
- patch: fix permissions in tmp storage https://github.com/canonical/mongo-single-kernel-library/pull/157
