### PR TITLE
DPE-9758: Promote workflow in charms repositories

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -16,5 +16,5 @@ on:
 jobs:
   check-pr:
     name: Check pull request
-    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@vXYZ
+    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@v49.0.1
     permissions: {}

--- a/.github/workflows/check_pr.yaml
+++ b/.github/workflows/check_pr.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Check pull request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+    branches:
+      - 8/edge
+      - 8-transition/edge
+      - 6/edge
+
+jobs:
+  check-pr:
+    name: Check pull request
+    uses: canonical/data-platform-workflows/.github/workflows/check_charm_pr.yaml@vXYZ
+    permissions: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   lint-workflows:
     name: Lint .github/workflows
-    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49.0.1
     permissions:
       contents: read
 
@@ -125,7 +125,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.1
     with:
       cache: true
     permissions:

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Promote revisions to next channel
+
+on:
+  workflow_dispatch:
+    inputs:
+      revisions:
+        description: |
+          Comma-separated list of git revision tags to promote.
+          These must match the tags pushed by the release workflow.
+
+          Example: 'rev123,rev124'
+        required: true
+        type: string
+      track:
+        description: |
+          Charmhub track to promote to
+
+          https://juju.is/docs/juju/channel#heading--track
+        required: true
+        type: string
+      to-risk:
+        description: |
+          Promote to `track` input and this Charmhub risk
+
+          https://juju.is/docs/juju/channel#heading--risk
+
+          Must be one of "beta", "candidate", "stable"
+        required: true
+        type: string
+      charmcraft-snap-revision:
+        description: charmcraft snap revision
+        required: false
+        type: string
+      charmcraft-snap-channel:
+        description: |
+          charmcraft snap channel
+
+          Cannot be used if `charmcraft-snap-revision` input is passed
+        required: false
+        type: string
+
+jobs:
+  promote:
+    name: Promote charm revisions
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms_by_revision.yaml@vXYZ
+    with:
+      revisions: ${{ inputs.revisions }}
+      track: ${{ inputs.track }}
+      to-risk: ${{ inputs.to-risk }}
+    secrets:
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+    permissions:
+      contents: write # Needed to create git tags

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -33,7 +33,7 @@ on:
 jobs:
   promote:
     name: Promote charm revisions
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms_by_revision.yaml@v49.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms.yaml@v49.0.1
     with:
       revisions: ${{ inputs.revisions }}
       track: ${{ inputs.track }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -29,22 +29,11 @@ on:
           Must be one of "beta", "candidate", "stable"
         required: true
         type: string
-      charmcraft-snap-revision:
-        description: charmcraft snap revision
-        required: false
-        type: string
-      charmcraft-snap-channel:
-        description: |
-          charmcraft snap channel
-
-          Cannot be used if `charmcraft-snap-revision` input is passed
-        required: false
-        type: string
 
 jobs:
   promote:
     name: Promote charm revisions
-    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms_by_revision.yaml@vXYZ
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_charms_by_revision.yaml@v49.0.1
     with:
       revisions: ${{ inputs.revisions }}
       track: ${{ inputs.track }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -25,10 +25,12 @@ on:
           Promote to `track` input and this Charmhub risk
 
           https://juju.is/docs/juju/channel#heading--risk
-
-          Must be one of "beta", "candidate", "stable"
         required: true
-        type: string
+        type: choice
+        options:
+          - beta
+          - candidate
+          - stable
 
 jobs:
   promote:
@@ -41,4 +43,5 @@ jobs:
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
+      actions: read # Needed for Github API call to get workflow version
       contents: write # Needed to create git tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   tag:
     name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v49.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v49.0.1
     with:
       track: "8"
     permissions:
@@ -29,7 +29,7 @@ jobs:
     needs:
       - ci-tests
       - tag
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v49.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v49.0.1
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}


### PR DESCRIPTION
This is the required workflows for release:

 * check PR checks that all PRs are labelled with either bug or enhancement
 * .github/release.yaml is here for the auto generated notes.
 * Promote from revisions to risk.