### PR TITLE
feat: DPW49 (8/edge)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   lint-workflows:
     name: Lint .github/workflows
-    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v48.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49.0.0
     permissions:
       contents: read
 
@@ -125,7 +125,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.0
     with:
       cache: true
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,22 +18,41 @@ on:
         value: ${{ jobs.build.outputs.artifact-prefix }}
 
 jobs:
-  lint:
-    name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v42.1.0
+  lint-workflows:
+    name: Lint .github/workflows
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v48.0.2
     permissions:
       contents: read
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install poetry
+      - name: tox run -e lint
+        run: tox run -e lint
+    permissions: {}
 
   terraform-test:
     name: Terraform - Validation and replica-set product
     continue-on-error: true
     runs-on: ubuntu-22.04
     timeout-minutes: 120
+    permissions: {}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: (GitHub hosted) Free up disk space
         run: |
@@ -104,50 +123,23 @@ jobs:
             sleep 5
           done
 
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - run: |
-          # Workaround for https://github.com/canonical/charmcraft/issues/1389#issuecomment-1880921728
-          touch requirements.txt
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.6.3
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          use-labels: false
-          fail-build: ${{ github.event_name == 'pull_request' }}
-
   build:
-    strategy:
-      matrix:
-        path:
-          - .
-    name: Build charm | ${{ matrix.path }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v42.1.0
+    name: Build charm
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v48.0.2
     with:
-      path-to-charm-directory: ${{ matrix.path }}
       cache: true
-      charmcraft-snap-revisions: '{"amd64": "7517", "arm64": "7519"}'
     permissions:
+      actions: read
       contents: read
 
   integration-test:
     name: Integration test charm
     needs:
+      - lint-workflows
       - lint
       - build
     uses: ./.github/workflows/integration_test.yaml
     with:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
-    secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -7,3 +7,4 @@ jobs:
     steps:
       - name: Check if CLA signed
         uses: canonical/has-signed-canonical-cla@v2
+    permissions: {}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,11 +14,12 @@ jobs:
     name: Collect integration test spread jobs
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      contents: read
+    permissions: {}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up environment
         run: |
           sudo snap install go --classic
@@ -83,15 +84,16 @@ jobs:
       - collect-integration-tests
     runs-on: ${{ matrix.job.runner }}
     timeout-minutes: 217 # Sum of steps `timeout-minutes` + 5
-    permissions:
-      contents: read
+    permissions: {}
     steps:
       - name: Disk usage
         timeout-minutes: 1
         run: df --human-readable
       - name: Checkout
         timeout-minutes: 3
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up environment
         timeout-minutes: 5
         run: sudo snap install charmcraft --classic
@@ -112,7 +114,9 @@ jobs:
         # TODO: replace with `charmcraft test` when
         # https://github.com/canonical/charmcraft/issues/2105 and
         # https://github.com/canonical/charmcraft/issues/2130 fixed
-        run: ~/go/bin/spread -vv -artifacts=artifacts '${{ matrix.job.spread_job }}'
+        run: ~/go/bin/spread -vv -artifacts=artifacts "${VAR_SPREAD_JOB}"
+        env:
+          VAR_SPREAD_JOB: ${{ matrix.job.spread_job }}
       - timeout-minutes: 1
         if: ${{ success() || (failure() && steps.spread.outcome == 'failure') }}
         run: snap list

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tag:
     name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v42.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v48.0.2
     with:
       track: "8"
     permissions:
@@ -19,8 +19,8 @@ jobs:
   ci-tests:
     needs: tag
     uses: ./.github/workflows/ci.yaml
-    secrets: inherit
     permissions:
+      actions: read # Needed for GitHub API call to get workflow version
       contents: write
 
   release:
@@ -28,11 +28,12 @@ jobs:
     needs:
       - ci-tests
       - tag
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v42.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v48.0.2
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read # Needed for GitHub API call to get workflow version
       contents: write # Needed to create git tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tag:
     name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v48.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v49.0.0
     with:
       track: "8"
     permissions:
@@ -28,7 +28,7 @@ jobs:
     needs:
       - ci-tests
       - tag
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v48.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v49.0.0
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}


### PR DESCRIPTION
lib check and release lib are removed as they are not used anymore (all lives in the pip package)
