### PR TITLE
patch: fix secrets definitions in TF modules

### DIFF
--- a/terraform/product/replica_set/main.tf
+++ b/terraform/product/replica_set/main.tf
@@ -18,10 +18,10 @@ module "mongodb" {
   config = merge(
     var.mongodb.config,
     { "role" : "replication" },
-    length(juju_secret.tls_client_private_key) > 0 ? {
+    var.tls_client_private_key != null ? {
       "tls-client-private-key" = juju_secret.tls_client_private_key[0].secret_uri
     } : {},
-    length(juju_secret.tls_peer_private_key) > 0 ? {
+    var.tls_peer_private_key != null ? {
       "tls-peer-private-key" = juju_secret.tls_peer_private_key[0].secret_uri
     } : {}
   )
@@ -47,7 +47,7 @@ resource "juju_secret" "tls_client_private_key" {
 
 resource "juju_access_secret" "tls_client_private_key" {
   depends_on = [juju_secret.tls_client_private_key, module.mongodb]
-  count      = length(juju_secret.tls_client_private_key) > 0 ? 1 : 0
+  count      = var.tls_client_private_key != null ? 1 : 0
   model_uuid = var.mongodb.model_uuid
   applications = [
     module.mongodb.application.name
@@ -67,7 +67,7 @@ resource "juju_secret" "tls_peer_private_key" {
 
 resource "juju_access_secret" "tls_peer_private_key" {
   depends_on = [juju_secret.tls_peer_private_key, module.mongodb]
-  count      = length(juju_secret.tls_peer_private_key) > 0 ? 1 : 0
+  count      = var.tls_peer_private_key != null ? 1 : 0
   model_uuid = var.mongodb.model_uuid
   applications = [
     module.mongodb.application.name
@@ -128,7 +128,7 @@ module "gcs_integrator" {
   channel  = local.backups_integrator_channel
   config = merge(
     var.backups_integrator.config,
-    length(juju_secret.gcs_secret) > 0 ? {
+    local.gcs_integrator_enabled && var.gcs_secret_key != null ? {
       credentials = juju_secret.gcs_secret[0].secret_uri
     } : {}
   )
@@ -151,7 +151,7 @@ resource "juju_secret" "gcs_secret" {
 
 resource "juju_access_secret" "gcs_secret_access" {
   depends_on = [juju_secret.gcs_secret, module.gcs_integrator]
-  count      = length(juju_secret.gcs_secret) > 0 ? 1 : 0
+  count      = local.gcs_integrator_enabled && var.gcs_secret_key != null ? 1 : 0
   model_uuid = var.backups_integrator.model_uuid
   applications = [
     module.gcs_integrator[0].application.name
@@ -180,7 +180,7 @@ module "s3_integrator" {
   channel  = local.backups_integrator_channel
   config = merge(
     var.backups_integrator.config,
-    length(juju_secret.s3_secret) > 0 ? {
+    local.s3_integrator_enabled && var.s3_access_key != null && var.s3_secret_key != null ? {
       credentials = juju_secret.s3_secret[0].secret_uri
     } : {}
   )
@@ -193,7 +193,7 @@ module "s3_integrator" {
 
 resource "juju_access_secret" "s3_secret_access" {
   depends_on = [juju_secret.s3_secret, module.s3_integrator]
-  count      = length(juju_secret.s3_secret) > 0 ? 1 : 0
+  count      = local.s3_integrator_enabled && var.s3_access_key != null && var.s3_secret_key != null ? 1 : 0
   model_uuid = var.backups_integrator.model_uuid
   applications = [
     module.s3_integrator[0].application.name

--- a/terraform/product/replica_set/outputs.tf
+++ b/terraform/product/replica_set/outputs.tf
@@ -3,6 +3,7 @@
 
 output "components" {
   description = "All deployed applications."
+  sensitive   = true
   value = {
     mongodb         = module.mongodb.application
     data_integrator = module.data_integrator.application
@@ -13,6 +14,7 @@ output "components" {
 
 output "models" {
   description = "Models and deployed components managed by this module."
+  sensitive   = true
   value = {
     for model_uuid in distinct([for component in local.model_components : component.model_uuid]) :
     model_uuid => {

--- a/terraform/product/sharded_cluster/main.tf
+++ b/terraform/product/sharded_cluster/main.tf
@@ -16,10 +16,10 @@ module "config_and_routing" {
     {
       config = merge(
         var.config_server.config,
-        length(juju_secret.tls_client_private_key) > 0 ? {
+        var.tls_client_private_key != null ? {
           "tls-client-private-key" = juju_secret.tls_client_private_key[0].secret_uri
         } : {},
-        length(juju_secret.tls_peer_private_key) > 0 ? {
+        var.tls_peer_private_key != null ? {
           "tls-peer-private-key" = juju_secret.tls_peer_private_key[0].secret_uri
         } : {}
       )
@@ -40,7 +40,7 @@ resource "juju_secret" "tls_client_private_key" {
 
 resource "juju_access_secret" "tls_client_private_key" {
   depends_on = [juju_secret.tls_client_private_key, module.config_and_routing]
-  count      = length(juju_secret.tls_client_private_key) > 0 ? 1 : 0
+  count      = var.tls_client_private_key != null ? 1 : 0
   model_uuid = var.config_server.model_uuid
   applications = [
     module.config_and_routing.components["config_server"].name
@@ -60,7 +60,7 @@ resource "juju_secret" "tls_peer_private_key" {
 
 resource "juju_access_secret" "tls_peer_private_key" {
   depends_on = [juju_secret.tls_peer_private_key, module.config_and_routing]
-  count      = length(juju_secret.tls_peer_private_key) > 0 ? 1 : 0
+  count      = var.tls_peer_private_key != null ? 1 : 0
   model_uuid = var.config_server.model_uuid
   applications = [
     module.config_and_routing.components["config_server"].name
@@ -194,7 +194,7 @@ module "gcs_integrator" {
   channel  = local.backups_integrator_channel
   config = merge(
     var.backups_integrator.config,
-    length(juju_secret.gcs_secret) > 0 ? {
+    local.gcs_credentials_enabled && var.gcs_secret_key != null ? {
       credentials = juju_secret.gcs_secret[0].secret_uri
     } : {}
   )
@@ -217,7 +217,7 @@ resource "juju_secret" "gcs_secret" {
 
 resource "juju_access_secret" "gcs_secret_access" {
   depends_on = [juju_secret.gcs_secret, module.gcs_integrator]
-  count      = length(juju_secret.gcs_secret) > 0 ? 1 : 0
+  count      = local.gcs_credentials_enabled && var.gcs_secret_key != null ? 1 : 0
   model_uuid = var.backups_integrator.model_uuid
   applications = [
     module.gcs_integrator[0].application.name
@@ -246,7 +246,7 @@ module "s3_integrator" {
   channel  = local.backups_integrator_channel
   config = merge(
     var.backups_integrator.config,
-    length(juju_secret.s3_secret) > 0 ? {
+    local.s3_credentials_enabled && var.s3_access_key != null && var.s3_secret_key != null ? {
       credentials = juju_secret.s3_secret[0].secret_uri
     } : {}
   )
@@ -259,7 +259,7 @@ module "s3_integrator" {
 
 resource "juju_access_secret" "s3_secret_access" {
   depends_on = [juju_secret.s3_secret, module.s3_integrator]
-  count      = length(juju_secret.s3_secret) > 0 ? 1 : 0
+  count      = local.s3_credentials_enabled && var.s3_access_key != null && var.s3_secret_key != null ? 1 : 0
   model_uuid = var.backups_integrator.model_uuid
   applications = [
     module.s3_integrator[0].application.name

--- a/terraform/product/sharded_cluster/outputs.tf
+++ b/terraform/product/sharded_cluster/outputs.tf
@@ -3,6 +3,7 @@
 
 output "components" {
   description = "All deployed applications."
+  sensitive   = true
   value = merge(
     module.config_and_routing.components,
     {
@@ -20,6 +21,7 @@ output "components" {
 
 output "models" {
   description = "Models and deployed components managed by this module."
+  sensitive   = true
   value = {
     for model_uuid in distinct([for component in local.model_components : component.model_uuid]) :
     model_uuid => {


### PR DESCRIPTION
## Issue

The way we define the `count` for the juju secrets in the TF modules is problematic because it cannot be decided at plan time. 
This PR changes the way we handle secrets so that we do not have the following errors:

```
.terraform/modules/mongodb_sharded_cluster/terraform/product/sharded_cluster/main.tf line 63, in resource "juju_access_secret" "tls_peer_private_key":
│   63:   count      = length(juju_secret.tls_peer_private_key) > 0 ? 1 : 0
│ 
│ The "count" value depends on resource attributes that cannot be determined until apply, so
│ Terraform cannot predict how many instances will be created. To work around this, use the -target
│ argument to first apply only the resources that the count depends on.
╵
```

Tested in

https://github.com/canonical/charms-reference-architectures/pull/17
