### PR TITLE
fix: missing perms

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
     permissions:
+      actions: read # Needed for GitHub API call to get workflow version
       contents: write # Needed to create git tag
 
   release:


### PR DESCRIPTION
Missing `actions: read` on CI call