### PR TITLE
patch: Add charmcraft-snap-revision to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
     with:
       track: ${{ needs.tag.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
+      charmcraft-snap-revision: "8022"
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
## Description

We need to pin the charmcraft snap revision < 4.4.1

Fix for https://github.com/canonical/mongodb-k8s-operator/actions/runs/33054971925/job/98466177827

Based on https://github.com/canonical/charmed-etcd-operator/pull/253/changes