### PR TITLE
fix: Use PAT

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,7 @@ jobs:
       - name: Checkout releases
         uses: actions/checkout@v6
         with:
+          persist-credentials: true
           ref: ${{ env.RELEASES_BRANCH }}
           token: ${{ secrets.PAT }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,8 +75,8 @@ jobs:
       - name: Checkout releases
         uses: actions/checkout@v6
         with:
-          persist-credentials: false
           ref: ${{ env.RELEASES_BRANCH }}
+          token: ${{ secrets.PAT }}
 
       - name: Configure git signing
         run: |


### PR DESCRIPTION
## Issue

cf [action run](https://github.com/canonical/mongodb-operator/actions/runs/24890398308/job/72886366458)
`fatal: could not read Username for '[https://github.com](https://github.com)': No such device or address`

## Solution

Use a PAT to be allowed to push content.