### PR TITLE
feat: upgrade CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v35.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.1.0
     permissions:
       contents: read
 
@@ -132,10 +132,11 @@ jobs:
         path:
           - .
     name: Build charm | ${{ matrix.path }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v35.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v42.1.0
     with:
       path-to-charm-directory: ${{ matrix.path }}
       cache: true
+      charmcraft-snap-revisions: '{"amd64": "7517", "arm64": "7519"}'
     permissions:
       contents: read
 
@@ -144,11 +145,9 @@ jobs:
     needs:
       - lint
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/integration_test_charm.yaml@v35.0.4
+    uses: ./.github/workflows/integration_test.yaml
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
-      cloud: lxd
-      juju-snap-channel: 3.6/stable
-      _beta_allure_report: true
+    secrets: inherit
     permissions:
-      contents: write # Needed for Allure Report beta
+      contents: read

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,151 @@
+on:
+  workflow_call:
+    inputs:
+      artifact-prefix:
+        description: |
+          Prefix for charm package GitHub artifact(s)
+
+          Use canonical/data-platform-workflows build_charm.yaml to build the charm(s)
+        required: true
+        type: string
+
+jobs:
+  collect-integration-tests:
+    name: Collect integration test spread jobs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up environment
+        run: |
+          sudo snap install go --classic
+          go install github.com/canonical/spread/cmd/spread@latest
+          pipx install tox poetry
+      - name: Collect spread jobs
+        id: collect-jobs
+        shell: python
+        run: |
+          import json
+          import pathlib
+          import os
+          import subprocess
+
+          spread_jobs = (
+              subprocess.run(
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
+              )
+              .stdout.strip()
+              .split("\n")
+          )
+          jobs = []
+          for job in spread_jobs:
+              # Example `job`: "github-ci:ubuntu-24.04:tests/spread/test_charm.py:juju36"
+              # no variant in mongodb for now
+              # _, runner, task, variant = job.split(":")
+              _, runner, task = job.split(":")
+              # Example: "test_charm.py"
+              task = task.removeprefix("tests/spread/")
+              # For IS-hosted runners
+              if "arm64" in runner:
+                  architecture = "arm64"
+              else:
+                  architecture = "amd64"
+              # Example: "test_charm.py:juju36 | amd64"
+              name = f"{task} | {architecture}"
+              # ":" character not valid in GitHub Actions artifact
+              name_in_artifact = f"{task.replace('/', '-')}-{architecture}"
+              jobs.append({
+                  "spread_job": job,
+                  "name": name,
+                  "name_in_artifact": name_in_artifact,
+                  "runner": runner,
+              })
+          output = f"jobs={json.dumps(jobs)}"
+          print(output)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as file:
+              file.write(output)
+    outputs:
+      jobs: ${{ steps.collect-jobs.outputs.jobs }}
+
+  integration-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        job: ${{ fromJSON(needs.collect-integration-tests.outputs.jobs) }}
+    name: ${{ matrix.job.name }}
+    needs:
+      - collect-integration-tests
+    runs-on: ${{ matrix.job.runner }}
+    timeout-minutes: 217 # Sum of steps `timeout-minutes` + 5
+    permissions:
+      contents: read
+    steps:
+      - name: Disk usage
+        timeout-minutes: 1
+        run: df --human-readable
+      - name: Checkout
+        timeout-minutes: 3
+        uses: actions/checkout@v4
+      - name: Set up environment
+        timeout-minutes: 5
+        run: sudo snap install charmcraft --classic
+      # TODO: remove when https://github.com/canonical/charmcraft/issues/2105 and
+      # https://github.com/canonical/charmcraft/issues/2130 fixed
+      - run: |
+          sudo snap install go --classic
+          go install github.com/canonical/spread/cmd/spread@latest
+      - name: Download packed charm(s)
+        timeout-minutes: 5
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ${{ inputs.artifact-prefix }}-*
+          merge-multiple: true
+      - name: Run spread job
+        timeout-minutes: 60
+        id: spread
+        # TODO: replace with `charmcraft test` when
+        # https://github.com/canonical/charmcraft/issues/2105 and
+        # https://github.com/canonical/charmcraft/issues/2130 fixed
+        run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
+      - timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: snap list
+      - name: Select model
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        id: juju-switch
+        run: |
+          # sudo needed since spread runs scripts as root
+          # "testing" is default model created by concierge
+          sudo juju switch testing
+          mkdir ~/logs/
+      - name: juju status
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: sudo juju status --color --relations | tee ~/logs/juju-status.txt
+      - name: juju debug-log
+        timeout-minutes: 3
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: sudo juju debug-log --color --replay --no-tail | tee ~/logs/juju-debug-log.txt
+      - name: jhack tail
+        timeout-minutes: 3
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: sudo jhack tail --printer raw --replay --no-watch | tee ~/logs/jhack-tail.txt
+      - name: Upload logs
+        timeout-minutes: 5
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: logs-integration-test-${{ matrix.job.name_in_artifact }}
+          path: ~/logs/
+          if-no-files-found: error
+      - name: Disk usage
+        timeout-minutes: 1
+        if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
+        run: df --human-readable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tag:
     name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v35.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v42.1.0
     with:
       track: "8"
     permissions:
@@ -28,7 +28,7 @@ jobs:
     needs:
       - ci-tests
       - tag
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v35.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v42.1.0
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,31 @@
+rules:
+  # Allowlist trusted actions
+  forbidden-uses:
+    config:
+      # Actions in this list have remote code execution in our workflows. Even if the workflow has
+      # limited permissions, those can be escaped. See https://github.com/AdnaneKhan/Cacheract and
+      # "But Wait, There’s More" section of
+      # https://www.praetorian.com/blog/codeqleaked-public-secrets-exposure-leads-to-supply-chain-attack-on-github-codeql/
+      # In general, this list should be limited to organizations that we trust to have a baseline
+      # level of operational security. Avoid adding actions that could be replaced with a few lines
+      # of bash.
+      allow: # Get approval from your manager before adding actions to this list.
+        - canonical/*
+        - actions/*
+        - docker/login-action
+        - tiobe/tics-github-action
+  # Pinning actions to a commit SHA has a security tradeoff—pinned actions cannot be later
+  # compromised, but they also cannot be security patched.
+  # Above (in `forbidden-uses`), we restrict actions usage to organizations that we trust to have
+  # a baseline level of operational security.
+  # Our actions usage involves several long-term support branches and reusable workflows (which
+  # themselves use actions). For our threat model, we believe it is safer to limit actions usage to
+  # organizations we trust and immediately receive security patching across our many branches than
+  # it is to pin actions to a commit SHA.
+  unpinned-uses:
+    config:
+      policies:
+        canonical/*: ref-pin
+        actions/*: ref-pin
+        docker/login-action: ref-pin
+        tiobe/tics-github-action: ref-pin

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,13 @@
+juju:
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
+providers:
+  lxd:
+    enable: true
+    bootstrap: true
+host:
+  snaps:
+    jhack:
+      channel: latest/edge
+      connections:
+        - jhack:dot-local-share-juju snapd

--- a/poetry.lock
+++ b/poetry.lock
@@ -17,27 +17,6 @@ allure-python-commons = "2.15.3"
 pytest = ">=4.5.0"
 
 [[package]]
-name = "allure-pytest-collection-report"
-version = "0.1.0"
-description = ""
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = []
-develop = false
-
-[package.dependencies]
-allure-pytest = ">=2.13.5"
-pytest = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/canonical/data-platform-workflows"
-reference = "v35.0.4"
-resolved_reference = "a5b9f86aca2c006ccf44f0f425eb0ff01f0db205"
-subdirectory = "python/pytest_plugins/allure_pytest_collection_report"
-
-[[package]]
 name = "allure-python-commons"
 version = "2.15.3"
 description = "Contains the API for end users as well as helper functions and classes to build Allure adapters for Python test frameworks"
@@ -2541,23 +2520,6 @@ docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
 testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
-name = "pytest-github-secrets"
-version = "0.1.0"
-description = ""
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = []
-develop = false
-
-[package.source]
-type = "git"
-url = "https://github.com/canonical/data-platform-workflows"
-reference = "v35.0.4"
-resolved_reference = "a5b9f86aca2c006ccf44f0f425eb0ff01f0db205"
-subdirectory = "python/pytest_plugins/github_secrets"
-
-[[package]]
 name = "pytest-mock"
 version = "3.15.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -2594,26 +2556,6 @@ juju = "*"
 pytest = "*"
 pytest-asyncio = "<0.23"
 pyyaml = "*"
-
-[[package]]
-name = "pytest-operator-groups"
-version = "0.1.0"
-description = ""
-optional = false
-python-versions = ">=3.8"
-groups = ["integration"]
-files = []
-develop = false
-
-[package.dependencies]
-pytest = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/canonical/data-platform-workflows"
-reference = "v35.0.4"
-resolved_reference = "a5b9f86aca2c006ccf44f0f425eb0ff01f0db205"
-subdirectory = "python/pytest_plugins/pytest_operator_groups"
 
 [[package]]
 name = "python-dateutil"
@@ -3336,4 +3278,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12.0"
-content-hash = "e1b54f1d4912cb459f2aeedc6013f64874766e8edc802e9b03c9bbc2d2924072"
+content-hash = "17d505c0349860b821e46465c964d1ba154c79ec4ec3ee44b57a31f8387347f3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,6 @@ pytest = "^8.1.1"
 pytest-asyncio = "^0.21.1"
 pytest-mock = "^3.14.0"
 pytest-operator = "^0.36.0"
-pytest-operator-groups = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/pytest_operator_groups"}
-pytest-github-secrets = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/github_secrets"}
-allure-pytest-collection-report = {git = "https://github.com/canonical/data-platform-workflows", tag = "v35.0.4", subdirectory = "python/pytest_plugins/allure_pytest_collection_report"}
 mongo-charms-single-kernel = "1.8.35"
 
 [tool.poetry.group.build-refresh-version]

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,131 @@
+project: charmed-mongodb-operator
+
+backends:
+  # Derived from https://github.com/jnsgruk/zinc-k8s-operator/blob/a21eae8399eb3b9df4ddb934b837af25ef831976/spread.yaml#L11
+  lxd-vm:
+    # TODO: remove after https://github.com/canonical/spread/pull/185 merged & in charmcraft
+    type: adhoc
+    allocate: |
+      hash=$(python3 -c "import hashlib; print(hashlib.sha256('$SPREAD_PASSWORD'.encode()).hexdigest()[:6])")
+      VM_NAME="${VM_NAME:-${SPREAD_SYSTEM//./-}-${hash}}"
+      DISK="${DISK:-20}"
+      CPU="${CPU:-4}"
+      MEM="${MEM:-8}"
+
+      cloud_config="#cloud-config
+      ssh_pwauth: true
+      users:
+        - default
+        - name: runner
+          plain_text_passwd: $SPREAD_PASSWORD
+          lock_passwd: false
+          sudo: ALL=(ALL) NOPASSWD:ALL
+      "
+
+      lxc launch --vm \
+        "${SPREAD_SYSTEM//-/:}" \
+        "${VM_NAME}" \
+        -c user.user-data="${cloud_config}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+      # Wait for the runner user
+      while ! lxc exec "${VM_NAME}" -- id -u runner &>/dev/null; do sleep 0.5; done
+
+      # Set the instance address for spread
+      ADDRESS "$(lxc ls -f csv | grep "${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1)"
+    discard: |
+      hash=$(python3 -c "import hashlib; print(hashlib.sha256('$SPREAD_PASSWORD'.encode()).hexdigest()[:6])")
+      VM_NAME="${VM_NAME:-${SPREAD_SYSTEM//./-}-${hash}}"
+      lxc delete --force "${VM_NAME}"
+    environment:
+      CONCIERGE_EXTRA_SNAPS: charmcraft
+      CONCIERGE_EXTRA_DEBS: pipx
+    systems:
+      - ubuntu-24.04:
+          username: runner
+    prepare: |
+      systemctl disable --now unattended-upgrades.service
+      systemctl mask unattended-upgrades.service
+      pipx install charmcraftcache
+      cd "$SPREAD_PATH"
+      charmcraftcache pack -v
+    restore-each: |
+      cd "$SPREAD_PATH"
+      # Revert python-libjuju version override
+      git restore pyproject.toml poetry.lock
+
+      # Use instead of `concierge restore` to save time between tests
+      # For example, with microk8s, using `concierge restore` takes twice as long as this (e.g. 6
+      # min instead of 3 min between every spread job)
+      juju destroy-model --force --no-wait --destroy-storage --no-prompt testing
+      juju kill-controller --no-prompt concierge-lxd
+    restore: |
+      rm -rf "$SPREAD_PATH"
+
+  github-ci:
+    type: adhoc
+    # Only run on CI
+    manual: true
+    # HACK: spread requires runners to be accessible via SSH
+    # Configure local sshd & instruct spread to connect to the same machine spread is running on
+    # (spread cannot provision GitHub Actions runners, so we provision a GitHub Actions runner for
+    # each spread job & select a single job when running spread)
+    # Derived from https://github.com/jnsgruk/zinc-k8s-operator/blob/a21eae8399eb3b9df4ddb934b837af25ef831976/spread.yaml#L47
+    allocate: |
+      sudo tee /etc/ssh/sshd_config.d/10-spread-github-ci.conf << 'EOF'
+      PasswordAuthentication yes
+      PermitEmptyPasswords yes
+      EOF
+
+      sudo systemctl daemon-reload
+      sudo systemctl start ssh
+
+      # Needed for IS-hosted runners
+      sudo passwd --delete ubuntu
+
+      ADDRESS localhost
+    # HACK: spread does not pass environment variables set on runner
+    # Manually pass specific environment variables
+    environment:
+      CI: "$(HOST: echo $CI)"
+      CHARM_UBUNTU_BASE: "$(HOST: echo $CHARM_UBUNTU_BASE)"
+      # To install pipx on self-hosted runners
+      CONCIERGE_EXTRA_DEBS: pipx,build-essential,python3-dev,libldap-dev,libsasl2-dev
+    systems:
+      - self-hosted-linux-amd64-noble-medium:
+          username: ubuntu
+      - self-hosted-linux-arm64-noble-medium:
+          username: ubuntu
+
+suites:
+  tests/spread/:
+    summary: General test suite
+
+path: /root/spread_project
+
+kill-timeout: 3h
+environment:
+  PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
+  CONCIERGE_JUJU_CHANNEL: 3.6/stable
+prepare: |
+  snap refresh --hold
+  chown -R root:root "$SPREAD_PATH"
+  cd "$SPREAD_PATH"
+  snap install --classic concierge
+
+  # Install charmcraft & pipx (on lxd-vm backend)
+  concierge prepare --trace
+
+  pipx install tox poetry
+prepare-each: |
+  cd "$SPREAD_PATH"
+  # `concierge prepare` needs to be run for each spread job in case Juju version changed
+  concierge prepare --trace
+
+  # Unable to set constraint on all models because of Juju bug:
+  # https://bugs.launchpad.net/juju/+bug/2065050
+  juju set-model-constraints arch="$(dpkg --print-architecture)"
+
+# Only restore on lxd backend—no need to restore on CI

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -2,48 +2,25 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import os
-import pathlib
-import subprocess
-import typing
+from platform import machine
+
+import pytest
 
 
-def pytest_configure(config) -> None:
-    if os.environ.get("CI") == "true":
-        # Running in GitHub Actions; skip build step
-        plugin = config.pluginmanager.get_plugin("pytest-operator")
-        plugin.OpsTest.build_charm = _build_charm
+@pytest.fixture(scope="session")
+def arch() -> str:
+    """Fixture to provide the platform architecture for testing."""
+    platforms = {
+        "x86_64": "amd64",
+        "aarch64": "arm64",
+    }
+    return platforms.get(machine(), "amd64")
 
-        # Remove charmcraft dependency from `ops_test` fixture
-        check_deps = plugin.check_deps
-        plugin.check_deps = lambda *deps: check_deps(*(dep for dep in deps if dep != "charmcraft"))
 
-
-async def _build_charm(self, charm_path: typing.Union[str, os.PathLike]) -> pathlib.Path:
-    charm_path = pathlib.Path(charm_path)
-    architecture = subprocess.run(
-        ["dpkg", "--print-architecture"],
-        capture_output=True,
-        check=True,
-        encoding="utf-8",
-    ).stdout.strip()
-    assert architecture in ("amd64", "arm64")
-    packed_charms = list(charm_path.glob(f"*{architecture}.charm"))
-    if len(packed_charms) == 1:
-        # python-libjuju's model.deploy(), juju deploy, and juju bundle files expect local charms
-        # to begin with `./` or `/` to distinguish them from Charmhub charms.
-        # Therefore, we need to return an absolute path—a relative `pathlib.Path` does not start
-        # with `./` when cast to a str.
-        # (python-libjuju model.deploy() expects a str but will cast any input to a str as a
-        # workaround for pytest-operator's non-compliant `build_charm` return type of
-        # `pathlib.Path`.)
-        return packed_charms[0].resolve(strict=True)
-    elif len(packed_charms) > 1:
-        raise ValueError(
-            f"More than one matching .charm file found at {charm_path=} for {architecture=} and "
-            f"Ubuntu 22.04: {packed_charms}."
-        )
-    else:
-        raise ValueError(
-            f"Unable to find .charm file for {architecture=} and Ubuntu 24.04 at {charm_path=}"
-        )
+@pytest.fixture
+def charm(arch: str) -> str:
+    """Path to the charm file to use for testing."""
+    # Return str instead of pathlib.Path since python-libjuju's model.deploy(), juju deploy, and
+    # juju bundle files expect local charms to begin with `./` or `/` to distinguish them from
+    # Charmhub charms.
+    return f"./mongodb_ubuntu@24.04-{arch}.charm"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,13 +23,12 @@ logger = logging.getLogger(__name__)
 MEDIAN_REELECTION_TIME = 12
 
 
-@pytest.mark.group(1)
 @pytest.mark.skipif(
     os.environ.get("PYTEST_SKIP_DEPLOY", False),
     reason="skipping deploy, model expected to be provided.",
 )
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest) -> None:
+async def test_build_and_deploy(ops_test: OpsTest, charm: str) -> None:
     """Build and deploy one unit of MongoDB."""
     # it is possible for users to provide their own cluster for testing. Hence check if there
     # is a pre-existing cluster.
@@ -37,12 +36,10 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     if app_name:
         return await check_or_scale_app(ops_test, app_name, len(UNIT_IDS))
 
-    my_charm = await ops_test.build_charm(".")
-    await ops_test.model.deploy(my_charm, num_units=len(UNIT_IDS))
+    await ops_test.model.deploy(charm, num_units=len(UNIT_IDS))
     await ops_test.model.wait_for_idle(timeout=DEPLOYMENT_TIMEOUT, status="active")
 
 
-@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 @pytest.mark.parametrize("unit_id", UNIT_IDS)
 async def test_application_is_up(ops_test: OpsTest, unit_id: int):

--- a/tests/integration/test_sharding.py
+++ b/tests/integration/test_sharding.py
@@ -30,31 +30,29 @@ CONFIG_SERVER_REL_NAME = "config-server"
 TIMEOUT = 30 * 60
 
 
-@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest) -> None:
+async def test_build_and_deploy(ops_test: OpsTest, charm: str) -> None:
     """Build and deploy a sharded cluster."""
-    my_charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(
-        my_charm,
+        charm,
         num_units=2,
         config={"role": "config-server"},
         application_name=CONFIG_SERVER_APP_NAME,
     )
     await ops_test.model.deploy(
-        my_charm,
+        charm,
         num_units=2,
         config={"role": "shard"},
         application_name=SHARD_ONE_APP_NAME,
     )
     await ops_test.model.deploy(
-        my_charm,
+        charm,
         num_units=2,
         config={"role": "shard"},
         application_name=SHARD_TWO_APP_NAME,
     )
     await ops_test.model.deploy(
-        my_charm,
+        charm,
         num_units=2,
         config={"role": "shard"},
         application_name=SHARD_THREE_APP_NAME,
@@ -80,7 +78,6 @@ async def test_build_and_deploy(ops_test: OpsTest) -> None:
     await wait_for_mongodb_units_blocked(ops_test, SHARD_THREE_APP_NAME, timeout=300)
 
 
-@pytest.mark.group(1)
 @pytest.mark.abort_on_fail
 async def test_cluster_active(ops_test: OpsTest) -> None:
     """Tests the integration of cluster components works without error."""

--- a/tests/spread/test_charm.py/task.yaml
+++ b/tests/spread/test_charm.py/task.yaml
@@ -1,0 +1,8 @@
+summary: test_charm.py
+environment:
+  TEST_MODULE: test_charm.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-arm64-noble-medium
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing

--- a/tests/spread/test_sharding.py/task.yaml
+++ b/tests/spread/test_sharding.py/task.yaml
@@ -1,0 +1,8 @@
+summary: test_sharding.py
+environment:
+  TEST_MODULE: test_sharding.py
+systems:
+  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-arm64-noble-medium
+execute: |
+  tox run -e integration -- "tests/integration/$TEST_MODULE" --model testing


### PR DESCRIPTION
## Issue

For multiple reasons, it's important to use the latest workflows, including security.

This needs new credentials, as candid auth is deprecated in charmhub.

## Solution
