### PR TITLE
patch: Bump mongo-charms-single-kernel to version v1.8.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1549,14 +1549,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.19"
+version = "1.8.22"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.19-py3-none-any.whl", hash = "sha256:6930c0efc6032aef107f0c61031f2b5670e37f270187be54749af389cdf0553f"},
-    {file = "mongo_charms_single_kernel-1.8.19.tar.gz", hash = "sha256:ed67da0d7ebfb69c90a0d815ef08fd0f67b3d9a3a29a376e39ae115a0de2ad2e"},
+    {file = "mongo_charms_single_kernel-1.8.22-py3-none-any.whl", hash = "sha256:3d2e381dead393496c9489775afcf37ab63e917916c0a204bac01b47b47c0523"},
+    {file = "mongo_charms_single_kernel-1.8.22.tar.gz", hash = "sha256:d1d05842dd69b9e96e6fa58405b5e39e72a7faf82baac38ab3143bbb8732e3bb"},
 ]
 
 [package.dependencies]
@@ -3201,4 +3201,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12.0"
-content-hash = "512284fc921e1f1c837d40edc89bf4d649a191bd5bcc028c10b604436bcb9a35"
+content-hash = "eedec1377d4684a0c9d4e59512676fea89bb9ebfbfd87647bda54bcae6dbe2ba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ rpds-py = "0.18.0"
 pyOpenSSL = "^24.2.1"
 charm-refresh = "^3.1.0.3"
 lightkube = "^0.15.3"
-mongo-charms-single-kernel = "v1.8.19"
+mongo-charms-single-kernel = "v1.8.22"
 
 [tool.poetry.group.charm-libs.dependencies]
 ops = ">=2.21"
@@ -66,7 +66,7 @@ pytest-operator = "^0.36.0"
 pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
 pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/github_secrets"}
 allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
-mongo-charms-single-kernel = "v1.8.19"
+mongo-charms-single-kernel = "v1.8.22"
 
 [tool.poetry.group.build-refresh-version]
 optional = true


### PR DESCRIPTION
Automated bump of mongo-charms-single-kernel to version v1.8.22 after PyPI release.

Includes:

- patch: add scheduler for TICS workflow in 6/edge by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/178
- patch: add workflow dispatch for bump library in charm repos workflow by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/167
- patch: validate private key matches certificate and config by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/177